### PR TITLE
feat(settings): add pinyin autocorrect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼; the choice is saved for the current user and applies to the next input session. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼 and enable full-pinyin autocorrection; these choices are saved for the current user and apply to the next input session. Additional input and candidate options will be added incrementally.
 
 ## Development tests
 

--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -5,8 +5,10 @@
 
 namespace metasequoia::mac
 {
-InputSession::InputSession(SchemeType scheme_type) : engine_(scheme_type)
+InputSession::InputSession(SchemeType scheme_type, bool quanpin_autocorrect_enabled)
+    : engine_(scheme_type), quanpin_autocorrect_enabled_(quanpin_autocorrect_enabled)
 {
+    engine_.set_quanpin_autocorrect_enabled(quanpin_autocorrect_enabled_);
 }
 
 KeyResult InputSession::handle_character(char character)
@@ -71,6 +73,11 @@ KeyResult InputSession::select_candidate(const std::string &candidate)
 SchemeType InputSession::scheme_type() const
 {
     return engine_.current_scheme_type();
+}
+
+bool InputSession::quanpin_autocorrect_enabled() const
+{
+    return quanpin_autocorrect_enabled_;
 }
 
 bool InputSession::has_composition() const

--- a/src/InputSession.h
+++ b/src/InputSession.h
@@ -24,7 +24,7 @@ struct KeyResult
 class InputSession
 {
   public:
-    explicit InputSession(SchemeType scheme_type = SchemeType::Quanpin);
+    explicit InputSession(SchemeType scheme_type = SchemeType::Quanpin, bool quanpin_autocorrect_enabled = true);
 
     KeyResult handle_character(char character);
     KeyResult handle_command(Command command);
@@ -32,6 +32,7 @@ class InputSession
     KeyResult select_candidate(const std::string &candidate);
 
     SchemeType scheme_type() const;
+    bool quanpin_autocorrect_enabled() const;
     bool has_composition() const;
     const std::string &preedit() const;
     const std::vector<WordItem> &candidates() const;
@@ -40,5 +41,6 @@ class InputSession
     KeyResult commit(size_t index);
 
     ImeSession engine_;
+    bool quanpin_autocorrect_enabled_ = true;
 };
 } // namespace metasequoia::mac

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -36,7 +36,8 @@ NSString *StringFromUtf8(const std::string &value)
         }
         const NSInteger storedScheme = [MetasequoiaPreferencesWindowController storedScheme];
         const SchemeType scheme = storedScheme == 1 ? SchemeType::Shuangpin : SchemeType::Quanpin;
-        _session = std::make_unique<metasequoia::mac::InputSession>(scheme);
+        const BOOL autocorrectEnabled = [MetasequoiaPreferencesWindowController storedAutocorrectEnabled];
+        _session = std::make_unique<metasequoia::mac::InputSession>(scheme, autocorrectEnabled);
         _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
         [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @NO}];
     }

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -6,5 +6,7 @@
 + (instancetype)sharedController;
 + (NSInteger)storedScheme;
 + (void)setStoredScheme:(NSInteger)scheme;
++ (BOOL)storedAutocorrectEnabled;
++ (void)setAutocorrectEnabled:(BOOL)enabled;
 - (void)showAndActivate;
 @end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -5,11 +5,13 @@ namespace
 constexpr CGFloat kWindowWidth = 480.0;
 constexpr CGFloat kWindowHeight = 276.0;
 NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
+NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect";
 } // namespace
 
 @implementation MetasequoiaPreferencesWindowController
 {
     NSPopUpButton *_schemeButton;
+    NSButton *_autocorrectButton;
 }
 
 + (instancetype)sharedController
@@ -34,6 +36,19 @@ NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
     [[NSUserDefaults standardUserDefaults] setInteger:normalizedScheme forKey:kSchemePreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaInputSchemeDidChangeNotification"
                                                         object:@(normalizedScheme)];
+}
+
++ (BOOL)storedAutocorrectEnabled
+{
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kAutocorrectPreferenceKey];
+    return value == nil ? YES : [value boolValue];
+}
+
++ (void)setAutocorrectEnabled:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kAutocorrectPreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaQuanpinAutocorrectDidChangeNotification"
+                                                        object:@(enabled)];
 }
 
 - (instancetype)initWithWindowNibName:(NSNibName)windowNibName owner:(id)owner
@@ -89,6 +104,9 @@ NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
     _schemeButton.accessibilityLabel = @"输入方案";
     _schemeButton.translatesAutoresizingMaskIntoConstraints = NO;
 
+    _autocorrectButton = [NSButton checkboxWithTitle:@"启用全拼自动纠错" target:self action:@selector(autocorrectChanged:)];
+    _autocorrectButton.translatesAutoresizingMaskIntoConstraints = NO;
+
     NSTextField *statusLabel = [NSTextField labelWithString:@"输入方案会保存到当前用户设置，并在下一次输入会话中生效。"];
     statusLabel.textColor = [NSColor secondaryLabelColor];
     statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
@@ -102,6 +120,7 @@ NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
     [contentView addSubview:descriptionLabel];
     [contentView addSubview:schemeLabel];
     [contentView addSubview:_schemeButton];
+    [contentView addSubview:_autocorrectButton];
     [contentView addSubview:statusLabel];
     [contentView addSubview:closeButton];
 
@@ -118,7 +137,9 @@ NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
         [_schemeButton.centerYAnchor constraintEqualToAnchor:schemeLabel.centerYAnchor],
         [_schemeButton.leadingAnchor constraintEqualToAnchor:schemeLabel.trailingAnchor constant:12.0],
         [_schemeButton.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-32.0],
-        [statusLabel.topAnchor constraintEqualToAnchor:_schemeButton.bottomAnchor constant:20.0],
+        [_autocorrectButton.leadingAnchor constraintEqualToAnchor:_schemeButton.leadingAnchor],
+        [_autocorrectButton.topAnchor constraintEqualToAnchor:_schemeButton.bottomAnchor constant:16.0],
+        [statusLabel.topAnchor constraintEqualToAnchor:_autocorrectButton.bottomAnchor constant:12.0],
         [statusLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [statusLabel.trailingAnchor constraintLessThanOrEqualToAnchor:contentView.trailingAnchor constant:-32.0],
         [closeButton.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-32.0],
@@ -131,10 +152,17 @@ NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
 - (void)showAndActivate
 {
     [_schemeButton selectItemAtIndex:[MetasequoiaPreferencesWindowController storedScheme]];
+    _autocorrectButton.state = [MetasequoiaPreferencesWindowController storedAutocorrectEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
     [self showWindow:nil];
     [self.window center];
     [self.window makeKeyAndOrderFront:nil];
     [NSApp activateIgnoringOtherApps:YES];
+}
+
+- (void)autocorrectChanged:(id)sender
+{
+    NSButton *button = (NSButton *)sender;
+    [MetasequoiaPreferencesWindowController setAutocorrectEnabled:button.state == NSControlStateValueOn];
 }
 
 - (void)schemeChanged:(id)sender

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -81,8 +81,11 @@ int main()
 
         metasequoia::mac::InputSession default_session;
         require(default_session.scheme_type() == SchemeType::Quanpin, "The default input scheme should be full pinyin.");
+        require(default_session.quanpin_autocorrect_enabled(), "Pinyin autocorrect should be enabled by default.");
         metasequoia::mac::InputSession shuangpin_session(SchemeType::Shuangpin);
         require(shuangpin_session.scheme_type() == SchemeType::Shuangpin, "The requested double-pinyin scheme was not retained.");
+        metasequoia::mac::InputSession no_autocorrect_session(SchemeType::Quanpin, false);
+        require(!no_autocorrect_session.quanpin_autocorrect_enabled(), "The requested pinyin autocorrect setting was not retained.");
 
         metasequoia::mac::InputSession session;
         type(session, "nihao");

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -47,6 +47,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("gh release upload", workflow)
         self.assertIn("gh release edit", workflow)
         self.assertIn("全拼 or 小鹤双拼", readme)
+        self.assertIn("enable full-pinyin autocorrection", readme)
         self.assertIn("Open Anyway", readme)
         self.assertIn("Privacy & Security", readme)
         self.assertIn("native 水杉输入法设置 panel", readme)
@@ -58,6 +59,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("storedScheme", preferences_controller)
         self.assertIn("setStoredScheme", preferences_controller)
         self.assertIn("小鹤双拼", preferences_controller)
+        self.assertIn("storedAutocorrectEnabled", preferences_controller)
+        self.assertIn("setAutocorrectEnabled", preferences_controller)
+        self.assertIn("启用全拼自动纠错", preferences_controller)
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)


### PR DESCRIPTION
## Summary
- add a persisted full-pinyin autocorrection checkbox to the native settings panel
- pass the preference into new input sessions and the engine query path
- cover default and disabled session configuration

## Verification
- `python3 tests/ReleaseConfigurationTests.py`
- `cmake --build build-autocorrect-test --parallel`
- `ctest --test-dir build-autocorrect-test --output-on-failure --timeout 120`
- Orca Computer: opened the settings panel, toggled `启用全拼自动纠错`, and observed the accessibility value change from 1 to 0; the preference was persisted in macOS defaults
