### PR TITLE
fix(input): commit the highlighted candidate with space

### DIFF
--- a/src/CandidateSelectionState.h
+++ b/src/CandidateSelectionState.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "InputSession.h"
+
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace metasequoia::mac
+{
+class CandidateSelectionState
+{
+  public:
+    void begin_navigation()
+    {
+        accepts_selection_changes_ = true;
+        selected_candidate_.reset();
+    }
+
+    void update(std::string candidate)
+    {
+        if (accepts_selection_changes_)
+        {
+            selected_candidate_ = std::move(candidate);
+        }
+    }
+
+    void reset()
+    {
+        accepts_selection_changes_ = false;
+        selected_candidate_.reset();
+    }
+
+    KeyResult commit(InputSession &session) const
+    {
+        if (selected_candidate_.has_value())
+        {
+            const KeyResult selected = session.select_candidate(*selected_candidate_);
+            if (selected.handled)
+            {
+                return selected;
+            }
+        }
+        return session.handle_command(Command::CommitCandidate);
+    }
+
+  private:
+    bool accepts_selection_changes_ = false;
+    std::optional<std::string> selected_candidate_;
+};
+} // namespace metasequoia::mac

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -2,6 +2,7 @@
 
 #import "DictionaryInstaller.h"
 #import "PreferencesWindowController.h"
+#include "CandidateSelectionState.h"
 #include "InputControllerKeyRouting.h"
 #include "InputSession.h"
 
@@ -47,6 +48,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 @implementation MetasequoiaInputController
 {
     std::unique_ptr<metasequoia::mac::InputSession> _session;
+    metasequoia::mac::CandidateSelectionState _candidateSelection;
     IMKCandidates *_candidatePanel;
     NSArray *_candidateData;
 }
@@ -120,21 +122,27 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     case metasequoia::mac::ControllerKeyAction::ConsumeCandidateKey:
         return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateLeft:
+        _candidateSelection.begin_navigation();
         [_candidatePanel moveLeft:self];
         return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateRight:
+        _candidateSelection.begin_navigation();
         [_candidatePanel moveRight:self];
         return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateUp:
+        _candidateSelection.begin_navigation();
         [_candidatePanel moveUp:self];
         return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateDown:
+        _candidateSelection.begin_navigation();
         [_candidatePanel moveDown:self];
         return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidatePageUp:
+        _candidateSelection.begin_navigation();
         [_candidatePanel pageUp:self];
         return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidatePageDown:
+        _candidateSelection.begin_navigation();
         [_candidatePanel pageDown:self];
         return YES;
     case metasequoia::mac::ControllerKeyAction::Backspace:
@@ -147,7 +155,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
         result = _session->handle_command(metasequoia::mac::Command::Cancel);
         break;
     case metasequoia::mac::ControllerKeyAction::CommitCandidate:
-        result = _session->handle_command(metasequoia::mac::Command::CommitCandidate);
+        result = _candidateSelection.commit(*_session);
         break;
     case metasequoia::mac::ControllerKeyAction::Character:
     {
@@ -212,6 +220,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     if (result.commit.has_value())
     {
         [client insertText:StringFromUtf8(*result.commit) replacementRange:replacementRange];
+        _candidateSelection.reset();
         [_candidatePanel hide];
         return;
     }
@@ -223,6 +232,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 
 - (void)updateCandidatePanel
 {
+    _candidateSelection.reset();
     NSMutableArray *data = [NSMutableArray arrayWithCapacity:_session->candidates().size()];
     for (const WordItem &candidate : _session->candidates())
     {
@@ -244,6 +254,15 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 {
     (void)sender;
     return _candidateData != nil ? _candidateData : @[];
+}
+
+- (void)candidateSelectionChanged:(NSAttributedString *)candidateString
+{
+    const char *utf8 = candidateString.string.UTF8String;
+    if (utf8 != nullptr)
+    {
+        _candidateSelection.update(utf8);
+    }
 }
 
 - (void)candidateSelected:(NSAttributedString *)candidateString

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -1,4 +1,5 @@
 #include "../src/InputSession.h"
+#include "../src/CandidateSelectionState.h"
 #include "../vendor/MetasequoiaImeEngine/core/data_path.h"
 
 #include <sqlite3.h>
@@ -140,6 +141,43 @@ int main()
         type(learned_session, "nihao");
         require(!learned_session.candidates().empty() && learned_session.candidates().front().word == "拟好",
                 "Selecting a candidate did not promote it for the next matching input.");
+
+        metasequoia::mac::CandidateSelectionState candidate_selection;
+        metasequoia::mac::InputSession unarmed_selection_session;
+        type(unarmed_selection_session, "nihao");
+        const std::string initial_leading_candidate = unarmed_selection_session.candidates().front().word;
+        candidate_selection.update(unarmed_selection_session.candidates()[1].word);
+        const auto initial_selection = candidate_selection.commit(unarmed_selection_session);
+        require(initial_selection.handled && initial_selection.commit == initial_leading_candidate,
+                "An unsolicited candidate selection callback replaced the leading candidate.");
+
+        metasequoia::mac::InputSession highlighted_session;
+        type(highlighted_session, "nihao");
+        const std::string highlighted_candidate = highlighted_session.candidates()[1].word;
+        candidate_selection.begin_navigation();
+        candidate_selection.update(highlighted_candidate);
+        const auto highlighted = candidate_selection.commit(highlighted_session);
+        require(highlighted.handled && highlighted.commit == highlighted_candidate,
+                "Space did not commit the candidate highlighted by the native panel.");
+
+        metasequoia::mac::InputSession leading_session;
+        type(leading_session, "nihao");
+        const std::string leading_candidate = leading_session.candidates().front().word;
+        candidate_selection.begin_navigation();
+        candidate_selection.update(leading_session.candidates()[1].word);
+        candidate_selection.reset();
+        const auto leading = candidate_selection.commit(leading_session);
+        require(leading.handled && leading.commit == leading_candidate,
+                "Clearing the native highlight did not restore leading-candidate commit.");
+
+        metasequoia::mac::InputSession stale_selection_session;
+        type(stale_selection_session, "nihao");
+        const std::string stale_fallback_candidate = stale_selection_session.candidates().front().word;
+        candidate_selection.begin_navigation();
+        candidate_selection.update("candidate-from-an-old-composition");
+        const auto stale_fallback = candidate_selection.commit(stale_selection_session);
+        require(stale_fallback.handled && stale_fallback.commit == stale_fallback_candidate,
+                "A stale native highlight did not fall back to the leading candidate.");
 
         type(session, "nihao");
         const auto out_of_range_digit = session.handle_candidate_key('9');


### PR DESCRIPTION
## Summary

- Track native candidate selection changes after explicit arrow or page navigation.
- Make Space commit the highlighted candidate while preserving the existing leading-candidate behavior when no navigation occurred.
- Reset selection state across candidate refreshes and commits, ignore unsolicited selection callbacks, and safely fall back when a saved candidate is stale.

## Verify

- Independent review: no Critical, Important, or Minor findings remain.
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 120` — 9/9 passed.
- Installed locally and verified with Orca Computer in TextEdit:
  - with `shi` candidates ordered `是`, `时`, `事`, Right then Space committed `时`;
  - direct Space still committed the current leading candidate;
  - the armed selection gate continued to select the second candidate after reinstall.
