### PR TITLE
feat(input): support Chinese punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, enable full-pinyin autocorrection, and enable auxiliary codes; these choices are saved for the current user and apply to the next input session. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion; these choices are saved for the current user and apply to the next input session. Additional input and candidate options will be added incrementally.
 
 ## Development tests
 

--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -5,8 +5,10 @@
 
 namespace metasequoia::mac
 {
-InputSession::InputSession(SchemeType scheme_type, bool quanpin_autocorrect_enabled, bool helpcode_enabled)
-    : engine_(scheme_type), quanpin_autocorrect_enabled_(quanpin_autocorrect_enabled), helpcode_enabled_(helpcode_enabled)
+InputSession::InputSession(SchemeType scheme_type, bool quanpin_autocorrect_enabled, bool helpcode_enabled,
+                           bool chinese_punctuation_enabled)
+    : engine_(scheme_type), quanpin_autocorrect_enabled_(quanpin_autocorrect_enabled), helpcode_enabled_(helpcode_enabled),
+      chinese_punctuation_enabled_(chinese_punctuation_enabled)
 {
     engine_.set_quanpin_autocorrect_enabled(quanpin_autocorrect_enabled_);
     engine_.set_quanpin_helpcode_enabled(helpcode_enabled_);
@@ -33,6 +35,48 @@ KeyResult InputSession::handle_candidate_key(char character)
         return {};
     }
     return select_candidate(static_cast<size_t>(character - '1'));
+}
+
+KeyResult InputSession::handle_punctuation(char character)
+{
+    if (!chinese_punctuation_enabled_)
+    {
+        return {};
+    }
+
+    const char *punctuation = nullptr;
+    switch (character)
+    {
+    case ',':
+        punctuation = "，";
+        break;
+    case '.':
+        punctuation = "。";
+        break;
+    case '?':
+        punctuation = "？";
+        break;
+    case '!':
+        punctuation = "！";
+        break;
+    case ';':
+        punctuation = "；";
+        break;
+    case ':':
+        punctuation = "：";
+        break;
+    default:
+        return {};
+    }
+
+    std::string text;
+    if (has_composition())
+    {
+        text = candidates().empty() ? preedit() : candidates().front().word;
+        engine_.reset();
+    }
+    text += punctuation;
+    return {true, std::move(text)};
 }
 
 KeyResult InputSession::handle_command(Command command)
@@ -94,6 +138,11 @@ bool InputSession::quanpin_autocorrect_enabled() const
 bool InputSession::helpcode_enabled() const
 {
     return helpcode_enabled_;
+}
+
+bool InputSession::chinese_punctuation_enabled() const
+{
+    return chinese_punctuation_enabled_;
 }
 
 bool InputSession::has_composition() const

--- a/src/InputSession.h
+++ b/src/InputSession.h
@@ -25,10 +25,11 @@ class InputSession
 {
   public:
     explicit InputSession(SchemeType scheme_type = SchemeType::Quanpin, bool quanpin_autocorrect_enabled = true,
-                          bool helpcode_enabled = true);
+                          bool helpcode_enabled = true, bool chinese_punctuation_enabled = true);
 
     KeyResult handle_character(char character);
     KeyResult handle_candidate_key(char character);
+    KeyResult handle_punctuation(char character);
     KeyResult handle_command(Command command);
     KeyResult select_candidate(size_t index);
     KeyResult select_candidate(const std::string &candidate);
@@ -36,6 +37,7 @@ class InputSession
     SchemeType scheme_type() const;
     bool quanpin_autocorrect_enabled() const;
     bool helpcode_enabled() const;
+    bool chinese_punctuation_enabled() const;
     bool has_composition() const;
     const std::string &preedit() const;
     const std::vector<WordItem> &candidates() const;
@@ -46,5 +48,6 @@ class InputSession
     ImeSession engine_;
     bool quanpin_autocorrect_enabled_ = true;
     bool helpcode_enabled_ = true;
+    bool chinese_punctuation_enabled_ = true;
 };
 } // namespace metasequoia::mac

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -38,7 +38,9 @@ NSString *StringFromUtf8(const std::string &value)
         const SchemeType scheme = storedScheme == 1 ? SchemeType::Shuangpin : SchemeType::Quanpin;
         const BOOL autocorrectEnabled = [MetasequoiaPreferencesWindowController storedAutocorrectEnabled];
         const BOOL helpcodeEnabled = [MetasequoiaPreferencesWindowController storedHelpcodeEnabled];
-        _session = std::make_unique<metasequoia::mac::InputSession>(scheme, autocorrectEnabled, helpcodeEnabled);
+        const BOOL chinesePunctuationEnabled = [MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled];
+        _session = std::make_unique<metasequoia::mac::InputSession>(scheme, autocorrectEnabled, helpcodeEnabled,
+                                                                   chinesePunctuationEnabled);
         _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
         [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @NO}];
     }
@@ -92,6 +94,11 @@ NSString *StringFromUtf8(const std::string &value)
                 {
                     return YES;
                 }
+            }
+            else if (character == ',' || character == '.' || character == '?' || character == '!' ||
+                     character == ';' || character == ':')
+            {
+                result = _session->handle_punctuation(static_cast<char>(character));
             }
         }
         break;

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -10,5 +10,7 @@
 + (void)setAutocorrectEnabled:(BOOL)enabled;
 + (BOOL)storedHelpcodeEnabled;
 + (void)setHelpcodeEnabled:(BOOL)enabled;
++ (BOOL)storedChinesePunctuationEnabled;
++ (void)setChinesePunctuationEnabled:(BOOL)enabled;
 - (void)showAndActivate;
 @end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -3,10 +3,11 @@
 namespace
 {
 constexpr CGFloat kWindowWidth = 480.0;
-constexpr CGFloat kWindowHeight = 276.0;
+constexpr CGFloat kWindowHeight = 320.0;
 NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
 NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect";
 NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
+NSString * const kChinesePunctuationPreferenceKey = @"MetasequoiaImeChinesePunctuation";
 } // namespace
 
 @implementation MetasequoiaPreferencesWindowController
@@ -14,6 +15,7 @@ NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
     NSPopUpButton *_schemeButton;
     NSButton *_autocorrectButton;
     NSButton *_helpcodeButton;
+    NSButton *_chinesePunctuationButton;
 }
 
 + (instancetype)sharedController
@@ -63,6 +65,19 @@ NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
 {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kHelpcodePreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaHelpcodeDidChangeNotification"
+                                                        object:@(enabled)];
+}
+
++ (BOOL)storedChinesePunctuationEnabled
+{
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kChinesePunctuationPreferenceKey];
+    return value == nil ? YES : [value boolValue];
+}
+
++ (void)setChinesePunctuationEnabled:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kChinesePunctuationPreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaChinesePunctuationDidChangeNotification"
                                                         object:@(enabled)];
 }
 
@@ -125,6 +140,9 @@ NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
     _helpcodeButton = [NSButton checkboxWithTitle:@"启用辅助码" target:self action:@selector(helpcodeChanged:)];
     _helpcodeButton.translatesAutoresizingMaskIntoConstraints = NO;
 
+    _chinesePunctuationButton = [NSButton checkboxWithTitle:@"使用中文标点" target:self action:@selector(chinesePunctuationChanged:)];
+    _chinesePunctuationButton.translatesAutoresizingMaskIntoConstraints = NO;
+
     NSTextField *statusLabel = [NSTextField labelWithString:@"输入方案会保存到当前用户设置，并在下一次输入会话中生效。"];
     statusLabel.textColor = [NSColor secondaryLabelColor];
     statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
@@ -140,6 +158,7 @@ NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
     [contentView addSubview:_schemeButton];
     [contentView addSubview:_autocorrectButton];
     [contentView addSubview:_helpcodeButton];
+    [contentView addSubview:_chinesePunctuationButton];
     [contentView addSubview:statusLabel];
     [contentView addSubview:closeButton];
 
@@ -160,7 +179,9 @@ NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
         [_autocorrectButton.topAnchor constraintEqualToAnchor:_schemeButton.bottomAnchor constant:16.0],
         [_helpcodeButton.leadingAnchor constraintEqualToAnchor:_schemeButton.leadingAnchor],
         [_helpcodeButton.topAnchor constraintEqualToAnchor:_autocorrectButton.bottomAnchor constant:10.0],
-        [statusLabel.topAnchor constraintEqualToAnchor:_helpcodeButton.bottomAnchor constant:12.0],
+        [_chinesePunctuationButton.leadingAnchor constraintEqualToAnchor:_schemeButton.leadingAnchor],
+        [_chinesePunctuationButton.topAnchor constraintEqualToAnchor:_helpcodeButton.bottomAnchor constant:10.0],
+        [statusLabel.topAnchor constraintEqualToAnchor:_chinesePunctuationButton.bottomAnchor constant:12.0],
         [statusLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [statusLabel.trailingAnchor constraintLessThanOrEqualToAnchor:contentView.trailingAnchor constant:-32.0],
         [closeButton.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-32.0],
@@ -175,6 +196,7 @@ NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
     [_schemeButton selectItemAtIndex:[MetasequoiaPreferencesWindowController storedScheme]];
     _autocorrectButton.state = [MetasequoiaPreferencesWindowController storedAutocorrectEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
     _helpcodeButton.state = [MetasequoiaPreferencesWindowController storedHelpcodeEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
+    _chinesePunctuationButton.state = [MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
     [self showWindow:nil];
     [self.window center];
     [self.window makeKeyAndOrderFront:nil];
@@ -191,6 +213,12 @@ NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
 {
     NSButton *button = (NSButton *)sender;
     [MetasequoiaPreferencesWindowController setHelpcodeEnabled:button.state == NSControlStateValueOn];
+}
+
+- (void)chinesePunctuationChanged:(id)sender
+{
+    NSButton *button = (NSButton *)sender;
+    [MetasequoiaPreferencesWindowController setChinesePunctuationEnabled:button.state == NSControlStateValueOn];
 }
 
 - (void)schemeChanged:(id)sender

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -89,6 +89,9 @@ int main()
         require(!no_autocorrect_session.quanpin_autocorrect_enabled(), "The requested pinyin autocorrect setting was not retained.");
         metasequoia::mac::InputSession no_helpcode_session(SchemeType::Quanpin, true, false);
         require(!no_helpcode_session.helpcode_enabled(), "The requested helpcode setting was not retained.");
+        metasequoia::mac::InputSession ascii_punctuation_session(SchemeType::Quanpin, true, true, false);
+        require(!ascii_punctuation_session.chinese_punctuation_enabled(), "The requested punctuation setting was not retained.");
+        require(!ascii_punctuation_session.handle_punctuation('.').handled, "Disabled Chinese punctuation swallowed ASCII punctuation.");
 
         metasequoia::mac::InputSession session;
         type(session, "nihao");
@@ -102,6 +105,12 @@ int main()
         type(session, "nihao");
         const auto space = session.handle_command(metasequoia::mac::Command::CommitCandidate);
         require(space.handled && space.commit == "你好", "Space did not commit the leading candidate.");
+
+        type(session, "nihao");
+        const auto composed_punctuation = session.handle_punctuation(',');
+        require(composed_punctuation.handled && composed_punctuation.commit == "你好，", "Punctuation did not commit the candidate atomically.");
+        const auto idle_punctuation = session.handle_punctuation('.');
+        require(idle_punctuation.handled && idle_punctuation.commit == "。", "Idle Chinese punctuation was not converted.");
 
         type(session, "nihao");
         const auto digit = session.handle_candidate_key('2');

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -72,6 +72,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("storedHelpcodeEnabled", preferences_controller)
         self.assertIn("setHelpcodeEnabled", preferences_controller)
         self.assertIn("启用辅助码", preferences_controller)
+        self.assertIn("storedChinesePunctuationEnabled", preferences_controller)
+        self.assertIn("setChinesePunctuationEnabled", preferences_controller)
+        self.assertIn("使用中文标点", preferences_controller)
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)


### PR DESCRIPTION
## Summary
- convert common ASCII punctuation to Chinese punctuation by default
- commit the leading candidate and punctuation atomically during composition
- add a persisted `使用中文标点` preference with an enlarged native settings layout
- preserve ASCII punctuation when the option is disabled

## Verification
- `cmake --build build-punctuation-test --parallel`
- `ctest --test-dir build-punctuation-test --output-on-failure --timeout 120` (6/6)
- `python3 tests/ReleaseConfigurationTests.py`
- Orca Computer: verified the enlarged settings panel exposes `使用中文标点` and toggles its accessibility value from 1 to 0
