### PR TITLE
fix(input): commit candidate when composition ends

### DIFF
--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -258,15 +258,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 
 - (void)commitComposition:(id)sender
 {
-    if (_session == nullptr)
-    {
-        return;
-    }
-    const auto result = _session->handle_command(metasequoia::mac::Command::CommitRaw);
-    if (result.handled)
-    {
-        [self applyResult:result client:sender];
-    }
+    [self commitLeadingCandidate:sender];
 }
 
 - (void)deactivateServer:(id)sender

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -80,6 +80,11 @@ class ReleaseConfigurationTests(unittest.TestCase):
         input_controller = (PROJECT_ROOT / "src/MetasequoiaInputController.mm").read_text()
         self.assertIn("reloadSessionFromPreferences", input_controller)
         self.assertIn("- (void)activateServer:(id)sender", input_controller)
+        commit_composition = input_controller.split("- (void)commitComposition:(id)sender", 1)[1].split(
+            "- (void)deactivateServer:(id)sender", 1
+        )[0]
+        self.assertIn("commitLeadingCandidate", commit_composition)
+        self.assertNotIn("Command::CommitRaw", commit_composition)
         self.assertIn("next input-method activation", readme)
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()


### PR DESCRIPTION
## Summary
- commit the leading candidate when InputMethodKit requests composition finalization
- preserve Return as the explicit raw-pinyin commit command
- use the same candidate commit path for deactivation and focus changes

## Verification
- the controller regression assertion failed while `commitComposition:` still used `CommitRaw`
- `cmake --build build-test --parallel`
- `ctest --test-dir build-test --output-on-failure --timeout 20` (7/7)

Local `clang-format` is unavailable.