### PR TITLE
fix(input): map candidate numbers to the visible page

### DIFF
--- a/src/CandidateSelectionState.h
+++ b/src/CandidateSelectionState.h
@@ -2,6 +2,7 @@
 
 #include "InputSession.h"
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <utility>
@@ -11,17 +12,19 @@ namespace metasequoia::mac
 class CandidateSelectionState
 {
   public:
+    static constexpr size_t candidates_per_page = 9;
+
     void begin_navigation()
     {
         accepts_selection_changes_ = true;
         selected_candidate_.reset();
     }
 
-    void update(std::string candidate)
+    void update(size_t candidate_index, std::string candidate)
     {
         if (accepts_selection_changes_)
         {
-            selected_candidate_ = std::move(candidate);
+            selected_candidate_ = Selection{candidate_index, std::move(candidate)};
         }
     }
 
@@ -35,17 +38,46 @@ class CandidateSelectionState
     {
         if (selected_candidate_.has_value())
         {
-            const KeyResult selected = session.select_candidate(*selected_candidate_);
-            if (selected.handled)
+            const auto &candidates = session.candidates();
+            if (selected_candidate_->index < candidates.size()
+                && candidates[selected_candidate_->index].word == selected_candidate_->word)
             {
-                return selected;
+                const KeyResult selected = session.select_candidate(selected_candidate_->index);
+                if (selected.handled)
+                {
+                    return selected;
+                }
             }
         }
         return session.handle_command(Command::CommitCandidate);
     }
 
+    KeyResult commit_number(InputSession &session, char character) const
+    {
+        if (character < '1' || character > '9')
+        {
+            return {};
+        }
+
+        const auto &candidates = session.candidates();
+        if (!selected_candidate_.has_value() || selected_candidate_->index >= candidates.size()
+            || candidates[selected_candidate_->index].word != selected_candidate_->word)
+        {
+            return session.handle_candidate_key(character);
+        }
+
+        const size_t pageStart = selected_candidate_->index / candidates_per_page * candidates_per_page;
+        return session.select_candidate(pageStart + static_cast<size_t>(character - '1'));
+    }
+
   private:
+    struct Selection
+    {
+        size_t index;
+        std::string word;
+    };
+
     bool accepts_selection_changes_ = false;
-    std::optional<std::string> selected_candidate_;
+    std::optional<Selection> selected_candidate_;
 };
 } // namespace metasequoia::mac

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -173,7 +173,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
             }
             else if (character >= '1' && character <= '9')
             {
-                result = _session->handle_candidate_key(static_cast<char>(character));
+                result = _candidateSelection.commit_number(*_session, static_cast<char>(character));
                 if (!result.handled && _session->has_composition())
                 {
                     return YES;
@@ -259,9 +259,19 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 - (void)candidateSelectionChanged:(NSAttributedString *)candidateString
 {
     const char *utf8 = candidateString.string.UTF8String;
-    if (utf8 != nullptr)
+    const NSInteger selectedIdentifier = [_candidatePanel selectedCandidate];
+    if (utf8 == nullptr || selectedIdentifier == NSNotFound)
     {
-        _candidateSelection.update(utf8);
+        return;
+    }
+
+    for (NSUInteger index = 0; index < _candidateData.count; ++index)
+    {
+        if ([_candidatePanel candidateStringIdentifier:_candidateData[index]] == selectedIdentifier)
+        {
+            _candidateSelection.update(static_cast<size_t>(index), utf8);
+            return;
+        }
     }
 }
 

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -146,7 +146,7 @@ int main()
         metasequoia::mac::InputSession unarmed_selection_session;
         type(unarmed_selection_session, "nihao");
         const std::string initial_leading_candidate = unarmed_selection_session.candidates().front().word;
-        candidate_selection.update(unarmed_selection_session.candidates()[1].word);
+        candidate_selection.update(1, unarmed_selection_session.candidates()[1].word);
         const auto initial_selection = candidate_selection.commit(unarmed_selection_session);
         require(initial_selection.handled && initial_selection.commit == initial_leading_candidate,
                 "An unsolicited candidate selection callback replaced the leading candidate.");
@@ -155,7 +155,7 @@ int main()
         type(highlighted_session, "nihao");
         const std::string highlighted_candidate = highlighted_session.candidates()[1].word;
         candidate_selection.begin_navigation();
-        candidate_selection.update(highlighted_candidate);
+        candidate_selection.update(1, highlighted_candidate);
         const auto highlighted = candidate_selection.commit(highlighted_session);
         require(highlighted.handled && highlighted.commit == highlighted_candidate,
                 "Space did not commit the candidate highlighted by the native panel.");
@@ -164,7 +164,7 @@ int main()
         type(leading_session, "nihao");
         const std::string leading_candidate = leading_session.candidates().front().word;
         candidate_selection.begin_navigation();
-        candidate_selection.update(leading_session.candidates()[1].word);
+        candidate_selection.update(1, leading_session.candidates()[1].word);
         candidate_selection.reset();
         const auto leading = candidate_selection.commit(leading_session);
         require(leading.handled && leading.commit == leading_candidate,
@@ -174,7 +174,7 @@ int main()
         type(stale_selection_session, "nihao");
         const std::string stale_fallback_candidate = stale_selection_session.candidates().front().word;
         candidate_selection.begin_navigation();
-        candidate_selection.update("candidate-from-an-old-composition");
+        candidate_selection.update(1, "candidate-from-an-old-composition");
         const auto stale_fallback = candidate_selection.commit(stale_selection_session);
         require(stale_fallback.handled && stale_fallback.commit == stale_fallback_candidate,
                 "A stale native highlight did not fall back to the leading candidate.");
@@ -199,6 +199,47 @@ int main()
 
         const auto idle_backspace = session.handle_command(metasequoia::mac::Command::Backspace);
         require(!idle_backspace.handled, "Backspace was swallowed while no composition was active.");
+
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选三', 90)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选四', 80)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选五', 70)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选六', 60)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选七', 50)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选八', 40)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选九', 30)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选十', 20)");
+        database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '候选十一', 10)");
+
+        metasequoia::mac::InputSession paged_session;
+        type(paged_session, "nihao");
+        require(paged_session.candidates().size() >= 11, "The paging test dictionary did not return enough candidates.");
+        const std::string first_candidate_on_second_page = paged_session.candidates()[9].word;
+        candidate_selection.begin_navigation();
+        candidate_selection.update(9, first_candidate_on_second_page);
+        const auto out_of_range_page_digit = candidate_selection.commit_number(paged_session, '9');
+        require(!out_of_range_page_digit.handled && paged_session.has_composition(),
+                "An unavailable number on the current candidate page changed composition.");
+        const auto page_digit = candidate_selection.commit_number(paged_session, '1');
+        require(page_digit.handled && page_digit.commit == first_candidate_on_second_page,
+                "The 1 key did not commit the first candidate on the visible page.");
+
+        metasequoia::mac::InputSession middle_of_page_session;
+        type(middle_of_page_session, "nihao");
+        const std::string first_candidate_from_middle = middle_of_page_session.candidates()[9].word;
+        candidate_selection.begin_navigation();
+        candidate_selection.update(10, middle_of_page_session.candidates()[10].word);
+        const auto middle_page_digit = candidate_selection.commit_number(middle_of_page_session, '1');
+        require(middle_page_digit.handled && middle_page_digit.commit == first_candidate_from_middle,
+                "A highlight in the middle of a page did not preserve that page for number selection.");
+
+        metasequoia::mac::InputSession stale_page_session;
+        type(stale_page_session, "nihao");
+        const std::string stale_page_fallback = stale_page_session.candidates().front().word;
+        candidate_selection.begin_navigation();
+        candidate_selection.update(10, "candidate-from-an-old-composition");
+        const auto stale_page_digit = candidate_selection.commit_number(stale_page_session, '1');
+        require(stale_page_digit.handled && stale_page_digit.commit == stale_page_fallback,
+                "A stale page highlight did not fall back to the first candidate page.");
     }
 
     std::filesystem::remove_all(data_directory);


### PR DESCRIPTION
## Summary

- map number keys to the currently visible native candidate page
- track the highlighted candidate by its IMK identifier-derived absolute index
- validate the index and word before committing, with safe first-page fallback for stale callbacks
- cover second-page selection, middle-of-page anchors, unavailable digits, and stale state

## Verification

- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 120` (9/9 passed)
- Orca Computer: reproduced the existing bug where `shi` → Page Down → `1` committed the global first candidate
- Orca Computer: verified the page-relative implementation with Page Down → `1`, Page Down → `2`, and Page Down → Page Up → `1`
- independent review: no Critical or Important findings
