### PR TITLE
fix(input): preserve shifted key characters

### DIFF
--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -131,7 +131,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
         break;
     default:
     {
-        NSString *characters = event.charactersIgnoringModifiers;
+        NSString *characters = event.characters;
         if (characters.length == 1)
         {
             const unichar character = [characters characterAtIndex:0];

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -92,6 +92,8 @@ class ReleaseConfigurationTests(unittest.TestCase):
             controller_initialization.index("_candidatePanel ="),
             controller_initialization.index("EnsureMetasequoiaDictionary"),
         )
+        self.assertIn("NSString *characters = event.characters;", input_controller)
+        self.assertNotIn("charactersIgnoringModifiers", input_controller)
         commit_composition = input_controller.split("- (void)commitComposition:(id)sender", 1)[1].split(
             "- (void)deactivateServer:(id)sender", 1
         )[0]


### PR DESCRIPTION
## Summary
- route printable keys using the characters produced by the current modifier state
- prevent Shift+letter from entering lowercase pinyin
- prevent shifted number-row punctuation from being mistaken for candidate selection
- add a regression assertion for the controller routing source

## Verification
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 20` (7/7 passed)
- `git diff --check`

## Notes
- `clang-format` is unavailable in the local environment; the Objective-C++ change is a one-token API replacement and follows the existing formatting.