### PR TITLE
feat(input): expand Chinese punctuation

### DIFF
--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -21,6 +21,10 @@ KeyResult InputSession::handle_character(char character)
     {
         return {};
     }
+    if (character == '\'' && !has_composition())
+    {
+        return {};
+    }
 
     const auto unsigned_character = static_cast<unsigned char>(character);
     const ImeKeyCode key_code = character == '\'' ? ImeKey::Apostrophe : static_cast<ImeKeyCode>(std::toupper(unsigned_character));
@@ -64,6 +68,35 @@ KeyResult InputSession::handle_punctuation(char character)
         break;
     case ':':
         punctuation = "：";
+        break;
+    case '"':
+        punctuation = next_double_quote_is_opening_ ? "“" : "”";
+        next_double_quote_is_opening_ = !next_double_quote_is_opening_;
+        break;
+    case '\'':
+        punctuation = next_single_quote_is_opening_ ? "‘" : "’";
+        next_single_quote_is_opening_ = !next_single_quote_is_opening_;
+        break;
+    case '(':
+        punctuation = "（";
+        break;
+    case ')':
+        punctuation = "）";
+        break;
+    case '[':
+        punctuation = "【";
+        break;
+    case ']':
+        punctuation = "】";
+        break;
+    case '<':
+        punctuation = "《";
+        break;
+    case '>':
+        punctuation = "》";
+        break;
+    case '\\':
+        punctuation = "、";
         break;
     default:
         return {};

--- a/src/InputSession.h
+++ b/src/InputSession.h
@@ -50,5 +50,7 @@ class InputSession
     bool quanpin_autocorrect_enabled_ = true;
     bool helpcode_enabled_ = true;
     bool chinese_punctuation_enabled_ = true;
+    bool next_double_quote_is_opening_ = true;
+    bool next_single_quote_is_opening_ = true;
 };
 } // namespace metasequoia::mac

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -134,7 +134,11 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
         if (characters.length == 1)
         {
             const unichar character = [characters characterAtIndex:0];
-            if ((character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || character == '\'')
+            if ((character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z'))
+            {
+                result = _session->handle_character(static_cast<char>(character));
+            }
+            else if (character == '\'' && _session->has_composition())
             {
                 result = _session->handle_character(static_cast<char>(character));
             }
@@ -147,7 +151,9 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
                 }
             }
             else if (character == ',' || character == '.' || character == '?' || character == '!' ||
-                     character == ';' || character == ':')
+                     character == ';' || character == ':' || character == '"' || character == '\'' ||
+                     character == '(' || character == ')' || character == '[' || character == ']' ||
+                     character == '<' || character == '>' || character == '\\')
             {
                 result = _session->handle_punctuation(static_cast<char>(character));
             }

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -115,6 +115,22 @@ int main()
         require(composed_punctuation.handled && composed_punctuation.commit == "你好，", "Punctuation did not commit the candidate atomically.");
         const auto idle_punctuation = session.handle_punctuation('.');
         require(idle_punctuation.handled && idle_punctuation.commit == "。", "Idle Chinese punctuation was not converted.");
+        require(session.handle_punctuation('"').commit == "“" && session.handle_punctuation('"').commit == "”",
+                "Double quotes did not alternate between opening and closing Chinese quotes.");
+        require(session.handle_punctuation('\'').commit == "‘" && session.handle_punctuation('\'').commit == "’",
+                "Single quotes did not alternate between opening and closing Chinese quotes.");
+        require(session.handle_punctuation('(').commit == "（" && session.handle_punctuation(')').commit == "）",
+                "Parentheses were not converted to Chinese punctuation.");
+        require(session.handle_punctuation('[').commit == "【" && session.handle_punctuation(']').commit == "】",
+                "Square brackets were not converted to Chinese punctuation.");
+        require(session.handle_punctuation('<').commit == "《" && session.handle_punctuation('>').commit == "》",
+                "Book-title brackets were not converted to Chinese punctuation.");
+        require(session.handle_punctuation('\\').commit == "、", "The enumeration comma was not converted.");
+
+        type(session, "ni");
+        require(session.handle_character('\'').handled && session.preedit() == "ni'",
+                "An apostrophe inside composition was not retained as a pinyin delimiter.");
+        session.handle_command(metasequoia::mac::Command::Cancel);
 
         type(session, "nihao");
         const auto digit = session.handle_candidate_key('2');


### PR DESCRIPTION
## Summary
- add paired Chinese double and single quotes
- convert parentheses, square brackets, book-title brackets, and the enumeration comma
- keep apostrophes as pinyin delimiters while composition is active
- route idle apostrophes through Chinese punctuation conversion

## Verification
- the paired-quote regression failed before implementation
- `cmake --build build-test --parallel`
- `ctest --test-dir build-test --output-on-failure --timeout 20` (7/7)

Local `clang-format` is unavailable.