### PR TITLE
feat(input): support numbered candidate selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the native macOS frontend for Metasequoia IME. It uses InputMethodKit and AppKit, embeds the shared C++ engine directly, and does not port the Windows TSF or WebView2 host.
 
-The current alpha supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, and composition commit on focus changes.
+The current alpha supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, and composition commit on focus changes.
 
 ## Requirements
 

--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -26,6 +26,15 @@ KeyResult InputSession::handle_character(char character)
     return {true, std::nullopt};
 }
 
+KeyResult InputSession::handle_candidate_key(char character)
+{
+    if (!has_composition() || character < '1' || character > '9')
+    {
+        return {};
+    }
+    return select_candidate(static_cast<size_t>(character - '1'));
+}
+
 KeyResult InputSession::handle_command(Command command)
 {
     if (!has_composition())

--- a/src/InputSession.h
+++ b/src/InputSession.h
@@ -28,6 +28,7 @@ class InputSession
                           bool helpcode_enabled = true);
 
     KeyResult handle_character(char character);
+    KeyResult handle_candidate_key(char character);
     KeyResult handle_command(Command command);
     KeyResult select_candidate(size_t index);
     KeyResult select_candidate(const std::string &candidate);

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -85,6 +85,14 @@ NSString *StringFromUtf8(const std::string &value)
             {
                 result = _session->handle_character(static_cast<char>(character));
             }
+            else if (character >= '1' && character <= '9')
+            {
+                result = _session->handle_candidate_key(static_cast<char>(character));
+                if (!result.handled && _session->has_composition())
+                {
+                    return YES;
+                }
+            }
         }
         break;
     }

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -104,6 +104,18 @@ int main()
         require(space.handled && space.commit == "你好", "Space did not commit the leading candidate.");
 
         type(session, "nihao");
+        const auto digit = session.handle_candidate_key('2');
+        require(digit.handled && digit.commit == "拟好", "The 2 key did not commit the second candidate.");
+
+        type(session, "nihao");
+        const auto out_of_range_digit = session.handle_candidate_key('9');
+        require(!out_of_range_digit.handled && session.preedit() == "nihao", "An out-of-range candidate key changed composition.");
+        session.handle_command(metasequoia::mac::Command::Cancel);
+
+        const auto idle_digit = session.handle_candidate_key('1');
+        require(!idle_digit.handled, "A candidate key was swallowed while no composition was active.");
+
+        type(session, "nihao");
         session.handle_command(metasequoia::mac::Command::Backspace);
         require(session.preedit() == "niha", "Backspace did not remove the last pinyin character.");
         const auto raw = session.handle_command(metasequoia::mac::Command::CommitRaw);


### PR DESCRIPTION
## Summary
- map number keys 1–9 to the corresponding candidate while composing
- keep composition intact and swallow out-of-range selection keys
- preserve normal number input when no composition is active
- document numbered candidate selection

## Verification
- `cmake --build build-number-test --parallel`
- `ctest --test-dir build-number-test --output-on-failure --timeout 120` (6/6)
- `python3 tests/ReleaseConfigurationTests.py`
- Orca Computer: installed the development build and verified that TextEdit was controlled by 水杉输入法 and displayed the `nihao` marked-text composition
- Engine integration test verifies `2` commits the second real SQLite candidate (`拟好`) and invalid/idle selection keys remain safe
