### PR TITLE
fix(release): enforce Gatekeeper validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,11 @@ shasum -a 256 -c MetasequoiaIME-vX.Y.Z-macos-universal.pkg.sha256
 
 Release builds are signed with a Developer ID Application identity, signed as an installer with a Developer ID Installer identity, and notarized before publication. The release workflow requires the corresponding certificate and App Store Connect credentials to be configured as repository secrets; it fails closed when they are missing. Local development builds remain ad-hoc signed. After installation and logout, enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit.
 
-The ZIP remains the no-administrator option: it installs the signed bundle for the current user in `~/Library/Input Methods` via `Install.command`.
+The ZIP remains the no-administrator option: it installs the signed and notarized bundle for the current user in `~/Library/Input Methods` via `Install.command`. The installer verifies both the code signature and Gatekeeper acceptance before replacing an existing installation.
 
-Verify the ZIP checksum, extract it, remove quarantine from the extracted release directory, and run `Install.command`:
+Verify the ZIP checksum, extract it, and run `Install.command`:
 
 ```sh
 shasum -a 256 -c MetasequoiaIME-vX.Y.Z-macos-universal.zip.sha256
-xattr -dr com.apple.quarantine MetasequoiaIME-vX.Y.Z
 ./MetasequoiaIME-vX.Y.Z/Install.command
 ```

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -11,12 +11,8 @@ if [[ ! -d "$source_bundle" ]]; then
     exit 1
 fi
 
-if xattr -p com.apple.quarantine "$source_bundle" >/dev/null 2>&1; then
-    print -u2 "This alpha release is not notarized and the app is quarantined. Verify the release checksum, remove quarantine from the extracted release directory, and run Install.command again."
-    exit 1
-fi
-
 codesign --verify --deep --strict --verbose=2 "$source_bundle"
+spctl --assess --type execute --verbose=2 "$source_bundle"
 mkdir -p "$destination_root"
 staging_root=$(mktemp -d "$destination_root/.MetasequoiaIME.installing.XXXXXX")
 backup_root=$(mktemp -d "$destination_root/.MetasequoiaIME.backup.XXXXXX")
@@ -41,6 +37,7 @@ cleanup() {
 trap cleanup EXIT
 ditto "$source_bundle" "$staging_bundle"
 codesign --verify --deep --strict --verbose=2 "$staging_bundle"
+spctl --assess --type execute --verbose=2 "$staging_bundle"
 pkill -x MetasequoiaIME 2>/dev/null || true
 if [[ -e "$destination_bundle" ]]; then
     mv "$destination_bundle" "$backup_bundle"
@@ -49,6 +46,7 @@ fi
 mv "$staging_bundle" "$destination_bundle"
 moved_new=true
 codesign --verify --deep --strict --verbose=2 "$destination_bundle"
+spctl --assess --type execute --verbose=2 "$destination_bundle"
 install_complete=true
 print "Installed $destination_bundle"
 print "Log out and back in, then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit."

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -89,6 +89,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)
+        self.assertNotIn("xattr", release_installer)
+        self.assertIn("spctl --assess --type execute", release_installer)
+        self.assertNotIn("xattr -dr com.apple.quarantine", readme)
         self.assertNotIn("swift", release_installer.lower())
         install_script = (PROJECT_ROOT / "scripts/install.sh").read_text()
         self.assertIn("staging_root=$(mktemp -d", install_script)

--- a/tests/ReleasePackageTests.py
+++ b/tests/ReleasePackageTests.py
@@ -50,6 +50,9 @@ class ReleasePackageTests(unittest.TestCase):
                 self.assertIn(f"{package_root}MetasequoiaIME.app/Contents/Info.plist", names)
                 self.assertIn(f"{package_root}Install.command", names)
                 self.assertFalse(any(name.endswith("register_input_source.swift") for name in names))
+                install_command = release_zip.read(f"{package_root}Install.command").decode()
+                self.assertIn("spctl --assess --type execute", install_command)
+                self.assertNotIn("xattr", install_command)
 
             installer_package = output / f"MetasequoiaIME-v{version}-macos-universal.pkg"
             installer_checksum = installer_package.with_suffix(f"{installer_package.suffix}.sha256")


### PR DESCRIPTION
## Summary
- require Gatekeeper acceptance for the release ZIP app before installation
- re-check staged and installed copies while retaining atomic rollback
- remove the obsolete alpha/quarantine bypass from the installer and README
- assert the packaged Install.command contains the commercial validation contract

## Verification
- release configuration tests failed on the old quarantine bypass before implementation
- `cmake --build build-test --parallel`
- `ctest --test-dir build-test --output-on-failure --timeout 20` (7/7)

A real `spctl` acceptance check remains intentionally gated on the signed/notarized release credentials.