### PR TITLE
feat(settings): add macOS input method preferences panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if(METASEQUOIA_IME_BUILD_INPUT_METHOD)
     configure_file(resources/Info.plist ${CMAKE_CURRENT_BINARY_DIR}/MetasequoiaIME-Info.plist @ONLY)
 
     set(METASEQUOIA_IME_LOCALIZATIONS resources/en.lproj/InfoPlist.strings resources/zh-Hans.lproj/InfoPlist.strings)
-    add_executable(MetasequoiaIME MACOSX_BUNDLE src/main.mm src/DictionaryInstaller.mm src/MetasequoiaInputController.mm ${METASEQUOIA_IME_DICTIONARY} ${METASEQUOIA_IME_LOCALIZATIONS})
+    add_executable(MetasequoiaIME MACOSX_BUNDLE src/main.mm src/DictionaryInstaller.mm src/MetasequoiaInputController.mm src/PreferencesWindowController.mm ${METASEQUOIA_IME_DICTIONARY} ${METASEQUOIA_IME_LOCALIZATIONS})
     set_source_files_properties(${METASEQUOIA_IME_DICTIONARY} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set_source_files_properties(resources/en.lproj/InfoPlist.strings PROPERTIES MACOSX_PACKAGE_LOCATION Resources/en.lproj)
     set_source_files_properties(resources/zh-Hans.lproj/InfoPlist.strings PROPERTIES MACOSX_PACKAGE_LOCATION Resources/zh-Hans.lproj)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The dictionary build generates `vendor/MetasequoiaImeDict/out/msime.db` from the
 
 Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. The installer copies the signed bundle to `~/Library/Input Methods` and registers that exact bundle with macOS; it does not require administrator privileges.
 
+## Settings
+
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The first panel exposes the currently supported full-pinyin scheme; additional input and candidate options will be added incrementally.
+
 ## Development tests
 
 ```sh

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -55,6 +55,8 @@
     <string>MetasequoiaInputController</string>
     <key>InputMethodServerDelegateClass</key>
     <string>MetasequoiaInputController</string>
+    <key>InputMethodServerPreferencesWindowControllerClass</key>
+    <string>MetasequoiaPreferencesWindowController</string>
     <key>LSBackgroundOnly</key>
     <true/>
     <key>NSPrincipalClass</key>

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -1,6 +1,7 @@
 #import "MetasequoiaInputController.h"
 
 #import "DictionaryInstaller.h"
+#import "PreferencesWindowController.h"
 #include "InputSession.h"
 
 #import <Carbon/Carbon.h>
@@ -197,6 +198,12 @@ NSString *StringFromUtf8(const std::string &value)
     [self commitComposition:sender];
     [_candidatePanel hide];
     [super deactivateServer:sender];
+}
+
+- (void)showPreferences:(id)sender
+{
+    (void)sender;
+    [[MetasequoiaPreferencesWindowController sharedController] showAndActivate];
 }
 
 - (NSUInteger)recognizedEvents:(id)sender

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#import <AppKit/AppKit.h>
+
+@interface MetasequoiaPreferencesWindowController : NSWindowController
++ (instancetype)sharedController;
+- (void)showAndActivate;
+@end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -1,0 +1,125 @@
+#import "PreferencesWindowController.h"
+
+namespace
+{
+constexpr CGFloat kWindowWidth = 480.0;
+constexpr CGFloat kWindowHeight = 276.0;
+} // namespace
+
+@implementation MetasequoiaPreferencesWindowController
+
++ (instancetype)sharedController
+{
+    static MetasequoiaPreferencesWindowController *controller = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        controller = [[self alloc] init];
+    });
+    return controller;
+}
+
+- (instancetype)initWithWindowNibName:(NSNibName)windowNibName owner:(id)owner
+{
+    (void)windowNibName;
+    (void)owner;
+    return [self init];
+}
+
+- (instancetype)initWithWindowNibName:(NSNibName)windowNibName
+{
+    (void)windowNibName;
+    return [self init];
+}
+
+- (instancetype)init
+{
+    NSRect frame = NSMakeRect(0.0, 0.0, kWindowWidth, kWindowHeight);
+    NSWindow *window = [[NSWindow alloc] initWithContentRect:frame
+                                                   styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable)
+                                                     backing:NSBackingStoreBuffered
+                                                       defer:NO];
+    window.title = @"水杉输入法设置";
+    window.releasedWhenClosed = NO;
+    window.restorable = NO;
+
+    self = [super initWithWindow:window];
+    if (self == nil)
+    {
+        return nil;
+    }
+
+    NSView *contentView = [[NSView alloc] initWithFrame:frame];
+    contentView.translatesAutoresizingMaskIntoConstraints = NO;
+    window.contentView = contentView;
+
+    NSTextField *titleLabel = [NSTextField labelWithString:@"水杉输入法设置"];
+    titleLabel.font = [NSFont boldSystemFontOfSize:24.0];
+    titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+    NSTextField *descriptionLabel = [NSTextField labelWithString:@"配置输入方案和输入行为。"];
+    descriptionLabel.textColor = [NSColor secondaryLabelColor];
+    descriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+    NSTextField *schemeLabel = [NSTextField labelWithString:@"输入方案"];
+    schemeLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+    NSPopUpButton *schemeButton = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
+    [schemeButton addItemWithTitle:@"全拼（当前支持）"];
+    schemeButton.enabled = NO;
+    schemeButton.accessibilityLabel = @"输入方案";
+    schemeButton.translatesAutoresizingMaskIntoConstraints = NO;
+
+    NSTextField *statusLabel = [NSTextField labelWithString:@"更多设置将在后续版本提供。"];
+    statusLabel.textColor = [NSColor secondaryLabelColor];
+    statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+    NSButton *closeButton = [NSButton buttonWithTitle:@"关闭" target:self action:@selector(close:)];
+    closeButton.bezelStyle = NSBezelStyleRounded;
+    closeButton.keyEquivalent = @"\r";
+    closeButton.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [contentView addSubview:titleLabel];
+    [contentView addSubview:descriptionLabel];
+    [contentView addSubview:schemeLabel];
+    [contentView addSubview:schemeButton];
+    [contentView addSubview:statusLabel];
+    [contentView addSubview:closeButton];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [titleLabel.topAnchor constraintEqualToAnchor:contentView.topAnchor constant:28.0],
+        [titleLabel.leadingAnchor constraintEqualToAnchor:contentView.leadingAnchor constant:32.0],
+        [titleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:contentView.trailingAnchor constant:-32.0],
+        [descriptionLabel.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:8.0],
+        [descriptionLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
+        [descriptionLabel.trailingAnchor constraintLessThanOrEqualToAnchor:contentView.trailingAnchor constant:-32.0],
+        [schemeLabel.topAnchor constraintEqualToAnchor:descriptionLabel.bottomAnchor constant:34.0],
+        [schemeLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
+        [schemeLabel.widthAnchor constraintEqualToConstant:100.0],
+        [schemeButton.centerYAnchor constraintEqualToAnchor:schemeLabel.centerYAnchor],
+        [schemeButton.leadingAnchor constraintEqualToAnchor:schemeLabel.trailingAnchor constant:12.0],
+        [schemeButton.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-32.0],
+        [statusLabel.topAnchor constraintEqualToAnchor:schemeButton.bottomAnchor constant:20.0],
+        [statusLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
+        [statusLabel.trailingAnchor constraintLessThanOrEqualToAnchor:contentView.trailingAnchor constant:-32.0],
+        [closeButton.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-32.0],
+        [closeButton.bottomAnchor constraintEqualToAnchor:contentView.bottomAnchor constant:-24.0],
+        [closeButton.widthAnchor constraintGreaterThanOrEqualToConstant:80.0],
+    ]];
+    return self;
+}
+
+- (void)showAndActivate
+{
+    [self showWindow:nil];
+    [self.window center];
+    [self.window makeKeyAndOrderFront:nil];
+    [NSApp activateIgnoringOtherApps:YES];
+}
+
+- (void)close:(id)sender
+{
+    (void)sender;
+    [self.window orderOut:nil];
+}
+
+@end

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -24,6 +24,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
         config = json.loads((PROJECT_ROOT / "release-please-config.json").read_text())
         package = config["packages"]["."]
         workflow = (PROJECT_ROOT / ".github/workflows/release.yml").read_text()
+        readme = (PROJECT_ROOT / "README.md").read_text()
+        info_plist = (PROJECT_ROOT / "resources/Info.plist").read_text()
+        cmake = (PROJECT_ROOT / "CMakeLists.txt").read_text()
 
         self.assertEqual(package["release-type"], "simple")
         self.assertIn({"type": "generic", "path": "CMakeLists.txt"}, package["extra-files"])
@@ -41,6 +44,12 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("scripts/package_release.sh", workflow)
         self.assertIn("gh release upload", workflow)
         self.assertIn("gh release edit", workflow)
+        self.assertIn("native 水杉输入法设置 panel", readme)
+        self.assertIn("InputMethodServerPreferencesWindowControllerClass", info_plist)
+        self.assertIn("PreferencesWindowController.mm", cmake)
+        preferences_controller = (PROJECT_ROOT / "src/PreferencesWindowController.mm").read_text()
+        self.assertIn("initWithWindowNibName:(NSNibName)windowNibName owner:(id)owner", preferences_controller)
+        self.assertIn("showAndActivate", preferences_controller)
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)


### PR DESCRIPTION
## Summary

- Add the InputMethodKit preferences controller registration so macOS exposes a settings action for 水杉输入法.
- Add a native, accessible first-stage settings panel that shows the supported full-pinyin scheme and leaves future options for follow-up PRs.
- Document the entry point and cover the registration and controller wiring in release configuration tests.

## Verify

- `python3 tests/ReleaseConfigurationTests.py`
- `cmake --build build-settings --parallel`
- `ctest --test-dir build-settings --output-on-failure --timeout 120` (6/6 tests passed)
- Orca Computer: confirmed the registered 水杉输入法 input source in System Settings and inspected the panel accessibility tree (`水杉输入法设置`, `输入方案`, `全拼（当前支持）`, `关闭`); the close action removed the window.
