### PR TITLE
fix(input): pass through uppercase letters

### DIFF
--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -17,12 +17,12 @@ InputSession::InputSession(SchemeType scheme_type, bool quanpin_autocorrect_enab
 
 KeyResult InputSession::handle_character(char character)
 {
-    const auto unsigned_character = static_cast<unsigned char>(character);
-    if (!std::isalpha(unsigned_character) && character != '\'')
+    if ((character < 'a' || character > 'z') && character != '\'')
     {
         return {};
     }
 
+    const auto unsigned_character = static_cast<unsigned char>(character);
     const ImeKeyCode key_code = character == '\'' ? ImeKey::Apostrophe : static_cast<ImeKeyCode>(std::toupper(unsigned_character));
     engine_.handle_key(key_code, 0, static_cast<ImeCharacter>(unsigned_character));
     return {true, std::nullopt};

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -93,6 +93,14 @@ int main()
         require(!ascii_punctuation_session.chinese_punctuation_enabled(), "The requested punctuation setting was not retained.");
         require(!ascii_punctuation_session.handle_punctuation('.').handled, "Disabled Chinese punctuation swallowed ASCII punctuation.");
 
+        metasequoia::mac::InputSession uppercase_session;
+        require(!uppercase_session.handle_character('N').handled,
+                "An uppercase letter was swallowed while no composition was active.");
+        type(uppercase_session, "ni");
+        require(!uppercase_session.handle_character('H').handled && uppercase_session.preedit() == "ni",
+                "An uppercase letter entered the active pinyin composition.");
+        uppercase_session.handle_command(metasequoia::mac::Command::Cancel);
+
         metasequoia::mac::InputSession session;
         type(session, "nihao");
         require(session.preedit() == "nihao", "The marked text did not mirror the raw pinyin.");


### PR DESCRIPTION
## Summary
- reject uppercase letters from the pinyin composition path
- let the controller commit any active leading candidate and pass Shift/Caps Lock text to the host
- cover idle and active-composition uppercase behavior

## Verification
- both uppercase regression assertions failed before implementation
- `cmake --build build-test --parallel`
- `ctest --test-dir build-test --output-on-failure --timeout 20` (7/7)

Local `clang-format` is unavailable.