### PR TITLE
feat(input): learn selected candidates

### DIFF
--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -72,7 +72,16 @@ KeyResult InputSession::handle_punctuation(char character)
     std::string text;
     if (has_composition())
     {
-        text = candidates().empty() ? preedit() : candidates().front().word;
+        if (candidates().empty())
+        {
+            text = preedit();
+        }
+        else
+        {
+            const WordItem candidate = candidates().front();
+            text = candidate.word;
+            learn_candidate(candidate);
+        }
         engine_.reset();
     }
     text += punctuation;
@@ -162,8 +171,28 @@ const std::vector<WordItem> &InputSession::candidates() const
 
 KeyResult InputSession::commit(size_t index)
 {
-    std::string text = index < candidates().size() ? candidates()[index].word : preedit();
+    if (index >= candidates().size())
+    {
+        std::string text = preedit();
+        engine_.reset();
+        return {true, std::move(text)};
+    }
+
+    const WordItem candidate = candidates()[index];
+    std::string text = candidate.word;
+    learn_candidate(candidate);
     engine_.reset();
     return {true, std::move(text)};
+}
+
+void InputSession::learn_candidate(const WordItem &candidate)
+{
+    if (candidate.source != CandidateSource::Database && candidate.source != CandidateSource::UserDatabase)
+    {
+        return;
+    }
+
+    const std::string &pinyin = candidate.canonical_pinyin.empty() ? candidate.pinyin : candidate.canonical_pinyin;
+    (void)engine_.update_weight_by_pinyin_and_word(pinyin, candidate.word);
 }
 } // namespace metasequoia::mac

--- a/src/InputSession.h
+++ b/src/InputSession.h
@@ -44,6 +44,7 @@ class InputSession
 
   private:
     KeyResult commit(size_t index);
+    void learn_candidate(const WordItem &candidate);
 
     ImeSession engine_;
     bool quanpin_autocorrect_enabled_ = true;

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -98,10 +98,6 @@ int main()
         require(session.preedit() == "nihao", "The marked text did not mirror the raw pinyin.");
         require(session.candidates().size() >= 2, "The real engine did not return both SQLite candidates.");
 
-        const auto selected = session.select_candidate(1);
-        require(selected.handled && selected.commit == "拟好", "Selecting the second candidate committed the wrong text.");
-        require(session.preedit().empty(), "Selecting a candidate did not end composition.");
-
         type(session, "nihao");
         const auto space = session.handle_command(metasequoia::mac::Command::CommitCandidate);
         require(space.handled && space.commit == "你好", "Space did not commit the leading candidate.");
@@ -115,6 +111,11 @@ int main()
         type(session, "nihao");
         const auto digit = session.handle_candidate_key('2');
         require(digit.handled && digit.commit == "拟好", "The 2 key did not commit the second candidate.");
+
+        metasequoia::mac::InputSession learned_session;
+        type(learned_session, "nihao");
+        require(!learned_session.candidates().empty() && learned_session.candidates().front().word == "拟好",
+                "Selecting a candidate did not promote it for the next matching input.");
 
         type(session, "nihao");
         const auto out_of_range_digit = session.handle_candidate_key('9');


### PR DESCRIPTION
## Summary
- promote selected dictionary candidates for subsequent matching input
- persist learned weights through the engine user-dictionary journal
- keep non-dictionary suggestions and raw fallback commits out of learning

## Verification
- `cmake --build build-test --parallel`
- `ctest --test-dir build-test --output-on-failure --timeout 20` (6/6)
- `python3 tests/ReleaseConfigurationTests.py`
- observed the new integration assertion fail before implementation and pass afterward

Note: local `clang-format` is unavailable on this machine.