### PR TITLE
feat(settings): add auxiliary code option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼 and enable full-pinyin autocorrection; these choices are saved for the current user and apply to the next input session. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, enable full-pinyin autocorrection, and enable auxiliary codes; these choices are saved for the current user and apply to the next input session. Additional input and candidate options will be added incrementally.
 
 ## Development tests
 

--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -5,10 +5,12 @@
 
 namespace metasequoia::mac
 {
-InputSession::InputSession(SchemeType scheme_type, bool quanpin_autocorrect_enabled)
-    : engine_(scheme_type), quanpin_autocorrect_enabled_(quanpin_autocorrect_enabled)
+InputSession::InputSession(SchemeType scheme_type, bool quanpin_autocorrect_enabled, bool helpcode_enabled)
+    : engine_(scheme_type), quanpin_autocorrect_enabled_(quanpin_autocorrect_enabled), helpcode_enabled_(helpcode_enabled)
 {
     engine_.set_quanpin_autocorrect_enabled(quanpin_autocorrect_enabled_);
+    engine_.set_quanpin_helpcode_enabled(helpcode_enabled_);
+    engine_.set_shuangpin_helpcode_enabled(helpcode_enabled_);
 }
 
 KeyResult InputSession::handle_character(char character)
@@ -78,6 +80,11 @@ SchemeType InputSession::scheme_type() const
 bool InputSession::quanpin_autocorrect_enabled() const
 {
     return quanpin_autocorrect_enabled_;
+}
+
+bool InputSession::helpcode_enabled() const
+{
+    return helpcode_enabled_;
 }
 
 bool InputSession::has_composition() const

--- a/src/InputSession.h
+++ b/src/InputSession.h
@@ -24,7 +24,8 @@ struct KeyResult
 class InputSession
 {
   public:
-    explicit InputSession(SchemeType scheme_type = SchemeType::Quanpin, bool quanpin_autocorrect_enabled = true);
+    explicit InputSession(SchemeType scheme_type = SchemeType::Quanpin, bool quanpin_autocorrect_enabled = true,
+                          bool helpcode_enabled = true);
 
     KeyResult handle_character(char character);
     KeyResult handle_command(Command command);
@@ -33,6 +34,7 @@ class InputSession
 
     SchemeType scheme_type() const;
     bool quanpin_autocorrect_enabled() const;
+    bool helpcode_enabled() const;
     bool has_composition() const;
     const std::string &preedit() const;
     const std::vector<WordItem> &candidates() const;
@@ -42,5 +44,6 @@ class InputSession
 
     ImeSession engine_;
     bool quanpin_autocorrect_enabled_ = true;
+    bool helpcode_enabled_ = true;
 };
 } // namespace metasequoia::mac

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -37,7 +37,8 @@ NSString *StringFromUtf8(const std::string &value)
         const NSInteger storedScheme = [MetasequoiaPreferencesWindowController storedScheme];
         const SchemeType scheme = storedScheme == 1 ? SchemeType::Shuangpin : SchemeType::Quanpin;
         const BOOL autocorrectEnabled = [MetasequoiaPreferencesWindowController storedAutocorrectEnabled];
-        _session = std::make_unique<metasequoia::mac::InputSession>(scheme, autocorrectEnabled);
+        const BOOL helpcodeEnabled = [MetasequoiaPreferencesWindowController storedHelpcodeEnabled];
+        _session = std::make_unique<metasequoia::mac::InputSession>(scheme, autocorrectEnabled, helpcodeEnabled);
         _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
         [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @NO}];
     }

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -8,5 +8,7 @@
 + (void)setStoredScheme:(NSInteger)scheme;
 + (BOOL)storedAutocorrectEnabled;
 + (void)setAutocorrectEnabled:(BOOL)enabled;
++ (BOOL)storedHelpcodeEnabled;
++ (void)setHelpcodeEnabled:(BOOL)enabled;
 - (void)showAndActivate;
 @end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -6,12 +6,14 @@ constexpr CGFloat kWindowWidth = 480.0;
 constexpr CGFloat kWindowHeight = 276.0;
 NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
 NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect";
+NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
 } // namespace
 
 @implementation MetasequoiaPreferencesWindowController
 {
     NSPopUpButton *_schemeButton;
     NSButton *_autocorrectButton;
+    NSButton *_helpcodeButton;
 }
 
 + (instancetype)sharedController
@@ -48,6 +50,19 @@ NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect"
 {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kAutocorrectPreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaQuanpinAutocorrectDidChangeNotification"
+                                                        object:@(enabled)];
+}
+
++ (BOOL)storedHelpcodeEnabled
+{
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kHelpcodePreferenceKey];
+    return value == nil ? YES : [value boolValue];
+}
+
++ (void)setHelpcodeEnabled:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kHelpcodePreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaHelpcodeDidChangeNotification"
                                                         object:@(enabled)];
 }
 
@@ -107,6 +122,9 @@ NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect"
     _autocorrectButton = [NSButton checkboxWithTitle:@"启用全拼自动纠错" target:self action:@selector(autocorrectChanged:)];
     _autocorrectButton.translatesAutoresizingMaskIntoConstraints = NO;
 
+    _helpcodeButton = [NSButton checkboxWithTitle:@"启用辅助码" target:self action:@selector(helpcodeChanged:)];
+    _helpcodeButton.translatesAutoresizingMaskIntoConstraints = NO;
+
     NSTextField *statusLabel = [NSTextField labelWithString:@"输入方案会保存到当前用户设置，并在下一次输入会话中生效。"];
     statusLabel.textColor = [NSColor secondaryLabelColor];
     statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
@@ -121,6 +139,7 @@ NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect"
     [contentView addSubview:schemeLabel];
     [contentView addSubview:_schemeButton];
     [contentView addSubview:_autocorrectButton];
+    [contentView addSubview:_helpcodeButton];
     [contentView addSubview:statusLabel];
     [contentView addSubview:closeButton];
 
@@ -139,7 +158,9 @@ NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect"
         [_schemeButton.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-32.0],
         [_autocorrectButton.leadingAnchor constraintEqualToAnchor:_schemeButton.leadingAnchor],
         [_autocorrectButton.topAnchor constraintEqualToAnchor:_schemeButton.bottomAnchor constant:16.0],
-        [statusLabel.topAnchor constraintEqualToAnchor:_autocorrectButton.bottomAnchor constant:12.0],
+        [_helpcodeButton.leadingAnchor constraintEqualToAnchor:_schemeButton.leadingAnchor],
+        [_helpcodeButton.topAnchor constraintEqualToAnchor:_autocorrectButton.bottomAnchor constant:10.0],
+        [statusLabel.topAnchor constraintEqualToAnchor:_helpcodeButton.bottomAnchor constant:12.0],
         [statusLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [statusLabel.trailingAnchor constraintLessThanOrEqualToAnchor:contentView.trailingAnchor constant:-32.0],
         [closeButton.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-32.0],
@@ -153,6 +174,7 @@ NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect"
 {
     [_schemeButton selectItemAtIndex:[MetasequoiaPreferencesWindowController storedScheme]];
     _autocorrectButton.state = [MetasequoiaPreferencesWindowController storedAutocorrectEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
+    _helpcodeButton.state = [MetasequoiaPreferencesWindowController storedHelpcodeEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
     [self showWindow:nil];
     [self.window center];
     [self.window makeKeyAndOrderFront:nil];
@@ -163,6 +185,12 @@ NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect"
 {
     NSButton *button = (NSButton *)sender;
     [MetasequoiaPreferencesWindowController setAutocorrectEnabled:button.state == NSControlStateValueOn];
+}
+
+- (void)helpcodeChanged:(id)sender
+{
+    NSButton *button = (NSButton *)sender;
+    [MetasequoiaPreferencesWindowController setHelpcodeEnabled:button.state == NSControlStateValueOn];
 }
 
 - (void)schemeChanged:(id)sender

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -82,10 +82,13 @@ int main()
         metasequoia::mac::InputSession default_session;
         require(default_session.scheme_type() == SchemeType::Quanpin, "The default input scheme should be full pinyin.");
         require(default_session.quanpin_autocorrect_enabled(), "Pinyin autocorrect should be enabled by default.");
+        require(default_session.helpcode_enabled(), "Helpcode should be enabled by default.");
         metasequoia::mac::InputSession shuangpin_session(SchemeType::Shuangpin);
         require(shuangpin_session.scheme_type() == SchemeType::Shuangpin, "The requested double-pinyin scheme was not retained.");
         metasequoia::mac::InputSession no_autocorrect_session(SchemeType::Quanpin, false);
         require(!no_autocorrect_session.quanpin_autocorrect_enabled(), "The requested pinyin autocorrect setting was not retained.");
+        metasequoia::mac::InputSession no_helpcode_session(SchemeType::Quanpin, true, false);
+        require(!no_helpcode_session.helpcode_enabled(), "The requested helpcode setting was not retained.");
 
         metasequoia::mac::InputSession session;
         type(session, "nihao");

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -62,6 +62,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("storedAutocorrectEnabled", preferences_controller)
         self.assertIn("setAutocorrectEnabled", preferences_controller)
         self.assertIn("启用全拼自动纠错", preferences_controller)
+        self.assertIn("storedHelpcodeEnabled", preferences_controller)
+        self.assertIn("setHelpcodeEnabled", preferences_controller)
+        self.assertIn("启用辅助码", preferences_controller)
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)


### PR DESCRIPTION
## Summary
- add a persisted auxiliary-code checkbox to the native settings panel
- pass the preference into new input sessions for both pinyin schemes
- cover default and disabled helpcode session configuration

## Verification
- `python3 tests/ReleaseConfigurationTests.py`
- `cmake --build build-helpcode-test --parallel`
- `ctest --test-dir build-helpcode-test --output-on-failure --timeout 120`
- Orca Computer: opened the settings panel, toggled `启用辅助码`, and observed the accessibility value change from 1 to 0; the preference was persisted in macOS defaults
