### PR TITLE
fix(release): run automation with bash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
-        run: scripts/merge-release-pr.sh
+        run: bash scripts/merge-release-pr.sh
       - name: Finalize automated release
         if: ${{ github.event_name == 'push' && steps.merge_release_pr.outputs.merged == 'true' }}
         id: finalized_release

--- a/scripts/merge-release-pr.sh
+++ b/scripts/merge-release-pr.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 set -euo pipefail
 
 : "${GH_REPO:?GH_REPO is required}"
@@ -6,14 +6,14 @@ set -euo pipefail
 
 write_output() {
     if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-        print -r -- "$1" >> "$GITHUB_OUTPUT"
+        printf '%s\n' "$1" >> "$GITHUB_OUTPUT"
     fi
 }
 
 pr_number=$(jq -er '.number | select(type == "number")' <<< "$RELEASE_PR")
 expected_head_branch=$(jq -er '.headBranchName | select(type == "string" and length > 0)' <<< "$RELEASE_PR")
 if [[ "$expected_head_branch" != release-please--* ]]; then
-    print -u2 -- "Refusing to merge a non-Release-Please branch: $expected_head_branch"
+    printf '%s\n' "Refusing to merge a non-Release-Please branch: $expected_head_branch" >&2
     exit 1
 fi
 
@@ -28,11 +28,11 @@ base_sha=$(jq -er .baseRefOid <<< "$pr_json")
 title=$(jq -er .title <<< "$pr_json")
 
 if [[ "$state" != OPEN || "$is_draft" != false || "$head_branch" != "$expected_head_branch" || "$base_branch" != main ]]; then
-    print -u2 -- "Release PR #$pr_number is not an open, mergeable Release Please PR against main."
+    printf '%s\n' "Release PR #$pr_number is not an open, mergeable Release Please PR against main." >&2
     exit 1
 fi
 if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
-    print -u2 -- "Release PR #$pr_number returned invalid commit metadata."
+    printf '%s\n' "Release PR #$pr_number returned invalid commit metadata." >&2
     exit 1
 fi
 
@@ -51,7 +51,7 @@ for ((attempt = 1; attempt <= max_polls; ++attempt)); do
     sleep "$poll_interval"
 done
 if [[ -z "$run_id" ]]; then
-    print -u2 -- "Timed out waiting for CI to start for release PR #$pr_number at $head_sha."
+    printf '%s\n' "Timed out waiting for CI to start for release PR #$pr_number at $head_sha." >&2
     exit 1
 fi
 
@@ -59,7 +59,7 @@ gh run watch "$run_id" --repo "$GH_REPO" --exit-status --interval 10
 
 current_base_sha=$(gh api "repos/$GH_REPO/git/ref/heads/$base_branch" --jq .object.sha)
 if [[ "$current_base_sha" != "$base_sha" ]]; then
-    print -- "main advanced while release PR #$pr_number was being tested; leaving it open for the next release run."
+    printf '%s\n' "main advanced while release PR #$pr_number was being tested; leaving it open for the next release run."
     write_output "merged=false"
     exit 0
 fi
@@ -71,7 +71,7 @@ if [[ "$(jq -er .state <<< "$current_pr_json")" != OPEN || \
       "$(jq -er .headRefName <<< "$current_pr_json")" != "$head_branch" || \
       "$(jq -er .headRefOid <<< "$current_pr_json")" != "$head_sha" || \
       "$(jq -er .baseRefName <<< "$current_pr_json")" != "$base_branch" ]]; then
-    print -u2 -- "Release PR #$pr_number changed after CI completed; refusing to merge it."
+    printf '%s\n' "Release PR #$pr_number changed after CI completed; refusing to merge it." >&2
     exit 1
 fi
 

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -38,7 +38,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7", workflow)
         self.assertIn("actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803", workflow)
         self.assertIn("steps.release.outputs.release_created", workflow)
-        self.assertIn("scripts/merge-release-pr.sh", workflow)
+        self.assertIn("run: bash scripts/merge-release-pr.sh", workflow)
         self.assertIn("id: merge_release_pr", workflow)
         self.assertIn("id: finalized_release", workflow)
         self.assertIn("steps.merge_release_pr.outputs.merged == 'true'", workflow)
@@ -49,6 +49,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("gh workflow run ci.yml", merge_release_pr)
         self.assertIn("gh run watch", merge_release_pr)
         self.assertIn("--match-head-commit", merge_release_pr)
+        self.assertTrue(merge_release_pr.startswith("#!/usr/bin/env bash\n"))
         self.assertIn("scripts/package_release.sh", workflow)
         self.assertIn("macos-universal.pkg", workflow)
         self.assertIn("timeout-minutes: 30", workflow)
@@ -138,13 +139,13 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("THIRD_PARTY_NOTICES.txt", package_script)
 
     def test_release_scripts_have_valid_zsh_syntax(self):
-        for relative_path in (
-            "scripts/install-release.sh",
-            "scripts/merge-release-pr.sh",
-            "scripts/package_release.sh",
-        ):
+        for relative_path in ("scripts/install-release.sh", "scripts/package_release.sh"):
             result = subprocess.run(["zsh", "-n", str(PROJECT_ROOT / relative_path)], capture_output=True, text=True)
             self.assertEqual(result.returncode, 0, result.stderr)
+        result = subprocess.run(
+            ["bash", "-n", str(PROJECT_ROOT / "scripts/merge-release-pr.sh")], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run the Release Please merge helper with Ubuntu-native Bash
- replace zsh-only `print` calls with portable `printf`
- validate the script using Bash syntax checks and ShellCheck
- invoke Bash explicitly from the workflow as defense in depth

## Root cause
The release `prepare` job runs on `ubuntu-latest`, but `merge-release-pr.sh` used `/bin/zsh`. The live v0.9.0 automation run therefore failed with exit 127 before it could dispatch CI. Release PR #40 remains open and unchanged.

## Verification
- `bash -n scripts/merge-release-pr.sh`
- `shellcheck --shell=bash scripts/merge-release-pr.sh`
- `actionlint .github/workflows/release.yml`
- `python3 tests/ReleaseAutomationTests.py` (3/3 passed)
- `python3 tests/ReleaseConfigurationTests.py` (3/3 passed)
- `git diff --check`

After this PR merges, the resulting main push will update #40 and exercise the corrected automatic CI/merge/finalize path.