### PR TITLE
feat(settings): control candidate learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, switch the native candidate window between a horizontal row and vertical list, show 5, 7, or 9 candidates per page, enable full-pinyin autocorrection and auxiliary codes, and switch Chinese punctuation conversion. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, switch the native candidate window between a horizontal row and vertical list, show 5, 7, or 9 candidates per page, enable full-pinyin autocorrection and auxiliary codes, switch Chinese punctuation conversion, and control whether selected candidates update learned word frequencies. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
 
 ## Development tests
 

--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -6,9 +6,9 @@
 namespace metasequoia::mac
 {
 InputSession::InputSession(SchemeType scheme_type, bool quanpin_autocorrect_enabled, bool helpcode_enabled,
-                           bool chinese_punctuation_enabled)
+                           bool chinese_punctuation_enabled, bool candidate_learning_enabled)
     : engine_(scheme_type), quanpin_autocorrect_enabled_(quanpin_autocorrect_enabled), helpcode_enabled_(helpcode_enabled),
-      chinese_punctuation_enabled_(chinese_punctuation_enabled)
+      chinese_punctuation_enabled_(chinese_punctuation_enabled), candidate_learning_enabled_(candidate_learning_enabled)
 {
     engine_.set_quanpin_autocorrect_enabled(quanpin_autocorrect_enabled_);
     engine_.set_quanpin_helpcode_enabled(helpcode_enabled_);
@@ -187,6 +187,11 @@ bool InputSession::chinese_punctuation_enabled() const
     return chinese_punctuation_enabled_;
 }
 
+bool InputSession::candidate_learning_enabled() const
+{
+    return candidate_learning_enabled_;
+}
+
 bool InputSession::has_composition() const
 {
     return !preedit().empty();
@@ -220,6 +225,10 @@ KeyResult InputSession::commit(size_t index)
 
 void InputSession::learn_candidate(const WordItem &candidate)
 {
+    if (!candidate_learning_enabled_)
+    {
+        return;
+    }
     if (candidate.source != CandidateSource::Database && candidate.source != CandidateSource::UserDatabase)
     {
         return;

--- a/src/InputSession.h
+++ b/src/InputSession.h
@@ -25,7 +25,8 @@ class InputSession
 {
   public:
     explicit InputSession(SchemeType scheme_type = SchemeType::Quanpin, bool quanpin_autocorrect_enabled = true,
-                          bool helpcode_enabled = true, bool chinese_punctuation_enabled = true);
+                          bool helpcode_enabled = true, bool chinese_punctuation_enabled = true,
+                          bool candidate_learning_enabled = true);
 
     KeyResult handle_character(char character);
     KeyResult handle_candidate_key(char character);
@@ -38,6 +39,7 @@ class InputSession
     bool quanpin_autocorrect_enabled() const;
     bool helpcode_enabled() const;
     bool chinese_punctuation_enabled() const;
+    bool candidate_learning_enabled() const;
     bool has_composition() const;
     const std::string &preedit() const;
     const std::vector<WordItem> &candidates() const;
@@ -50,6 +52,7 @@ class InputSession
     bool quanpin_autocorrect_enabled_ = true;
     bool helpcode_enabled_ = true;
     bool chinese_punctuation_enabled_ = true;
+    bool candidate_learning_enabled_ = true;
     bool next_double_quote_is_opening_ = true;
     bool next_single_quote_is_opening_ = true;
 };

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -30,6 +30,7 @@ struct SessionPreferences
     bool chinesePunctuationEnabled;
     metasequoia::mac::CandidatePanelStyle candidatePanelStyle;
     size_t candidatePageSize;
+    bool candidateLearningEnabled;
 };
 
 SessionPreferences ReadSessionPreferences()
@@ -44,6 +45,7 @@ SessionPreferences ReadSessionPreferences()
             [MetasequoiaPreferencesWindowController storedCandidatePanelStyle]),
         metasequoia::mac::NormalizeCandidatePageSize(
             static_cast<size_t>([MetasequoiaPreferencesWindowController storedCandidatePageSize])),
+        [MetasequoiaPreferencesWindowController storedCandidateLearningEnabled] == YES,
     };
 }
 
@@ -52,7 +54,8 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     return session.scheme_type() == preferences.scheme &&
            session.quanpin_autocorrect_enabled() == preferences.autocorrectEnabled &&
            session.helpcode_enabled() == preferences.helpcodeEnabled &&
-           session.chinese_punctuation_enabled() == preferences.chinesePunctuationEnabled;
+           session.chinese_punctuation_enabled() == preferences.chinesePunctuationEnabled &&
+           session.candidate_learning_enabled() == preferences.candidateLearningEnabled;
 }
 } // namespace
 
@@ -97,7 +100,7 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     }
     _session = std::make_unique<metasequoia::mac::InputSession>(
         preferences.scheme, preferences.autocorrectEnabled, preferences.helpcodeEnabled,
-        preferences.chinesePunctuationEnabled);
+        preferences.chinesePunctuationEnabled, preferences.candidateLearningEnabled);
     _candidateSelection.reset();
     _candidateHighlightedIndex = 0;
     _candidatePageStart = 0;

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -16,5 +16,7 @@
 + (void)setCandidatePanelStyle:(NSInteger)style;
 + (NSInteger)storedCandidatePageSize;
 + (void)setCandidatePageSize:(NSInteger)pageSize;
++ (BOOL)storedCandidateLearningEnabled;
++ (void)setCandidateLearningEnabled:(BOOL)enabled;
 - (void)showAndActivate;
 @end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -7,13 +7,14 @@
 namespace
 {
 constexpr CGFloat kWindowWidth = 600.0;
-constexpr CGFloat kWindowHeight = 540.0;
+constexpr CGFloat kWindowHeight = 572.0;
 NSString * const kSchemePreferenceKey = @"MetasequoiaImeInputScheme";
 NSString * const kAutocorrectPreferenceKey = @"MetasequoiaImeQuanpinAutocorrect";
 NSString * const kHelpcodePreferenceKey = @"MetasequoiaImeHelpcodeEnabled";
 NSString * const kChinesePunctuationPreferenceKey = @"MetasequoiaImeChinesePunctuation";
 NSString * const kCandidatePanelStylePreferenceKey = @"MetasequoiaImeCandidatePanelStyle";
 NSString * const kCandidatePageSizePreferenceKey = @"MetasequoiaImeCandidatePageSize";
+NSString * const kCandidateLearningPreferenceKey = @"MetasequoiaImeCandidateLearning";
 
 NSColor *MetasequoiaBrandColor()
 {
@@ -47,6 +48,7 @@ void ConfigureCard(NSBox *card)
     NSButton *_chinesePunctuationButton;
     NSPopUpButton *_candidatePanelStyleButton;
     NSPopUpButton *_candidatePageSizeButton;
+    NSButton *_candidateLearningButton;
     NSTextField *_statusLabel;
 }
 
@@ -141,6 +143,19 @@ void ConfigureCard(NSBox *card)
     [[NSUserDefaults standardUserDefaults] setInteger:normalizedPageSize forKey:kCandidatePageSizePreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaCandidatePageSizeDidChangeNotification"
                                                         object:@(normalizedPageSize)];
+}
+
++ (BOOL)storedCandidateLearningEnabled
+{
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kCandidateLearningPreferenceKey];
+    return value == nil ? YES : [value boolValue];
+}
+
++ (void)setCandidateLearningEnabled:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kCandidateLearningPreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaCandidateLearningDidChangeNotification"
+                                                        object:@(enabled)];
 }
 
 - (instancetype)initWithWindowNibName:(NSNibName)windowNibName owner:(id)owner
@@ -284,6 +299,9 @@ void ConfigureCard(NSBox *card)
     _chinesePunctuationButton = [NSButton checkboxWithTitle:@"使用中文标点" target:self action:@selector(chinesePunctuationChanged:)];
     _chinesePunctuationButton.translatesAutoresizingMaskIntoConstraints = NO;
 
+    _candidateLearningButton = [NSButton checkboxWithTitle:@"记住候选词频" target:self action:@selector(candidateLearningChanged:)];
+    _candidateLearningButton.translatesAutoresizingMaskIntoConstraints = NO;
+
     _statusLabel = [NSTextField labelWithString:@"检查词库状态…"];
     _statusLabel.accessibilityLabel = @"词库状态";
     _statusLabel.textColor = [NSColor secondaryLabelColor];
@@ -326,6 +344,7 @@ void ConfigureCard(NSBox *card)
     [behaviorCard addSubview:_autocorrectButton];
     [behaviorCard addSubview:_helpcodeButton];
     [behaviorCard addSubview:_chinesePunctuationButton];
+    [behaviorCard addSubview:_candidateLearningButton];
     [settingsPanel addSubview:_statusLabel];
     [settingsPanel addSubview:restoreButton];
     [settingsPanel addSubview:versionLabel];
@@ -385,13 +404,15 @@ void ConfigureCard(NSBox *card)
         [behaviorCard.topAnchor constraintEqualToAnchor:behaviorSectionLabel.bottomAnchor constant:8.0],
         [behaviorCard.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [behaviorCard.trailingAnchor constraintEqualToAnchor:settingsPanel.trailingAnchor constant:-28.0],
-        [behaviorCard.heightAnchor constraintEqualToConstant:116.0],
+        [behaviorCard.heightAnchor constraintEqualToConstant:148.0],
         [_autocorrectButton.leadingAnchor constraintEqualToAnchor:behaviorCard.leadingAnchor constant:18.0],
         [_autocorrectButton.topAnchor constraintEqualToAnchor:behaviorCard.topAnchor constant:16.0],
         [_helpcodeButton.leadingAnchor constraintEqualToAnchor:_autocorrectButton.leadingAnchor],
         [_helpcodeButton.topAnchor constraintEqualToAnchor:_autocorrectButton.bottomAnchor constant:12.0],
         [_chinesePunctuationButton.leadingAnchor constraintEqualToAnchor:_autocorrectButton.leadingAnchor],
         [_chinesePunctuationButton.topAnchor constraintEqualToAnchor:_helpcodeButton.bottomAnchor constant:12.0],
+        [_candidateLearningButton.leadingAnchor constraintEqualToAnchor:_autocorrectButton.leadingAnchor],
+        [_candidateLearningButton.topAnchor constraintEqualToAnchor:_chinesePunctuationButton.bottomAnchor constant:12.0],
         [_statusLabel.topAnchor constraintEqualToAnchor:behaviorCard.bottomAnchor constant:12.0],
         [_statusLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [_statusLabel.trailingAnchor constraintLessThanOrEqualToAnchor:settingsPanel.trailingAnchor constant:-28.0],
@@ -415,6 +436,7 @@ void ConfigureCard(NSBox *card)
     [_candidatePanelStyleButton selectItemAtIndex:[MetasequoiaPreferencesWindowController storedCandidatePanelStyle]];
     [_candidatePageSizeButton selectItemAtIndex:static_cast<NSInteger>(metasequoia::mac::CandidatePageSizeOptionIndex(
                                                         static_cast<size_t>([MetasequoiaPreferencesWindowController storedCandidatePageSize])))];
+    _candidateLearningButton.state = [MetasequoiaPreferencesWindowController storedCandidateLearningEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
 }
 
 - (void)refreshDictionaryStatus
@@ -481,6 +503,12 @@ void ConfigureCard(NSBox *card)
     [MetasequoiaPreferencesWindowController setCandidatePageSize:static_cast<NSInteger>(pageSize)];
 }
 
+- (void)candidateLearningChanged:(id)sender
+{
+    NSButton *button = (NSButton *)sender;
+    [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:button.state == NSControlStateValueOn];
+}
+
 - (void)restoreDefaults:(id)sender
 {
     (void)sender;
@@ -490,6 +518,7 @@ void ConfigureCard(NSBox *card)
     [MetasequoiaPreferencesWindowController setChinesePunctuationEnabled:YES];
     [MetasequoiaPreferencesWindowController setCandidatePanelStyle:0];
     [MetasequoiaPreferencesWindowController setCandidatePageSize:9];
+    [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:YES];
     [self refreshControls];
 }
 

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -79,11 +79,15 @@ int main()
         database.execute("CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER)");
         database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '你好', 200)");
         database.execute("INSERT INTO tbl_2_n VALUES('ni''hao', 'nh', '拟好', 100)");
+        database.execute("CREATE TABLE tbl_2_b(key TEXT, jp TEXT, value TEXT, weight INTEGER)");
+        database.execute("INSERT INTO tbl_2_b VALUES('bu''hao', 'bh', '不好', 200)");
+        database.execute("INSERT INTO tbl_2_b VALUES('bu''hao', 'bh', '补好', 100)");
 
         metasequoia::mac::InputSession default_session;
         require(default_session.scheme_type() == SchemeType::Quanpin, "The default input scheme should be full pinyin.");
         require(default_session.quanpin_autocorrect_enabled(), "Pinyin autocorrect should be enabled by default.");
         require(default_session.helpcode_enabled(), "Helpcode should be enabled by default.");
+        require(default_session.candidate_learning_enabled(), "Candidate learning should be enabled by default.");
         metasequoia::mac::InputSession shuangpin_session(SchemeType::Shuangpin);
         require(shuangpin_session.scheme_type() == SchemeType::Shuangpin, "The requested double-pinyin scheme was not retained.");
         metasequoia::mac::InputSession no_autocorrect_session(SchemeType::Quanpin, false);
@@ -93,6 +97,18 @@ int main()
         metasequoia::mac::InputSession ascii_punctuation_session(SchemeType::Quanpin, true, true, false);
         require(!ascii_punctuation_session.chinese_punctuation_enabled(), "The requested punctuation setting was not retained.");
         require(!ascii_punctuation_session.handle_punctuation('.').handled, "Disabled Chinese punctuation swallowed ASCII punctuation.");
+        metasequoia::mac::InputSession no_learning_session(SchemeType::Quanpin, true, true, true, false);
+        require(!no_learning_session.candidate_learning_enabled(), "The requested candidate-learning setting was not retained.");
+        type(no_learning_session, "buhao");
+        require(no_learning_session.candidates().size() >= 2 && no_learning_session.candidates().front().word == "不好",
+                "The learning test dictionary did not preserve its initial order.");
+        const auto unlearned_selection = no_learning_session.select_candidate(1);
+        require(unlearned_selection.handled && unlearned_selection.commit == "补好",
+                "Candidate selection failed while learning was disabled.");
+        metasequoia::mac::InputSession verify_unlearned_session;
+        type(verify_unlearned_session, "buhao");
+        require(!verify_unlearned_session.candidates().empty() && verify_unlearned_session.candidates().front().word == "不好",
+                "A selected candidate was learned while candidate learning was disabled.");
 
         metasequoia::mac::InputSession uppercase_session;
         require(!uppercase_session.handle_character('N').handled,

--- a/tests/PreferencesWindowTests.mm
+++ b/tests/PreferencesWindowTests.mm
@@ -43,10 +43,13 @@ int main()
         [NSApplication sharedApplication];
         [MetasequoiaPreferencesWindowController setCandidatePanelStyle:1];
         [MetasequoiaPreferencesWindowController setCandidatePageSize:5];
+        [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:NO];
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 1,
                 "The vertical candidate layout preference was not stored.");
         require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 5,
                 "The five-candidate page-size preference was not stored.");
+        require(![MetasequoiaPreferencesWindowController storedCandidateLearningEnabled],
+                "The disabled candidate-learning preference was not stored.");
 
         MetasequoiaPreferencesWindowController *controller =
             [[MetasequoiaPreferencesWindowController alloc] init];
@@ -74,6 +77,13 @@ int main()
         require(pageSizeButton.indexOfSelectedItem == 0,
                 "The candidate page-size control did not reflect the stored value.");
 
+        NSView *learningView = FindViewWithAccessibilityLabel(controller.window.contentView, @"记住候选词频");
+        require([learningView isKindOfClass:[NSButton class]],
+                "The settings window did not expose the candidate-learning control.");
+        NSButton *learningButton = (NSButton *)learningView;
+        require(learningButton.state == NSControlStateValueOff,
+                "The candidate-learning control did not reflect the stored disabled value.");
+
         [styleButton selectItemAtIndex:0];
         require([NSApp sendAction:styleButton.action to:styleButton.target from:styleButton],
                 "The candidate layout control did not dispatch its action.");
@@ -85,6 +95,12 @@ int main()
                 "The candidate page-size control did not dispatch its action.");
         require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 7,
                 "The candidate page-size control did not store the selected value.");
+
+        learningButton.state = NSControlStateValueOn;
+        require([NSApp sendAction:learningButton.action to:learningButton.target from:learningButton],
+                "The candidate-learning control did not dispatch its action.");
+        require([MetasequoiaPreferencesWindowController storedCandidateLearningEnabled],
+                "The candidate-learning control did not store the selected value.");
 
         [MetasequoiaPreferencesWindowController setCandidatePanelStyle:99];
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 0,


### PR DESCRIPTION
## Summary
- add a persisted `记住候选词频` setting, enabled by default
- carry the preference into each input session without changing an active composition
- skip all candidate weight updates when learning is disabled while preserving normal commits
- verify the no-learning path against an isolated real SQLite dictionary and cover the settings control

## Verification
- `./scripts/build.sh` (11/11 tests passed)
- post-rebase build and 11/11 tests passed
- code signature and designated requirement validated
- Orca accessibility verification: 600pt × 604pt settings window exposed `记住候选词频: off`, retained all existing controls, and was on-screen without clipping
- independent review: no Critical/Important findings