### PR TITLE
feat(settings): configure candidate page size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, switch the native candidate window between a horizontal row and vertical list, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, switch the native candidate window between a horizontal row and vertical list, show 5, 7, or 9 candidates per page, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
 
 ## Development tests
 

--- a/src/CandidatePageSize.h
+++ b/src/CandidatePageSize.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+
+namespace metasequoia::mac
+{
+constexpr size_t NormalizeCandidatePageSize(size_t value)
+{
+    return value == 5 || value == 7 || value == 9 ? value : 9;
+}
+
+constexpr size_t CandidatePageSizeForOptionIndex(size_t index)
+{
+    return index == 0 ? 5 : index == 1 ? 7 : 9;
+}
+
+constexpr size_t CandidatePageSizeOptionIndex(size_t pageSize)
+{
+    pageSize = NormalizeCandidatePageSize(pageSize);
+    return pageSize == 5 ? 0 : pageSize == 7 ? 1 : 2;
+}
+} // namespace metasequoia::mac
+
+#ifdef __OBJC__
+#import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
+
+namespace metasequoia::mac
+{
+inline NSArray<NSNumber *> *CandidateSelectionKeys(size_t pageSize)
+{
+    NSArray<NSNumber *> *allKeys = @[
+        @(kVK_ANSI_1), @(kVK_ANSI_2), @(kVK_ANSI_3), @(kVK_ANSI_4), @(kVK_ANSI_5),
+        @(kVK_ANSI_6), @(kVK_ANSI_7), @(kVK_ANSI_8), @(kVK_ANSI_9),
+    ];
+    return [allKeys subarrayWithRange:NSMakeRange(0, NormalizeCandidatePageSize(pageSize))];
+}
+} // namespace metasequoia::mac
+#endif

--- a/src/CandidateSelectionState.h
+++ b/src/CandidateSelectionState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CandidatePageSize.h"
 #include "InputSession.h"
 
 #include <cstddef>
@@ -52,9 +53,16 @@ class CandidateSelectionState
         return session.handle_command(Command::CommitCandidate);
     }
 
-    KeyResult commit_number(InputSession &session, char character) const
+    KeyResult commit_number(InputSession &session, char character, size_t pageSize = candidates_per_page) const
     {
         if (character < '1' || character > '9')
+        {
+            return {};
+        }
+
+        pageSize = NormalizeCandidatePageSize(pageSize);
+        const size_t candidateOffset = static_cast<size_t>(character - '1');
+        if (candidateOffset >= pageSize)
         {
             return {};
         }
@@ -66,8 +74,8 @@ class CandidateSelectionState
             return session.handle_candidate_key(character);
         }
 
-        const size_t pageStart = selected_candidate_->index / candidates_per_page * candidates_per_page;
-        return session.select_candidate(pageStart + static_cast<size_t>(character - '1'));
+        const size_t pageStart = selected_candidate_->index / pageSize * pageSize;
+        return session.select_candidate(pageStart + candidateOffset);
     }
 
   private:

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -1,6 +1,7 @@
 #import "MetasequoiaInputController.h"
 
 #import "DictionaryInstaller.h"
+#include "CandidatePageSize.h"
 #include "CandidatePanelStyle.h"
 #import "InputMenu.h"
 #import "PreferencesWindowController.h"
@@ -28,6 +29,7 @@ struct SessionPreferences
     bool helpcodeEnabled;
     bool chinesePunctuationEnabled;
     metasequoia::mac::CandidatePanelStyle candidatePanelStyle;
+    size_t candidatePageSize;
 };
 
 SessionPreferences ReadSessionPreferences()
@@ -40,6 +42,8 @@ SessionPreferences ReadSessionPreferences()
         [MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled] == YES,
         metasequoia::mac::NormalizeCandidatePanelStyle(
             [MetasequoiaPreferencesWindowController storedCandidatePanelStyle]),
+        metasequoia::mac::NormalizeCandidatePageSize(
+            static_cast<size_t>([MetasequoiaPreferencesWindowController storedCandidatePageSize])),
     };
 }
 
@@ -86,6 +90,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 
     const SessionPreferences preferences = ReadSessionPreferences();
     [_candidatePanel setPanelType:metasequoia::mac::CandidatePanelTypeForStyle(preferences.candidatePanelStyle)];
+    [_candidatePanel setSelectionKeys:metasequoia::mac::CandidateSelectionKeys(preferences.candidatePageSize)];
     if (_session != nullptr && SessionMatchesPreferences(*_session, preferences))
     {
         return;
@@ -347,7 +352,8 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
             }
             else if (character >= '1' && character <= '9')
             {
-                result = _candidateSelection.commit_number(*_session, static_cast<char>(character));
+                result = _candidateSelection.commit_number(
+                    *_session, static_cast<char>(character), _candidatePanel.selectionKeys.count);
                 if (!result.handled && _session->has_composition())
                 {
                     return YES;

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -14,5 +14,7 @@
 + (void)setChinesePunctuationEnabled:(BOOL)enabled;
 + (NSInteger)storedCandidatePanelStyle;
 + (void)setCandidatePanelStyle:(NSInteger)style;
++ (NSInteger)storedCandidatePageSize;
++ (void)setCandidatePageSize:(NSInteger)pageSize;
 - (void)showAndActivate;
 @end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -1,17 +1,19 @@
 #import "PreferencesWindowController.h"
 
+#include "CandidatePageSize.h"
 #include "CandidatePanelStyle.h"
 #import "DictionaryInstaller.h"
 
 namespace
 {
 constexpr CGFloat kWindowWidth = 600.0;
-constexpr CGFloat kWindowHeight = 504.0;
+constexpr CGFloat kWindowHeight = 540.0;
 NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
 NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect";
 NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
 NSString * const kChinesePunctuationPreferenceKey = @"MetasequoiaImeChinesePunctuation";
 NSString * const kCandidatePanelStylePreferenceKey = @"MetasequoiaImeCandidatePanelStyle";
+NSString * const kCandidatePageSizePreferenceKey = @"MetasequoiaImeCandidatePageSize";
 
 NSColor *MetasequoiaBrandColor()
 {
@@ -44,6 +46,7 @@ void ConfigureCard(NSBox *card)
     NSButton *_helpcodeButton;
     NSButton *_chinesePunctuationButton;
     NSPopUpButton *_candidatePanelStyleButton;
+    NSPopUpButton *_candidatePageSizeButton;
     NSTextField *_statusLabel;
 }
 
@@ -123,6 +126,21 @@ void ConfigureCard(NSBox *card)
     [[NSUserDefaults standardUserDefaults] setInteger:normalizedStyle forKey:kCandidatePanelStylePreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaCandidatePanelStyleDidChangeNotification"
                                                         object:@(normalizedStyle)];
+}
+
++ (NSInteger)storedCandidatePageSize
+{
+    const NSInteger value = [[NSUserDefaults standardUserDefaults] integerForKey:kCandidatePageSizePreferenceKey];
+    return static_cast<NSInteger>(metasequoia::mac::NormalizeCandidatePageSize(static_cast<size_t>(value)));
+}
+
++ (void)setCandidatePageSize:(NSInteger)pageSize
+{
+    const NSInteger normalizedPageSize = static_cast<NSInteger>(
+        metasequoia::mac::NormalizeCandidatePageSize(static_cast<size_t>(pageSize)));
+    [[NSUserDefaults standardUserDefaults] setInteger:normalizedPageSize forKey:kCandidatePageSizePreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaCandidatePageSizeDidChangeNotification"
+                                                        object:@(normalizedPageSize)];
 }
 
 - (instancetype)initWithWindowNibName:(NSNibName)windowNibName owner:(id)owner
@@ -238,6 +256,17 @@ void ConfigureCard(NSBox *card)
     _candidatePanelStyleButton.accessibilityLabel = @"候选排列";
     _candidatePanelStyleButton.translatesAutoresizingMaskIntoConstraints = NO;
 
+    NSTextField *candidatePageSizeLabel = [NSTextField labelWithString:@"每页候选"];
+    candidatePageSizeLabel.font = [NSFont systemFontOfSize:13.0 weight:NSFontWeightMedium];
+    candidatePageSizeLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+    _candidatePageSizeButton = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
+    [_candidatePageSizeButton addItemsWithTitles:@[@"5 个", @"7 个", @"9 个"]];
+    _candidatePageSizeButton.target = self;
+    _candidatePageSizeButton.action = @selector(candidatePageSizeChanged:);
+    _candidatePageSizeButton.accessibilityLabel = @"每页候选";
+    _candidatePageSizeButton.translatesAutoresizingMaskIntoConstraints = NO;
+
     NSTextField *behaviorSectionLabel = [NSTextField labelWithString:@"输入行为"];
     behaviorSectionLabel.font = [NSFont systemFontOfSize:11.0 weight:NSFontWeightSemibold];
     behaviorSectionLabel.textColor = [NSColor secondaryLabelColor];
@@ -290,6 +319,8 @@ void ConfigureCard(NSBox *card)
     [inputCard addSubview:_schemeButton];
     [inputCard addSubview:candidatePanelStyleLabel];
     [inputCard addSubview:_candidatePanelStyleButton];
+    [inputCard addSubview:candidatePageSizeLabel];
+    [inputCard addSubview:_candidatePageSizeButton];
     [settingsPanel addSubview:behaviorSectionLabel];
     [settingsPanel addSubview:behaviorCard];
     [behaviorCard addSubview:_autocorrectButton];
@@ -333,17 +364,22 @@ void ConfigureCard(NSBox *card)
         [inputCard.topAnchor constraintEqualToAnchor:inputSectionLabel.bottomAnchor constant:8.0],
         [inputCard.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [inputCard.trailingAnchor constraintEqualToAnchor:settingsPanel.trailingAnchor constant:-28.0],
-        [inputCard.heightAnchor constraintEqualToConstant:112.0],
+        [inputCard.heightAnchor constraintEqualToConstant:148.0],
         [schemeLabel.leadingAnchor constraintEqualToAnchor:inputCard.leadingAnchor constant:18.0],
         [schemeLabel.topAnchor constraintEqualToAnchor:inputCard.topAnchor constant:18.0],
         [_schemeButton.centerYAnchor constraintEqualToAnchor:schemeLabel.centerYAnchor],
         [_schemeButton.trailingAnchor constraintEqualToAnchor:inputCard.trailingAnchor constant:-16.0],
         [_schemeButton.widthAnchor constraintEqualToConstant:180.0],
         [candidatePanelStyleLabel.leadingAnchor constraintEqualToAnchor:schemeLabel.leadingAnchor],
-        [candidatePanelStyleLabel.bottomAnchor constraintEqualToAnchor:inputCard.bottomAnchor constant:-18.0],
+        [candidatePanelStyleLabel.topAnchor constraintEqualToAnchor:schemeLabel.topAnchor constant:48.0],
         [_candidatePanelStyleButton.centerYAnchor constraintEqualToAnchor:candidatePanelStyleLabel.centerYAnchor],
         [_candidatePanelStyleButton.trailingAnchor constraintEqualToAnchor:_schemeButton.trailingAnchor],
         [_candidatePanelStyleButton.widthAnchor constraintEqualToAnchor:_schemeButton.widthAnchor],
+        [candidatePageSizeLabel.leadingAnchor constraintEqualToAnchor:schemeLabel.leadingAnchor],
+        [candidatePageSizeLabel.topAnchor constraintEqualToAnchor:candidatePanelStyleLabel.topAnchor constant:48.0],
+        [_candidatePageSizeButton.centerYAnchor constraintEqualToAnchor:candidatePageSizeLabel.centerYAnchor],
+        [_candidatePageSizeButton.trailingAnchor constraintEqualToAnchor:_schemeButton.trailingAnchor],
+        [_candidatePageSizeButton.widthAnchor constraintEqualToAnchor:_schemeButton.widthAnchor],
         [behaviorSectionLabel.topAnchor constraintEqualToAnchor:inputCard.bottomAnchor constant:18.0],
         [behaviorSectionLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [behaviorCard.topAnchor constraintEqualToAnchor:behaviorSectionLabel.bottomAnchor constant:8.0],
@@ -377,6 +413,8 @@ void ConfigureCard(NSBox *card)
     _helpcodeButton.state = [MetasequoiaPreferencesWindowController storedHelpcodeEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
     _chinesePunctuationButton.state = [MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
     [_candidatePanelStyleButton selectItemAtIndex:[MetasequoiaPreferencesWindowController storedCandidatePanelStyle]];
+    [_candidatePageSizeButton selectItemAtIndex:static_cast<NSInteger>(metasequoia::mac::CandidatePageSizeOptionIndex(
+                                                        static_cast<size_t>([MetasequoiaPreferencesWindowController storedCandidatePageSize])))];
 }
 
 - (void)refreshDictionaryStatus
@@ -435,6 +473,14 @@ void ConfigureCard(NSBox *card)
     [MetasequoiaPreferencesWindowController setCandidatePanelStyle:styleButton.indexOfSelectedItem];
 }
 
+- (void)candidatePageSizeChanged:(id)sender
+{
+    NSPopUpButton *pageSizeButton = (NSPopUpButton *)sender;
+    const size_t pageSize =
+        metasequoia::mac::CandidatePageSizeForOptionIndex(static_cast<size_t>(pageSizeButton.indexOfSelectedItem));
+    [MetasequoiaPreferencesWindowController setCandidatePageSize:static_cast<NSInteger>(pageSize)];
+}
+
 - (void)restoreDefaults:(id)sender
 {
     (void)sender;
@@ -443,6 +489,7 @@ void ConfigureCard(NSBox *card)
     [MetasequoiaPreferencesWindowController setHelpcodeEnabled:YES];
     [MetasequoiaPreferencesWindowController setChinesePunctuationEnabled:YES];
     [MetasequoiaPreferencesWindowController setCandidatePanelStyle:0];
+    [MetasequoiaPreferencesWindowController setCandidatePageSize:9];
     [self refreshControls];
 }
 

--- a/tests/InputControllerKeyRoutingTests.mm
+++ b/tests/InputControllerKeyRoutingTests.mm
@@ -1,5 +1,6 @@
 #include "../src/InputControllerKeyRouting.h"
 #include "../src/CandidatePanelStyle.h"
+#include "../src/CandidatePageSize.h"
 
 #import <InputMethodKit/InputMethodKit.h>
 
@@ -27,8 +28,12 @@ int main()
     using metasequoia::mac::CandidatePageStart;
     using metasequoia::mac::CandidatePanelStyle;
     using metasequoia::mac::CandidatePanelTypeForStyle;
+    using metasequoia::mac::CandidatePageSizeForOptionIndex;
+    using metasequoia::mac::CandidatePageSizeOptionIndex;
+    using metasequoia::mac::CandidateSelectionKeys;
     using metasequoia::mac::ClassifyControllerKey;
     using metasequoia::mac::IsPrimaryCandidateDirection;
+    using metasequoia::mac::NormalizeCandidatePageSize;
     using metasequoia::mac::NormalizeCandidatePanelStyle;
 
     require(NormalizeCandidatePanelStyle(0) == CandidatePanelStyle::Horizontal &&
@@ -48,6 +53,22 @@ int main()
                 IsPrimaryCandidateDirection(kVK_UpArrow, kIMKSingleColumnScrollingCandidatePanel) &&
                 IsPrimaryCandidateDirection(kVK_DownArrow, kIMKSingleColumnScrollingCandidatePanel),
             "The vertical candidate panel did not restrict navigation to its primary axis.");
+    require(NormalizeCandidatePageSize(5) == 5 && NormalizeCandidatePageSize(7) == 7 &&
+                NormalizeCandidatePageSize(9) == 9 && NormalizeCandidatePageSize(0) == 9 &&
+                NormalizeCandidatePageSize(99) == 9,
+            "The stored candidate page size was not normalized safely.");
+    require(CandidatePageSizeForOptionIndex(0) == 5 && CandidatePageSizeForOptionIndex(1) == 7 &&
+                CandidatePageSizeForOptionIndex(2) == 9 && CandidatePageSizeForOptionIndex(99) == 9 &&
+                CandidatePageSizeOptionIndex(5) == 0 && CandidatePageSizeOptionIndex(7) == 1 &&
+                CandidatePageSizeOptionIndex(9) == 2,
+            "The candidate page-size options did not map to persisted values.");
+    NSArray<NSNumber *> *fiveSelectionKeys = CandidateSelectionKeys(5);
+    NSArray<NSNumber *> *nineSelectionKeys = CandidateSelectionKeys(9);
+    require(fiveSelectionKeys.count == 5 && nineSelectionKeys.count == 9 &&
+                fiveSelectionKeys.firstObject.unsignedShortValue == kVK_ANSI_1 &&
+                fiveSelectionKeys.lastObject.unsignedShortValue == kVK_ANSI_5 &&
+                nineSelectionKeys.lastObject.unsignedShortValue == kVK_ANSI_9,
+            "The candidate page size did not produce the expected number-key mappings.");
 
     require(ClassifyControllerKey(kVK_Return, true) == ControllerKeyAction::CommitRaw,
             "Return did not remain a raw commit while candidates were visible.");

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -223,6 +223,23 @@ int main()
         require(page_digit.handled && page_digit.commit == first_candidate_on_second_page,
                 "The 1 key did not commit the first candidate on the visible page.");
 
+        metasequoia::mac::InputSession compact_page_session;
+        type(compact_page_session, "nihao");
+        const std::string compact_page_candidate = compact_page_session.candidates()[5].word;
+        candidate_selection.begin_navigation();
+        candidate_selection.update(5, compact_page_candidate);
+        const auto compact_page_digit = candidate_selection.commit_number(compact_page_session, '1', 5);
+        require(compact_page_digit.handled && compact_page_digit.commit == compact_page_candidate,
+                "The 1 key did not use the configured five-candidate page boundary.");
+
+        metasequoia::mac::InputSession hidden_compact_candidate_session;
+        type(hidden_compact_candidate_session, "nihao");
+        candidate_selection.reset();
+        const auto hidden_compact_candidate =
+            candidate_selection.commit_number(hidden_compact_candidate_session, '6', 5);
+        require(!hidden_compact_candidate.handled && hidden_compact_candidate_session.has_composition(),
+                "A number key selected a candidate hidden by the configured page size.");
+
         metasequoia::mac::InputSession middle_of_page_session;
         type(middle_of_page_session, "nihao");
         const std::string first_candidate_from_middle = middle_of_page_session.candidates()[9].word;

--- a/tests/PreferencesWindowTests.mm
+++ b/tests/PreferencesWindowTests.mm
@@ -42,8 +42,11 @@ int main()
     {
         [NSApplication sharedApplication];
         [MetasequoiaPreferencesWindowController setCandidatePanelStyle:1];
+        [MetasequoiaPreferencesWindowController setCandidatePageSize:5];
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 1,
                 "The vertical candidate layout preference was not stored.");
+        require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 5,
+                "The five-candidate page-size preference was not stored.");
 
         MetasequoiaPreferencesWindowController *controller =
             [[MetasequoiaPreferencesWindowController alloc] init];
@@ -59,16 +62,36 @@ int main()
         require(styleButton.indexOfSelectedItem == 1,
                 "The candidate layout control did not reflect the stored vertical layout.");
 
+        NSView *pageSizeView = FindViewWithAccessibilityLabel(controller.window.contentView, @"每页候选");
+        require([pageSizeView isKindOfClass:[NSPopUpButton class]],
+                "The settings window did not expose the candidate page-size control.");
+        NSPopUpButton *pageSizeButton = (NSPopUpButton *)pageSizeView;
+        require(pageSizeButton.numberOfItems == 3 &&
+                    [[pageSizeButton itemTitleAtIndex:0] isEqualToString:@"5 个"] &&
+                    [[pageSizeButton itemTitleAtIndex:1] isEqualToString:@"7 个"] &&
+                    [[pageSizeButton itemTitleAtIndex:2] isEqualToString:@"9 个"],
+                "The candidate page-size control did not contain all supported values.");
+        require(pageSizeButton.indexOfSelectedItem == 0,
+                "The candidate page-size control did not reflect the stored value.");
+
         [styleButton selectItemAtIndex:0];
         require([NSApp sendAction:styleButton.action to:styleButton.target from:styleButton],
                 "The candidate layout control did not dispatch its action.");
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 0,
                 "The candidate layout control did not store the selected horizontal layout.");
 
+        [pageSizeButton selectItemAtIndex:1];
+        require([NSApp sendAction:pageSizeButton.action to:pageSizeButton.target from:pageSizeButton],
+                "The candidate page-size control did not dispatch its action.");
+        require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 7,
+                "The candidate page-size control did not store the selected value.");
+
         [MetasequoiaPreferencesWindowController setCandidatePanelStyle:99];
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 0,
                 "An unsupported candidate layout preference was not normalized safely.");
-
+        [MetasequoiaPreferencesWindowController setCandidatePageSize:99];
+        require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 9,
+                "An unsupported candidate page size was not normalized safely.");
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a persisted 5/7/9 candidates-per-page option to the native settings panel
- configure InputMethodKit selection keys from that preference before the next composition
- calculate number-key selection from the active page size and reject numbers for hidden candidates
- extend settings, mapping, and real-engine candidate selection tests

## Verification
- `./scripts/build.sh` (11/11 tests passed)
- post-rebase full build and 11/11 tests passed
- code signature and designated requirement validated
- Orca accessibility verification: 600pt × 572pt settings window exposed `每页候选: 5 个`, retained all existing controls, and was on-screen without clipping
- independent review: no Critical/Important findings