### PR TITLE
fix(settings): apply preferences on the next input

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion; these choices are saved for the current user and apply on the next input-method activation. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
 
 ## Development tests
 

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -12,6 +12,8 @@
 
 namespace
 {
+constexpr NSTimeInterval kDictionaryRetryDelay = 2.0;
+
 NSString *StringFromUtf8(const std::string &value)
 {
     return [[NSString alloc] initWithBytes:value.data() length:value.size() encoding:NSUTF8StringEncoding];
@@ -51,6 +53,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     metasequoia::mac::CandidateSelectionState _candidateSelection;
     IMKCandidates *_candidatePanel;
     NSArray *_candidateData;
+    NSTimeInterval _dictionaryRetryAfter;
 }
 
 - (instancetype)initWithServer:(IMKServer *)server delegate:(id)delegate client:(id)inputClient
@@ -61,54 +64,80 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
         _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
         [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @YES}];
 
-        NSError *error = nil;
-        if (!EnsureMetasequoiaDictionary(&error))
-        {
-            NSLog(@"Failed to prepare the Metasequoia dictionary: %@", error.localizedDescription);
-            return self;
-        }
-        [self reloadSessionFromPreferences];
+        [self prepareSessionIfNeeded];
     }
     return self;
 }
 
 - (void)reloadSessionFromPreferences
 {
+    if (_session != nullptr && _session->has_composition())
+    {
+        return;
+    }
+
     const SessionPreferences preferences = ReadSessionPreferences();
-    if (_session != nullptr &&
-        (_session->has_composition() || SessionMatchesPreferences(*_session, preferences)))
+    if (_session != nullptr && SessionMatchesPreferences(*_session, preferences))
     {
         return;
     }
     _session = std::make_unique<metasequoia::mac::InputSession>(
         preferences.scheme, preferences.autocorrectEnabled, preferences.helpcodeEnabled,
         preferences.chinesePunctuationEnabled);
+    _candidateSelection.reset();
     _candidateData = @[];
     [_candidatePanel setCandidateData:_candidateData];
+    [_candidatePanel hide];
+}
+
+- (BOOL)prepareSessionIfNeeded
+{
+    if (_session != nullptr)
+    {
+        return YES;
+    }
+
+    const NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    if (now < _dictionaryRetryAfter)
+    {
+        return NO;
+    }
+
+    NSError *error = nil;
+    if (!EnsureMetasequoiaDictionary(&error))
+    {
+        _dictionaryRetryAfter = now + kDictionaryRetryDelay;
+        NSLog(@"Failed to prepare the Metasequoia dictionary: %@", error.localizedDescription);
+        return NO;
+    }
+
+    _dictionaryRetryAfter = 0.0;
+    [self reloadSessionFromPreferences];
+    return _session != nullptr;
 }
 
 - (void)activateServer:(id)sender
 {
     [super activateServer:sender];
-    if (_session == nullptr)
+    _dictionaryRetryAfter = 0.0;
+    if ([self prepareSessionIfNeeded])
     {
-        NSError *error = nil;
-        if (!EnsureMetasequoiaDictionary(&error))
-        {
-            NSLog(@"Failed to prepare the Metasequoia dictionary: %@", error.localizedDescription);
-            return;
-        }
+        [self reloadSessionFromPreferences];
     }
-    [self reloadSessionFromPreferences];
 }
 
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender
 {
-    if (event.type != NSEventTypeKeyDown || _session == nullptr)
+    if (event.type != NSEventTypeKeyDown)
+    {
+        return NO;
+    }
+    if (![self prepareSessionIfNeeded])
     {
         return NO;
     }
 
+    [self reloadSessionFromPreferences];
     const NSEventModifierFlags modifiers = event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
     if ((modifiers & (NSEventModifierFlagCommand | NSEventModifierFlagControl | NSEventModifierFlagOption)) != 0)
     {

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -225,7 +225,7 @@ NSString * const kChinesePunctuationPreferenceKey = @"MetasequoiaImeChinesePunct
     NSError *error = nil;
     if (EnsureMetasequoiaDictionary(&error))
     {
-        _statusLabel.stringValue = @"词库已就绪；设置将在下次激活时生效。";
+        _statusLabel.stringValue = @"词库已就绪；设置将在当前输入结束后的下一次按键生效。";
         _statusLabel.textColor = [NSColor secondaryLabelColor];
         _statusLabel.toolTip = nil;
         return;

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -95,16 +95,38 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("refreshDictionaryStatus", preferences_controller)
         self.assertIn("EnsureMetasequoiaDictionary", preferences_controller)
         self.assertIn("词库已就绪", preferences_controller)
+        self.assertIn("当前输入结束后的下一次按键生效", preferences_controller)
         self.assertIn("词库不可用，请重新安装水杉输入法", preferences_controller)
         input_controller = (PROJECT_ROOT / "src/MetasequoiaInputController.mm").read_text()
         self.assertIn("reloadSessionFromPreferences", input_controller)
+        self.assertIn("prepareSessionIfNeeded", input_controller)
+        self.assertIn("kDictionaryRetryDelay", input_controller)
         self.assertIn("- (void)activateServer:(id)sender", input_controller)
+        handle_event = input_controller.split("- (BOOL)handleEvent:(NSEvent *)event client:(id)sender", 1)[1].split(
+            "- (void)commitLeadingCandidate:(id)sender", 1
+        )[0]
+        self.assertIn("[self prepareSessionIfNeeded]", handle_event)
+        self.assertIn("[self reloadSessionFromPreferences];", handle_event)
+        self.assertLess(
+            handle_event.index("[self prepareSessionIfNeeded]"),
+            handle_event.index("[self reloadSessionFromPreferences];"),
+        )
+        self.assertLess(
+            handle_event.index("[self reloadSessionFromPreferences];"),
+            handle_event.index("const NSEventModifierFlags modifiers"),
+        )
+        reload_session = input_controller.split("- (void)reloadSessionFromPreferences", 1)[1].split(
+            "- (BOOL)prepareSessionIfNeeded", 1
+        )[0]
+        self.assertLess(reload_session.index("_session->has_composition()"), reload_session.index("ReadSessionPreferences()"))
+        self.assertIn("_candidateSelection.reset();", reload_session)
+        self.assertIn("[_candidatePanel hide];", reload_session)
         controller_initialization = input_controller.split("- (instancetype)initWithServer:", 1)[1].split(
             "- (void)reloadSessionFromPreferences", 1
         )[0]
         self.assertLess(
             controller_initialization.index("_candidatePanel ="),
-            controller_initialization.index("EnsureMetasequoiaDictionary"),
+            controller_initialization.index("prepareSessionIfNeeded"),
         )
         self.assertIn("NSString *characters = event.characters;", input_controller)
         self.assertNotIn("charactersIgnoringModifiers", input_controller)
@@ -113,7 +135,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         )[0]
         self.assertIn("commitLeadingCandidate", commit_composition)
         self.assertNotIn("Command::CommitRaw", commit_composition)
-        self.assertIn("next input-method activation", readme)
+        self.assertIn("next key event when no composition is active", readme)
 
         release_installer = (PROJECT_ROOT / "scripts/install-release.sh").read_text()
         self.assertNotIn("xcrun", release_installer)


### PR DESCRIPTION
## Summary

- reload saved settings before the next key event when the session is idle
- preserve the current configuration while a composition is active
- recover automatically when the dictionary becomes available after an initial startup failure
- rate-limit failed dictionary preparation retries to avoid expensive work on every key
- reset stale candidate UI state when rebuilding a session and clarify settings copy

## Verification

- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 120` (9/9 passed)
- confirmed the macOS Keyboard settings accessibility tree exposes the Text Input editor; protected System Settings actions were not bypassed
- independent review: no Critical or Important findings
