### PR TITLE
fix(install): make user install atomic

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,9 +12,38 @@ if [[ ! -d "$source_bundle" ]]; then
 fi
 
 mkdir -p "$destination_root"
+staging_root=$(mktemp -d "$destination_root/.MetasequoiaIME.installing.XXXXXX")
+backup_root=$(mktemp -d "$destination_root/.MetasequoiaIME.backup.XXXXXX")
+staging_bundle="$staging_root/MetasequoiaIME.app"
+backup_bundle="$backup_root/MetasequoiaIME.app"
+had_previous=false
+moved_new=false
+install_complete=false
+
+cleanup() {
+    if [[ "$install_complete" != true ]]; then
+        if [[ "$moved_new" == true && -e "$destination_bundle" ]]; then
+            rm -rf "$destination_bundle"
+        fi
+        if [[ "$had_previous" == true && -e "$backup_bundle" ]]; then
+            mv "$backup_bundle" "$destination_bundle"
+        fi
+    fi
+    rm -rf "$staging_root" "$backup_root"
+}
+
+trap cleanup EXIT
+ditto "$source_bundle" "$staging_bundle"
+codesign --verify --deep --strict --verbose=2 "$staging_bundle"
 pkill -x MetasequoiaIME 2>/dev/null || true
-ditto "$source_bundle" "$destination_bundle"
+if [[ -e "$destination_bundle" ]]; then
+    mv "$destination_bundle" "$backup_bundle"
+    had_previous=true
+fi
+mv "$staging_bundle" "$destination_bundle"
+moved_new=true
 codesign --verify --deep --strict --verbose=2 "$destination_bundle"
 xcrun swift "$project_root/scripts/register_input_source.swift" "$destination_bundle"
+install_complete=true
 print "Installed $destination_bundle"
 print "Enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit."

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -73,6 +73,11 @@ class ReleaseConfigurationTests(unittest.TestCase):
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)
         self.assertNotIn("swift", release_installer.lower())
+        install_script = (PROJECT_ROOT / "scripts/install.sh").read_text()
+        self.assertIn("staging_root=$(mktemp -d", install_script)
+        self.assertIn("backup_root=$(mktemp -d", install_script)
+        self.assertIn("install_complete=false", install_script)
+        self.assertIn("TISRegisterInputSource", (PROJECT_ROOT / "scripts/register_input_source.swift").read_text())
 
     def test_release_scripts_have_valid_zsh_syntax(self):
         for relative_path in ("scripts/install-release.sh", "scripts/package_release.sh"):


### PR DESCRIPTION
## Summary
- stage the user-level bundle before touching the installed input method
- keep a backup and restore it if verification or TIS registration fails
- clean up temporary staging and backup directories on every exit path

## Verification
- `python3 tests/ReleaseConfigurationTests.py`
- `zsh -n scripts/install.sh`
- `git diff --check`
