### PR TITLE
fix(input): preserve candidate panel on recovery

### DIFF
--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -55,6 +55,9 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     self = [super initWithServer:server delegate:delegate client:inputClient];
     if (self != nil)
     {
+        _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
+        [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @NO}];
+
         NSError *error = nil;
         if (!EnsureMetasequoiaDictionary(&error))
         {
@@ -62,8 +65,6 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
             return self;
         }
         [self reloadSessionFromPreferences];
-        _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
-        [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @NO}];
     }
     return self;
 }

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -85,6 +85,13 @@ class ReleaseConfigurationTests(unittest.TestCase):
         input_controller = (PROJECT_ROOT / "src/MetasequoiaInputController.mm").read_text()
         self.assertIn("reloadSessionFromPreferences", input_controller)
         self.assertIn("- (void)activateServer:(id)sender", input_controller)
+        controller_initialization = input_controller.split("- (instancetype)initWithServer:", 1)[1].split(
+            "- (void)reloadSessionFromPreferences", 1
+        )[0]
+        self.assertLess(
+            controller_initialization.index("_candidatePanel ="),
+            controller_initialization.index("EnsureMetasequoiaDictionary"),
+        )
         commit_composition = input_controller.split("- (void)commitComposition:(id)sender", 1)[1].split(
             "- (void)deactivateServer:(id)sender", 1
         )[0]


### PR DESCRIPTION
## Summary
- initialize the native candidate panel independently of dictionary readiness
- preserve candidate UI when a controller starts during a temporary dictionary failure and recovers on a later activation

## Verification
- TDD: release configuration regression failed while candidate panel creation followed the early dictionary return
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 20` (7/7 passed)

## Notes
- local `clang-format` is unavailable; the moved Objective-C++ code is unchanged and follows existing style