### PR TITLE
fix(dictionary): fall back to validated database

### DIFF
--- a/src/DictionaryInstaller.h
+++ b/src/DictionaryInstaller.h
@@ -3,5 +3,7 @@
 #import <Foundation/Foundation.h>
 
 BOOL EnsureMetasequoiaDictionary(NSError **error);
+BOOL PrepareMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
+                                  NSError **error);
 BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
                                   NSError **error);

--- a/src/DictionaryInstaller.mm
+++ b/src/DictionaryInstaller.mm
@@ -2,6 +2,8 @@
 
 #include "../vendor/MetasequoiaImeEngine/user_dictionary/user_dictionary_journal.h"
 
+#include <sqlite3.h>
+
 namespace
 {
 NSString *const MetasequoiaDictionaryErrorDomain = @"com.houko.inputmethod.MetasequoiaIME.dictionary";
@@ -21,6 +23,44 @@ std::string FileSystemPath(NSURL *url)
 {
     const char *path = url.fileSystemRepresentation;
     return path == nullptr ? std::string{} : std::string(path);
+}
+
+BOOL IsUsableDictionary(NSURL *dictionary)
+{
+    const std::string path = FileSystemPath(dictionary);
+    if (path.empty())
+    {
+        return NO;
+    }
+
+    sqlite3 *database = nullptr;
+    if (sqlite3_open_v2(path.c_str(), &database, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK)
+    {
+        sqlite3_close(database);
+        return NO;
+    }
+
+    sqlite3_stmt *integrityStatement = nullptr;
+    BOOL integrityValid = sqlite3_prepare_v2(database, "PRAGMA quick_check(1)", -1, &integrityStatement, nullptr) ==
+                              SQLITE_OK &&
+                          sqlite3_step(integrityStatement) == SQLITE_ROW;
+    if (integrityValid)
+    {
+        const unsigned char *result = sqlite3_column_text(integrityStatement, 0);
+        integrityValid = result != nullptr && std::string(reinterpret_cast<const char *>(result)) == "ok";
+    }
+    sqlite3_finalize(integrityStatement);
+
+    sqlite3_stmt *schemaStatement = nullptr;
+    BOOL schemaValid = integrityValid &&
+                       sqlite3_prepare_v2(database,
+                                          "SELECT 1 FROM sqlite_master WHERE type='table' AND name GLOB 'tbl_*' "
+                                          "LIMIT 1",
+                                          -1, &schemaStatement, nullptr) == SQLITE_OK &&
+                       sqlite3_step(schemaStatement) == SQLITE_ROW;
+    sqlite3_finalize(schemaStatement);
+    sqlite3_close(database);
+    return schemaValid;
 }
 } // namespace
 
@@ -140,6 +180,41 @@ BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString 
     }
 }
 
+BOOL PrepareMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
+                                  NSError **error)
+{
+    NSError *installError = nil;
+    if (InstallMetasequoiaDictionary(source, dataDirectory, dictionaryFingerprint, &installError))
+    {
+        if (error != nullptr)
+        {
+            *error = nil;
+        }
+        return YES;
+    }
+
+    NSURL *existingDictionary = [dataDirectory URLByAppendingPathComponent:@"msime.db" isDirectory:NO];
+    if (IsUsableDictionary(existingDictionary))
+    {
+        NSLog(@"Bundled dictionary update failed; continuing with the validated existing dictionary.");
+        if (error != nullptr)
+        {
+            *error = nil;
+        }
+        return YES;
+    }
+
+    if (installError != nil)
+    {
+        if (error != nullptr)
+        {
+            *error = installError;
+        }
+        return NO;
+    }
+    return Fail(error, 4, @"No usable Metasequoia dictionary is available.");
+}
+
 BOOL EnsureMetasequoiaDictionary(NSError **error)
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -156,5 +231,5 @@ BOOL EnsureMetasequoiaDictionary(NSError **error)
     NSURL *dataDirectory = [applicationSupport URLByAppendingPathComponent:@"metasequoiaime" isDirectory:YES];
     NSURL *source = [[NSBundle mainBundle] URLForResource:@"msime" withExtension:@"db"];
     NSString *fingerprint = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MetasequoiaDictionarySHA256"];
-    return InstallMetasequoiaDictionary(source, dataDirectory, fingerprint, error);
+    return PrepareMetasequoiaDictionary(source, dataDirectory, fingerprint, error);
 }

--- a/tests/DictionaryInstallerTests.mm
+++ b/tests/DictionaryInstallerTests.mm
@@ -133,6 +133,10 @@ int main()
         Require(!InstallMetasequoiaDictionary(missingSource, failureDirectory, @"missing", &error),
                 "A missing bundled dictionary unexpectedly succeeded.");
         Require(ReadString(failureDestination) == "keep-me", "A failed update removed the working dictionary.");
+        error = nil;
+        Require(!PrepareMetasequoiaDictionary(missingSource, failureDirectory, @"missing", &error),
+                "A corrupt existing dictionary was accepted as an update fallback.");
+        Require(error != nil, "A rejected dictionary fallback did not preserve the update error.");
 
         NSURL *replayFailureDirectory = CreateDirectory(root, @"replay-failure");
         NSURL *replayFailureSource = [root URLByAppendingPathComponent:@"replay-failure-source.db"];
@@ -154,6 +158,13 @@ int main()
                 "An invalid user dictionary replay unexpectedly succeeded.");
         Require(ReadWeight(replayFailureDestination, "你好") == 321,
                 "A failed journal replay replaced the working dictionary.");
+        error = nil;
+        Require(PrepareMetasequoiaDictionary(replayFailureSource, replayFailureDirectory, @"new-fingerprint",
+                                             &error),
+                "A valid existing dictionary was not used after an update failure.");
+        Require(error == nil, "A successful dictionary fallback leaked the update error.");
+        Require(ReadWeight(replayFailureDestination, "你好") == 321,
+                "Dictionary fallback did not preserve the existing working database.");
 
         Require([fileManager removeItemAtURL:root error:&error], error.localizedDescription.UTF8String);
     }


### PR DESCRIPTION
## Summary
- keep input sessions available when a bundled dictionary update fails but the installed database is still healthy
- validate fallback databases with SQLite quick-check and an expected dictionary table before use
- preserve the original installation error when no valid fallback exists

## Verification
- TDD: dictionary installer tests initially failed to compile because the fallback preparation API did not exist
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 20` (7/7 passed)
- verified replay failure preserves the old learned database and corrupt non-SQLite data is rejected

## Notes
- local `clang-format` is unavailable; touched Objective-C++ follows the existing style