### PR TITLE
ci(release): merge release pull requests automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,24 +28,34 @@ jobs:
       issues: write
       pull-requests: write
     outputs:
-      should_publish: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.release_created == 'true' }}
-      tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || steps.release.outputs.tag_name }}
+      should_publish: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.release_created == 'true' || steps.finalized_release.outputs.release_created == 'true' }}
+      tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || steps.finalized_release.outputs.tag_name || steps.release.outputs.tag_name }}
     steps:
+      - name: Check out release automation
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: Prepare release
         if: ${{ github.event_name == 'push' }}
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run CI for release pull request
+      - name: Test and merge release pull request
         if: ${{ github.event_name == 'push' && steps.release.outputs.prs_created == 'true' }}
+        id: merge_release_pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
-        run: |
-          head_branch=$(jq -er .headBranchName <<< "$RELEASE_PR")
-          gh workflow run ci.yml --repo "$GH_REPO" --ref "$head_branch"
+        run: scripts/merge-release-pr.sh
+      - name: Finalize automated release
+        if: ${{ github.event_name == 'push' && steps.merge_release_pr.outputs.merged == 'true' }}
+        id: finalized_release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate requested draft release
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if(BUILD_TESTING)
     target_link_libraries(MetasequoiaImeMacTests PRIVATE MetasequoiaImeMacCore)
     target_compile_options(MetasequoiaImeMacTests PRIVATE -Wall -Wextra -Wpedantic -Werror)
     add_test(NAME input_session COMMAND MetasequoiaImeMacTests)
+    add_test(NAME release_automation COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/ReleaseAutomationTests.py)
     add_test(NAME release_configuration COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/ReleaseConfigurationTests.py)
 endif()
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
       "draft": true,
       "force-tag-creation": true,
       "pull-request-header": "This PR prepares the next Metasequoia IME for macOS release.",
-      "pull-request-footer": "Merge after CI passes to create the tag and build release assets.",
+      "pull-request-footer": "CI runs automatically; after it passes, this PR is squash-merged and the release is finalized automatically.",
       "extra-files": [
         {
           "type": "generic",

--- a/scripts/merge-release-pr.sh
+++ b/scripts/merge-release-pr.sh
@@ -1,0 +1,81 @@
+#!/bin/zsh
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO is required}"
+: "${RELEASE_PR:?RELEASE_PR is required}"
+
+write_output() {
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        print -r -- "$1" >> "$GITHUB_OUTPUT"
+    fi
+}
+
+pr_number=$(jq -er '.number | select(type == "number")' <<< "$RELEASE_PR")
+expected_head_branch=$(jq -er '.headBranchName | select(type == "string" and length > 0)' <<< "$RELEASE_PR")
+if [[ "$expected_head_branch" != release-please--* ]]; then
+    print -u2 -- "Refusing to merge a non-Release-Please branch: $expected_head_branch"
+    exit 1
+fi
+
+pr_json=$(gh pr view "$pr_number" --repo "$GH_REPO" \
+    --json number,state,isDraft,headRefName,headRefOid,baseRefName,baseRefOid,title)
+state=$(jq -er .state <<< "$pr_json")
+is_draft=$(jq -r .isDraft <<< "$pr_json")
+head_branch=$(jq -er .headRefName <<< "$pr_json")
+head_sha=$(jq -er .headRefOid <<< "$pr_json")
+base_branch=$(jq -er .baseRefName <<< "$pr_json")
+base_sha=$(jq -er .baseRefOid <<< "$pr_json")
+title=$(jq -er .title <<< "$pr_json")
+
+if [[ "$state" != OPEN || "$is_draft" != false || "$head_branch" != "$expected_head_branch" || "$base_branch" != main ]]; then
+    print -u2 -- "Release PR #$pr_number is not an open, mergeable Release Please PR against main."
+    exit 1
+fi
+if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    print -u2 -- "Release PR #$pr_number returned invalid commit metadata."
+    exit 1
+fi
+
+gh workflow run ci.yml --repo "$GH_REPO" --ref "$head_branch"
+
+max_polls=${METASEQUOIA_RELEASE_CI_MAX_POLLS:-150}
+poll_interval=${METASEQUOIA_RELEASE_CI_POLL_INTERVAL:-2}
+run_id=""
+for ((attempt = 1; attempt <= max_polls; ++attempt)); do
+    run_id=$(gh run list --repo "$GH_REPO" --workflow ci.yml --branch "$head_branch" \
+        --event workflow_dispatch --limit 20 --json databaseId,headSha \
+        --jq "map(select(.headSha == \"$head_sha\")) | first | .databaseId // empty")
+    if [[ -n "$run_id" ]]; then
+        break
+    fi
+    sleep "$poll_interval"
+done
+if [[ -z "$run_id" ]]; then
+    print -u2 -- "Timed out waiting for CI to start for release PR #$pr_number at $head_sha."
+    exit 1
+fi
+
+gh run watch "$run_id" --repo "$GH_REPO" --exit-status --interval 10
+
+current_base_sha=$(gh api "repos/$GH_REPO/git/ref/heads/$base_branch" --jq .object.sha)
+if [[ "$current_base_sha" != "$base_sha" ]]; then
+    print -- "main advanced while release PR #$pr_number was being tested; leaving it open for the next release run."
+    write_output "merged=false"
+    exit 0
+fi
+
+current_pr_json=$(gh pr view "$pr_number" --repo "$GH_REPO" \
+    --json state,isDraft,headRefName,headRefOid,baseRefName)
+if [[ "$(jq -er .state <<< "$current_pr_json")" != OPEN || \
+      "$(jq -r .isDraft <<< "$current_pr_json")" != false || \
+      "$(jq -er .headRefName <<< "$current_pr_json")" != "$head_branch" || \
+      "$(jq -er .headRefOid <<< "$current_pr_json")" != "$head_sha" || \
+      "$(jq -er .baseRefName <<< "$current_pr_json")" != "$base_branch" ]]; then
+    print -u2 -- "Release PR #$pr_number changed after CI completed; refusing to merge it."
+    exit 1
+fi
+
+gh pr merge "$pr_number" --repo "$GH_REPO" --squash --delete-branch \
+    --match-head-commit "$head_sha" --subject "$title" \
+    --body "Automated release PR merge after CI passed."
+write_output "merged=true"

--- a/tests/ReleaseAutomationTests.py
+++ b/tests/ReleaseAutomationTests.py
@@ -1,0 +1,100 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+BASE_SHA = "1" * 40
+HEAD_SHA = "2" * 40
+
+
+class ReleaseAutomationTests(unittest.TestCase):
+    def run_merge(self, current_base=BASE_SHA, ci_exit_code="0"):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            log = temporary / "gh.log"
+            output = temporary / "github-output"
+            fake_gh = temporary / "gh"
+            fake_gh.write_text(
+                """#!/bin/zsh
+set -euo pipefail
+print -r -- "$*" >> "$FAKE_GH_LOG"
+if [[ "$1 $2" == "pr view" ]]; then
+    print -r -- "{\\"number\\":42,\\"state\\":\\"OPEN\\",\\"isDraft\\":false,\\"headRefName\\":\\"release-please--branches--main--components--MetasequoiaImeMac\\",\\"headRefOid\\":\\"$FAKE_HEAD_SHA\\",\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"$FAKE_BASE_SHA\\",\\"title\\":\\"chore(main): release 1.2.3\\"}"
+elif [[ "$1 $2" == "workflow run" ]]; then
+    exit 0
+elif [[ "$1 $2" == "run list" ]]; then
+    print -r -- "9001"
+elif [[ "$1 $2" == "run watch" ]]; then
+    exit "$FAKE_CI_EXIT_CODE"
+elif [[ "$1" == "api" ]]; then
+    print -r -- "$FAKE_CURRENT_BASE"
+elif [[ "$1 $2" == "pr merge" ]]; then
+    exit 0
+else
+    print -u2 -- "Unexpected gh invocation: $*"
+    exit 64
+fi
+"""
+            )
+            fake_gh.chmod(0o755)
+            release_pr = {
+                "headBranchName": "release-please--branches--main--components--MetasequoiaImeMac",
+                "number": 42,
+            }
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{temporary}:{environment['PATH']}",
+                    "GH_REPO": "houko/MetasequoiaImeMac",
+                    "RELEASE_PR": json.dumps(release_pr),
+                    "GITHUB_OUTPUT": str(output),
+                    "FAKE_GH_LOG": str(log),
+                    "FAKE_BASE_SHA": BASE_SHA,
+                    "FAKE_CURRENT_BASE": current_base,
+                    "FAKE_CI_EXIT_CODE": ci_exit_code,
+                    "FAKE_HEAD_SHA": HEAD_SHA,
+                    "METASEQUOIA_RELEASE_CI_MAX_POLLS": "1",
+                    "METASEQUOIA_RELEASE_CI_POLL_INTERVAL": "0",
+                }
+            )
+            result = subprocess.run(
+                [PROJECT_ROOT / "scripts/merge-release-pr.sh"],
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            return result, log.read_text() if log.exists() else "", output.read_text() if output.exists() else ""
+
+    def test_release_pull_request_merges_only_after_its_ci_run_passes(self):
+        result, calls, output = self.run_merge()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("workflow run ci.yml", calls)
+        self.assertLess(calls.index("workflow run ci.yml"), calls.index("run watch 9001"))
+        self.assertLess(calls.index("run watch 9001"), calls.index("pr merge 42"))
+        self.assertIn(f"--match-head-commit {HEAD_SHA}", calls)
+        self.assertEqual(output, "merged=true\n")
+
+    def test_release_pull_request_stays_open_when_main_advances_during_ci(self):
+        result, calls, output = self.run_merge(current_base="3" * 40)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("run watch 9001", calls)
+        self.assertNotIn("pr merge 42", calls)
+        self.assertEqual(output, "merged=false\n")
+
+    def test_release_pull_request_stays_open_when_ci_fails(self):
+        result, calls, output = self.run_merge(ci_exit_code="1")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("run watch 9001", calls)
+        self.assertNotIn("pr merge 42", calls)
+        self.assertEqual(output, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -24,6 +24,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         config = json.loads((PROJECT_ROOT / "release-please-config.json").read_text())
         package = config["packages"]["."]
         workflow = (PROJECT_ROOT / ".github/workflows/release.yml").read_text()
+        merge_release_pr = (PROJECT_ROOT / "scripts/merge-release-pr.sh").read_text()
         readme = (PROJECT_ROOT / "README.md").read_text()
         info_plist = (PROJECT_ROOT / "resources/Info.plist").read_text()
         cmake = (PROJECT_ROOT / "CMakeLists.txt").read_text()
@@ -37,10 +38,17 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7", workflow)
         self.assertIn("actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803", workflow)
         self.assertIn("steps.release.outputs.release_created", workflow)
+        self.assertIn("scripts/merge-release-pr.sh", workflow)
+        self.assertIn("id: merge_release_pr", workflow)
+        self.assertIn("id: finalized_release", workflow)
+        self.assertIn("steps.merge_release_pr.outputs.merged == 'true'", workflow)
+        self.assertIn("steps.finalized_release.outputs.release_created", workflow)
         self.assertIn("workflow_dispatch:", workflow)
         self.assertIn("persist-credentials: false", workflow)
         self.assertIn("GH_REPO: ${{ github.repository }}", workflow)
-        self.assertIn("gh workflow run ci.yml", workflow)
+        self.assertIn("gh workflow run ci.yml", merge_release_pr)
+        self.assertIn("gh run watch", merge_release_pr)
+        self.assertIn("--match-head-commit", merge_release_pr)
         self.assertIn("scripts/package_release.sh", workflow)
         self.assertIn("macos-universal.pkg", workflow)
         self.assertIn("timeout-minutes: 30", workflow)
@@ -125,7 +133,11 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("THIRD_PARTY_NOTICES.txt", package_script)
 
     def test_release_scripts_have_valid_zsh_syntax(self):
-        for relative_path in ("scripts/install-release.sh", "scripts/package_release.sh"):
+        for relative_path in (
+            "scripts/install-release.sh",
+            "scripts/merge-release-pr.sh",
+            "scripts/package_release.sh",
+        ):
             result = subprocess.run(["zsh", "-n", str(PROJECT_ROOT / relative_path)], capture_output=True, text=True)
             self.assertEqual(result.returncode, 0, result.stderr)
 


### PR DESCRIPTION
## Summary
- dispatch and wait for CI on the exact Release Please PR commit
- squash-merge the release PR automatically only after CI succeeds
- refuse stale or changed PRs when `main` advances during validation
- immediately rerun Release Please after the token-authored merge so the tag and draft release are finalized in the same workflow
- keep signed/notarized publishing fail-closed when release credentials are unavailable

## Verification
- TDD coverage for successful CI, failed CI, and advancing-main race cases
- `actionlint .github/workflows/release.yml`
- `shellcheck --shell=bash scripts/merge-release-pr.sh`
- `zsh -n scripts/merge-release-pr.sh`
- live read-only guard check against merged release PR #35
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 20` (8/8 passed)
- `git diff --check`

## Behavior
Release Please PRs no longer require manual approval or merge. Their exact head commit is tested first. Signing and notarization still require the documented GitHub Actions secrets; missing credentials leave the generated GitHub release as a draft and fail before building.