### PR TITLE
fix(release): use unprefixed version tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "MetasequoiaImeMac",
+      "include-component-in-tag": false,
       "include-v-in-tag": true,
       "version-file": "version.txt",
       "draft": true,

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -30,6 +30,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertNotIn("generated", (package["pull-request-header"] + package["pull-request-footer"]).lower())
         self.assertTrue(package["draft"])
         self.assertTrue(package["force-tag-creation"])
+        self.assertFalse(package.get("include-component-in-tag", True))
         self.assertIn("googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7", workflow)
         self.assertIn("actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803", workflow)
         self.assertIn("steps.release.outputs.release_created", workflow)


### PR DESCRIPTION
## Summary

- configure Release Please to create `vX.Y.Z` tags without a component prefix
- lock the tag naming contract with a release configuration regression test

## Why

The release packaging workflow accepts `vX.Y.Z`, while Release Please defaults to component-prefixed tags when `package-name` is set. Without this override, merging the release PR would create `MetasequoiaImeMac-v0.2.0` and the packaging job would reject it.

## Verification

- `python3 tests/ReleaseConfigurationTests.py`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `git diff --check`
