### PR TITLE
feat(settings): refresh preferences on activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion; these choices are saved for the current user and apply to the next input session. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion; these choices are saved for the current user and apply on the next input-method activation. Additional input and candidate options will be added incrementally.
 
 ## Development tests
 

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -14,6 +14,33 @@ NSString *StringFromUtf8(const std::string &value)
 {
     return [[NSString alloc] initWithBytes:value.data() length:value.size() encoding:NSUTF8StringEncoding];
 }
+
+struct SessionPreferences
+{
+    SchemeType scheme;
+    bool autocorrectEnabled;
+    bool helpcodeEnabled;
+    bool chinesePunctuationEnabled;
+};
+
+SessionPreferences ReadSessionPreferences()
+{
+    const NSInteger storedScheme = [MetasequoiaPreferencesWindowController storedScheme];
+    return {
+        storedScheme == 1 ? SchemeType::Shuangpin : SchemeType::Quanpin,
+        [MetasequoiaPreferencesWindowController storedAutocorrectEnabled] == YES,
+        [MetasequoiaPreferencesWindowController storedHelpcodeEnabled] == YES,
+        [MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled] == YES,
+    };
+}
+
+bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, const SessionPreferences &preferences)
+{
+    return session.scheme_type() == preferences.scheme &&
+           session.quanpin_autocorrect_enabled() == preferences.autocorrectEnabled &&
+           session.helpcode_enabled() == preferences.helpcodeEnabled &&
+           session.chinese_punctuation_enabled() == preferences.chinesePunctuationEnabled;
+}
 } // namespace
 
 @implementation MetasequoiaInputController
@@ -34,17 +61,41 @@ NSString *StringFromUtf8(const std::string &value)
             NSLog(@"Failed to prepare the Metasequoia dictionary: %@", error.localizedDescription);
             return self;
         }
-        const NSInteger storedScheme = [MetasequoiaPreferencesWindowController storedScheme];
-        const SchemeType scheme = storedScheme == 1 ? SchemeType::Shuangpin : SchemeType::Quanpin;
-        const BOOL autocorrectEnabled = [MetasequoiaPreferencesWindowController storedAutocorrectEnabled];
-        const BOOL helpcodeEnabled = [MetasequoiaPreferencesWindowController storedHelpcodeEnabled];
-        const BOOL chinesePunctuationEnabled = [MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled];
-        _session = std::make_unique<metasequoia::mac::InputSession>(scheme, autocorrectEnabled, helpcodeEnabled,
-                                                                   chinesePunctuationEnabled);
+        [self reloadSessionFromPreferences];
         _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
         [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @NO}];
     }
     return self;
+}
+
+- (void)reloadSessionFromPreferences
+{
+    const SessionPreferences preferences = ReadSessionPreferences();
+    if (_session != nullptr &&
+        (_session->has_composition() || SessionMatchesPreferences(*_session, preferences)))
+    {
+        return;
+    }
+    _session = std::make_unique<metasequoia::mac::InputSession>(
+        preferences.scheme, preferences.autocorrectEnabled, preferences.helpcodeEnabled,
+        preferences.chinesePunctuationEnabled);
+    _candidateData = @[];
+    [_candidatePanel setCandidateData:_candidateData];
+}
+
+- (void)activateServer:(id)sender
+{
+    [super activateServer:sender];
+    if (_session == nullptr)
+    {
+        NSError *error = nil;
+        if (!EnsureMetasequoiaDictionary(&error))
+        {
+            NSLog(@"Failed to prepare the Metasequoia dictionary: %@", error.localizedDescription);
+            return;
+        }
+    }
+    [self reloadSessionFromPreferences];
 }
 
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -143,7 +143,7 @@ NSString * const kChinesePunctuationPreferenceKey = @"MetasequoiaImeChinesePunct
     _chinesePunctuationButton = [NSButton checkboxWithTitle:@"使用中文标点" target:self action:@selector(chinesePunctuationChanged:)];
     _chinesePunctuationButton.translatesAutoresizingMaskIntoConstraints = NO;
 
-    NSTextField *statusLabel = [NSTextField labelWithString:@"输入方案会保存到当前用户设置，并在下一次输入会话中生效。"];
+    NSTextField *statusLabel = [NSTextField labelWithString:@"设置会保存到当前用户，并在下次激活水杉输入法时生效。"];
     statusLabel.textColor = [NSColor secondaryLabelColor];
     statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
 

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -77,6 +77,10 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("storedChinesePunctuationEnabled", preferences_controller)
         self.assertIn("setChinesePunctuationEnabled", preferences_controller)
         self.assertIn("使用中文标点", preferences_controller)
+        input_controller = (PROJECT_ROOT / "src/MetasequoiaInputController.mm").read_text()
+        self.assertIn("reloadSessionFromPreferences", input_controller)
+        self.assertIn("- (void)activateServer:(id)sender", input_controller)
+        self.assertIn("next input-method activation", readme)
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)


### PR DESCRIPTION
## Summary
- reload input scheme and behavior preferences when the input method activates
- preserve an active composition instead of rebuilding its session mid-input
- clear stale candidate data when a changed configuration creates a new session
- update the settings panel and README to describe the activation boundary

## Verification
- regression assertion failed before the activation hook was implemented
- `cmake --build build-test --parallel`
- `ctest --test-dir build-test --output-on-failure --timeout 20` (7/7)
- `codesign --verify --deep --strict --verbose=2 build-test/MetasequoiaIME.app`
- universal binary verified with `lipo -verify_arch arm64 x86_64`
- Orca Computer verified the 480x352 settings window, all controls, the activation status text, and checkbox interaction; the changed checkbox was restored afterward

Local `clang-format` is unavailable.