### PR TITLE
feat(release): require signed notarized artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,32 @@ jobs:
         run: if brew tap | grep -Fxq aws/tap; then brew untap aws/tap; fi
       - name: Install dependencies
         run: brew install boost fmt spdlog
+      - name: Import Developer ID signing certificates
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_SIGNING_KEYCHAIN_PASSWORD }}
+          NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_APP_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for required in CERTIFICATE_BASE64 CERTIFICATE_PASSWORD KEYCHAIN_PASSWORD NOTARY_APPLE_ID NOTARY_TEAM_ID NOTARY_PASSWORD; do
+            if [[ -z "${!required}" ]]; then
+              echo "Missing required release signing secret: $required" >&2
+              exit 1
+            fi
+          done
+          keychain="$RUNNER_TEMP/metasequoia-signing.keychain-db"
+          certificate="$RUNNER_TEMP/metasequoia-developer-id.p12"
+          echo "$CERTIFICATE_BASE64" | base64 -D > "$certificate"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security import "$certificate" -k "$keychain" -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
+          security list-keychains -d user -s "$keychain"
+          security default-keychain -s "$keychain"
+          xcrun notarytool store-credentials metasequoia-notary --keychain "$keychain" --apple-id "$NOTARY_APPLE_ID" --team-id "$NOTARY_TEAM_ID" --password "$NOTARY_PASSWORD"
       - name: Build dictionary
         run: python3 scripts/build_dictionary.py
       - name: Configure
@@ -100,6 +126,10 @@ jobs:
       - name: Package release
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+          METASEQUOIA_REQUIRE_RELEASE_SIGNING: true
+          METASEQUOIA_DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
+          METASEQUOIA_DEVELOPER_ID_INSTALLER: ${{ secrets.MACOS_DEVELOPER_ID_INSTALLER }}
+          METASEQUOIA_NOTARY_PROFILE: metasequoia-notary
         run: scripts/package_release.sh "$TAG_NAME" build/MetasequoiaIME.app dist
       - name: Upload and publish release
         env:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Download the `.pkg` and its checksum, verify it, then double-click the package t
 shasum -a 256 -c MetasequoiaIME-vX.Y.Z-macos-universal.pkg.sha256
 ```
 
-The current alpha uses an ad-hoc application signature and the package is not Developer ID signed or notarized. Gatekeeper may block the first double-click as expected. After verifying the checksum, try opening the package once, then open System Settings > Privacy & Security, scroll to Security, click Open Anyway, confirm Open, and return to the Installer. The Open Anyway button is available for about one hour after the blocked launch. After installation and logout, enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit.
+Release builds are signed with a Developer ID Application identity, signed as an installer with a Developer ID Installer identity, and notarized before publication. The release workflow requires the corresponding certificate and App Store Connect credentials to be configured as repository secrets; it fails closed when they are missing. Local development builds remain ad-hoc signed. After installation and logout, enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit.
 
 The ZIP remains the no-administrator option: it installs the signed bundle for the current user in `~/Library/Input Methods` via `Install.command`.
 

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -14,6 +14,17 @@ fi
 source_bundle=${source_bundle:A}
 output_dir=${output_dir:A}
 version=${tag_name#v}
+require_release_signing=${METASEQUOIA_REQUIRE_RELEASE_SIGNING:-false}
+application_identity=${METASEQUOIA_DEVELOPER_ID_APPLICATION:-}
+installer_identity=${METASEQUOIA_DEVELOPER_ID_INSTALLER:-}
+notary_profile=${METASEQUOIA_NOTARY_PROFILE:-}
+
+if [[ "$require_release_signing" == true ]]; then
+    if [[ -z "$application_identity" || -z "$installer_identity" || -z "$notary_profile" ]]; then
+        print -u2 "Commercial release signing requires METASEQUOIA_DEVELOPER_ID_APPLICATION, METASEQUOIA_DEVELOPER_ID_INSTALLER, and METASEQUOIA_NOTARY_PROFILE."
+        exit 1
+    fi
+fi
 
 if [[ ! -d "$source_bundle" ]]; then
     print -u2 "Input method bundle not found at $source_bundle"
@@ -26,6 +37,9 @@ if [[ "$bundle_version" != "$version" ]]; then
     exit 1
 fi
 
+if [[ -n "$application_identity" ]]; then
+    codesign --force --deep --options runtime --timestamp --sign "$application_identity" "$source_bundle"
+fi
 codesign --verify --deep --strict --verbose=2 "$source_bundle"
 mkdir -p "$output_dir"
 staging_root=$(mktemp -d "$output_dir/.package.XXXXXX")
@@ -43,11 +57,28 @@ ditto "$source_bundle" "$package_root/MetasequoiaIME.app"
 ditto "$project_root/scripts/install-release.sh" "$package_root/Install.command"
 chmod +x "$package_root/Install.command"
 rm -f "$archive_path" "$checksum_path" "$installer_path" "$installer_checksum_path"
+if [[ -n "$notary_profile" ]]; then
+    notary_input="$staging_root/MetasequoiaIME-notary.zip"
+    ditto -c -k --keepParent "$package_root/MetasequoiaIME.app" "$notary_input"
+    xcrun notarytool submit "$notary_input" --keychain-profile "$notary_profile" --wait
+    xcrun stapler staple "$package_root/MetasequoiaIME.app"
+    xcrun stapler validate "$package_root/MetasequoiaIME.app"
+fi
 ditto -c -k --keepParent "$package_root" "$archive_path"
 (cd "$output_dir" && shasum -a 256 "${archive_path:t}") > "$checksum_path"
-pkgbuild --component "$source_bundle" --identifier com.houko.inputmethod.MetasequoiaIME.pkg --version "$version" --install-location "Library/Input Methods" "$component_package"
+pkgbuild --component "$package_root/MetasequoiaIME.app" --identifier com.houko.inputmethod.MetasequoiaIME.pkg --version "$version" --install-location "Library/Input Methods" "$component_package"
 sed "s/@VERSION@/$version/g" "$project_root/resources/InstallerDistribution.xml.in" > "$distribution_file"
 productbuild --distribution "$distribution_file" --package-path "$staging_root" "$installer_path"
+if [[ -n "$installer_identity" ]]; then
+    signed_installer="$staging_root/MetasequoiaIME-signed.pkg"
+    productsign --sign "$installer_identity" "$installer_path" "$signed_installer"
+    mv "$signed_installer" "$installer_path"
+fi
+if [[ -n "$notary_profile" ]]; then
+    xcrun notarytool submit "$installer_path" --keychain-profile "$notary_profile" --wait
+    xcrun stapler staple "$installer_path"
+    xcrun stapler validate "$installer_path"
+fi
 (cd "$output_dir" && shasum -a 256 "${installer_path:t}") > "$installer_checksum_path"
 print "$archive_path"
 print "$checksum_path"

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -46,10 +46,13 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("timeout-minutes: 30", workflow)
         self.assertIn("gh release upload", workflow)
         self.assertIn("gh release edit", workflow)
+        self.assertIn("METASEQUOIA_REQUIRE_RELEASE_SIGNING", workflow)
+        self.assertIn("security import", workflow)
+        self.assertIn("notarytool store-credentials", workflow)
+        self.assertIn("Developer ID Application", readme)
+        self.assertIn("notarized", readme.lower())
         self.assertIn("全拼 or 小鹤双拼", readme)
         self.assertIn("enable full-pinyin autocorrection", readme)
-        self.assertIn("Open Anyway", readme)
-        self.assertIn("Privacy & Security", readme)
         self.assertIn("native 水杉输入法设置 panel", readme)
         self.assertIn("system-wide", readme)
         self.assertIn("/Library/Input Methods", readme)
@@ -78,6 +81,10 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("backup_root=$(mktemp -d", install_script)
         self.assertIn("install_complete=false", install_script)
         self.assertIn("TISRegisterInputSource", (PROJECT_ROOT / "scripts/register_input_source.swift").read_text())
+        package_script = (PROJECT_ROOT / "scripts/package_release.sh").read_text()
+        self.assertIn("productsign", package_script)
+        self.assertIn("notarytool", package_script)
+        self.assertIn("Commercial release signing requires", package_script)
 
     def test_release_scripts_have_valid_zsh_syntax(self):
         for relative_path in ("scripts/install-release.sh", "scripts/package_release.sh"):


### PR DESCRIPTION
## Summary
- import Developer ID credentials into an ephemeral CI keychain
- sign the input method with hardened runtime and sign the installer package
- notarize and staple both the app bundle and pkg before publication
- fail closed when commercial signing credentials are absent
- document the commercial release contract

## Verification
- `python3 tests/ReleaseConfigurationTests.py`
- `zsh -n scripts/package_release.sh`
- `METASEQUOIA_REQUIRE_RELEASE_SIGNING=true scripts/package_release.sh v0.5.0 /tmp/missing.app /tmp/release-audit` fails immediately with the expected missing-credentials error
- `git diff --check`
