### PR TITLE
feat(input): switch between Chinese and English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the native macOS frontend for Metasequoia IME. It uses InputMethodKit and AppKit, embeds the shared C++ engine directly, and does not port the Windows TSF or WebView2 host.
 
-The current alpha supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, and composition commit on focus changes.
+The current alpha supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, composition commit on focus changes, and Shift+Space switching between Chinese and direct English input.
 
 ## Requirements
 
@@ -34,6 +34,8 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 ## Settings
 
 In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, switch the native candidate window between a horizontal row and vertical list, show 5, 7, or 9 candidates per page, enable full-pinyin autocorrection and auxiliary codes, switch Chinese punctuation conversion, and control whether selected candidates update learned word frequencies. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
+
+The text input menu also shows whether 水杉 is in 中文输入 or 英文输入 mode. Choose either item directly, or press Shift+Space; switching to English commits the active Chinese composition before subsequent keys pass through unchanged.
 
 ## Development tests
 

--- a/src/InputMenu.h
+++ b/src/InputMenu.h
@@ -2,10 +2,23 @@
 
 #import <AppKit/AppKit.h>
 
-inline NSMenu *CreateMetasequoiaInputMenu(id target)
+inline NSMenuItem *CreateInputModeItem(NSString *title, SEL action, id target, BOOL selected)
+{
+    NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:title action:action keyEquivalent:@""];
+    item.target = target;
+    item.enabled = YES;
+    item.state = selected ? NSControlStateValueOn : NSControlStateValueOff;
+    return item;
+}
+
+inline NSMenu *CreateMetasequoiaInputMenu(id target, BOOL englishMode)
 {
     NSMenu *menu = [[NSMenu alloc] initWithTitle:@"水杉输入法"];
     menu.autoenablesItems = NO;
+
+    [menu addItem:CreateInputModeItem(@"中文输入", @selector(selectChineseMode:), target, !englishMode)];
+    [menu addItem:CreateInputModeItem(@"英文输入", @selector(selectEnglishMode:), target, englishMode)];
+    [menu addItem:[NSMenuItem separatorItem]];
 
     NSMenuItem *settingsItem = [[NSMenuItem alloc] initWithTitle:@"水杉输入法设置…"
                                                           action:@selector(showPreferences:)

--- a/src/InputModeRouting.h
+++ b/src/InputModeRouting.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
+
+namespace metasequoia::mac
+{
+inline bool IsInputModeToggle(unsigned short keyCode, NSEventModifierFlags modifiers)
+{
+    const NSEventModifierFlags competingModifiers =
+        modifiers & (NSEventModifierFlagCommand | NSEventModifierFlagControl | NSEventModifierFlagOption);
+    return keyCode == kVK_Space && (modifiers & NSEventModifierFlagShift) != 0 && competingModifiers == 0;
+}
+
+inline bool ShouldPrepareInputSession(bool englishMode)
+{
+    return !englishMode;
+}
+} // namespace metasequoia::mac

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -4,6 +4,7 @@
 #include "CandidatePageSize.h"
 #include "CandidatePanelStyle.h"
 #import "InputMenu.h"
+#include "InputModeRouting.h"
 #import "PreferencesWindowController.h"
 #include "CandidateSelectionState.h"
 #include "InputControllerKeyRouting.h"
@@ -79,7 +80,11 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
         _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
         [_candidatePanel setAttributes:@{IMKCandidatesSendServerKeyEventFirst: @YES}];
 
-        [self prepareSessionIfNeeded];
+        if (metasequoia::mac::ShouldPrepareInputSession(
+                [MetasequoiaPreferencesWindowController storedEnglishInputMode]))
+        {
+            [self prepareSessionIfNeeded];
+        }
     }
     return self;
 }
@@ -140,7 +145,9 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 {
     [super activateServer:sender];
     _dictionaryRetryAfter = 0.0;
-    if ([self prepareSessionIfNeeded])
+    if (metasequoia::mac::ShouldPrepareInputSession(
+            [MetasequoiaPreferencesWindowController storedEnglishInputMode]) &&
+        [self prepareSessionIfNeeded])
     {
         [self reloadSessionFromPreferences];
     }
@@ -217,6 +224,17 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender
 {
     if (event.type != NSEventTypeKeyDown)
+    {
+        return NO;
+    }
+    const NSEventModifierFlags inputModeModifiers =
+        event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
+    if (metasequoia::mac::IsInputModeToggle(event.keyCode, inputModeModifiers))
+    {
+        [self setEnglishInputMode:![MetasequoiaPreferencesWindowController storedEnglishInputMode] client:sender];
+        return YES;
+    }
+    if ([MetasequoiaPreferencesWindowController storedEnglishInputMode])
     {
         return NO;
     }
@@ -503,9 +521,32 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     [[MetasequoiaPreferencesWindowController sharedController] showAndActivate];
 }
 
+- (void)setEnglishInputMode:(BOOL)enabled client:(id)sender
+{
+    if (enabled)
+    {
+        [self commitLeadingCandidate:sender];
+    }
+    _candidateSelection.reset();
+    [_candidatePanel hide];
+    [MetasequoiaPreferencesWindowController setEnglishInputMode:enabled];
+}
+
+- (void)selectChineseMode:(id)sender
+{
+    (void)sender;
+    [self setEnglishInputMode:NO client:self.client];
+}
+
+- (void)selectEnglishMode:(id)sender
+{
+    (void)sender;
+    [self setEnglishInputMode:YES client:self.client];
+}
+
 - (NSMenu *)menu
 {
-    return CreateMetasequoiaInputMenu(self);
+    return CreateMetasequoiaInputMenu(self, [MetasequoiaPreferencesWindowController storedEnglishInputMode]);
 }
 
 - (NSUInteger)recognizedEvents:(id)sender

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -18,5 +18,7 @@
 + (void)setCandidatePageSize:(NSInteger)pageSize;
 + (BOOL)storedCandidateLearningEnabled;
 + (void)setCandidateLearningEnabled:(BOOL)enabled;
++ (BOOL)storedEnglishInputMode;
++ (void)setEnglishInputMode:(BOOL)enabled;
 - (void)showAndActivate;
 @end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -15,6 +15,7 @@ NSString * const kChinesePunctuationPreferenceKey = @"MetasequoiaImeChinesePunct
 NSString * const kCandidatePanelStylePreferenceKey = @"MetasequoiaImeCandidatePanelStyle";
 NSString * const kCandidatePageSizePreferenceKey = @"MetasequoiaImeCandidatePageSize";
 NSString * const kCandidateLearningPreferenceKey = @"MetasequoiaImeCandidateLearning";
+NSString * const kEnglishInputModePreferenceKey = @"MetasequoiaImeEnglishInputMode";
 
 NSColor *MetasequoiaBrandColor()
 {
@@ -155,6 +156,18 @@ void ConfigureCard(NSBox *card)
 {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kCandidateLearningPreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaCandidateLearningDidChangeNotification"
+                                                        object:@(enabled)];
+}
+
++ (BOOL)storedEnglishInputMode
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kEnglishInputModePreferenceKey];
+}
+
++ (void)setEnglishInputMode:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kEnglishInputModePreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaEnglishInputModeDidChangeNotification"
                                                         object:@(enabled)];
 }
 

--- a/tests/InputControllerKeyRoutingTests.mm
+++ b/tests/InputControllerKeyRoutingTests.mm
@@ -1,6 +1,7 @@
 #include "../src/InputControllerKeyRouting.h"
 #include "../src/CandidatePanelStyle.h"
 #include "../src/CandidatePageSize.h"
+#include "../src/InputModeRouting.h"
 
 #import <InputMethodKit/InputMethodKit.h>
 
@@ -35,6 +36,17 @@ int main()
     using metasequoia::mac::IsPrimaryCandidateDirection;
     using metasequoia::mac::NormalizeCandidatePageSize;
     using metasequoia::mac::NormalizeCandidatePanelStyle;
+    using metasequoia::mac::IsInputModeToggle;
+
+    require(IsInputModeToggle(kVK_Space, NSEventModifierFlagShift),
+            "Shift+Space did not map to input-mode switching.");
+    require(!IsInputModeToggle(kVK_Space, 0) &&
+                !IsInputModeToggle(kVK_ANSI_A, NSEventModifierFlagShift) &&
+                !IsInputModeToggle(kVK_Space, NSEventModifierFlagShift | NSEventModifierFlagCommand),
+            "A non-toggle shortcut unexpectedly mapped to input-mode switching.");
+    require(metasequoia::mac::ShouldPrepareInputSession(false) &&
+                !metasequoia::mac::ShouldPrepareInputSession(true),
+            "Direct English mode did not bypass input-session preparation.");
 
     require(NormalizeCandidatePanelStyle(0) == CandidatePanelStyle::Horizontal &&
                 NormalizeCandidatePanelStyle(1) == CandidatePanelStyle::Vertical &&

--- a/tests/InputMenuTests.mm
+++ b/tests/InputMenuTests.mm
@@ -17,6 +17,8 @@ void require(bool condition, const char *message)
 
 @interface PreferencesTarget : NSObject
 @property(nonatomic) BOOL preferencesShown;
+@property(nonatomic) BOOL chineseSelected;
+@property(nonatomic) BOOL englishSelected;
 @end
 
 @implementation PreferencesTarget
@@ -24,6 +26,18 @@ void require(bool condition, const char *message)
 {
     (void)sender;
     self.preferencesShown = YES;
+}
+
+- (void)selectChineseMode:(id)sender
+{
+    (void)sender;
+    self.chineseSelected = YES;
+}
+
+- (void)selectEnglishMode:(id)sender
+{
+    (void)sender;
+    self.englishSelected = YES;
 }
 @end
 
@@ -33,16 +47,37 @@ int main()
     {
         [NSApplication sharedApplication];
         PreferencesTarget *target = [[PreferencesTarget alloc] init];
-        NSMenu *menu = CreateMetasequoiaInputMenu(target);
+        NSMenu *menu = CreateMetasequoiaInputMenu(target, NO);
 
-        require(menu.numberOfItems == 1, "The input menu did not contain exactly one settings action.");
-        NSMenuItem *settingsItem = [menu itemAtIndex:0];
+        require(menu.numberOfItems == 4, "The input menu did not contain both input modes and settings.");
+        NSMenuItem *chineseItem = [menu itemAtIndex:0];
+        NSMenuItem *englishItem = [menu itemAtIndex:1];
+        require([chineseItem.title isEqualToString:@"中文输入"] &&
+                    chineseItem.action == @selector(selectChineseMode:) && chineseItem.target == target &&
+                    chineseItem.state == NSControlStateValueOn,
+                "The Chinese input mode was not represented as selected.");
+        require([englishItem.title isEqualToString:@"英文输入"] &&
+                    englishItem.action == @selector(selectEnglishMode:) && englishItem.target == target &&
+                    englishItem.state == NSControlStateValueOff,
+                "The English input mode was not represented as unselected.");
+        require([menu itemAtIndex:2].separatorItem, "The input modes were not separated from settings.");
+
+        NSMenuItem *settingsItem = [menu itemAtIndex:3];
         require([settingsItem.title isEqualToString:@"水杉输入法设置…"], "The settings action title was incorrect.");
         require(settingsItem.action == @selector(showPreferences:), "The settings action used the wrong selector.");
         require(settingsItem.target == target, "The settings action did not target the input controller.");
         require(settingsItem.enabled, "The settings action was unexpectedly disabled.");
 
-        [menu performActionForItemAtIndex:0];
+        [menu performActionForItemAtIndex:1];
+        require(target.englishSelected, "The English input mode action was not dispatched.");
+        NSMenu *englishMenu = CreateMetasequoiaInputMenu(target, YES);
+        require([englishMenu itemAtIndex:0].state == NSControlStateValueOff &&
+                    [englishMenu itemAtIndex:1].state == NSControlStateValueOn,
+                "The English input mode was not represented as selected.");
+        [englishMenu performActionForItemAtIndex:0];
+        require(target.chineseSelected, "The Chinese input mode action was not dispatched.");
+
+        [menu performActionForItemAtIndex:3];
         require(target.preferencesShown, "The settings action did not invoke showPreferences:.");
     }
     return 0;

--- a/tests/PreferencesWindowTests.mm
+++ b/tests/PreferencesWindowTests.mm
@@ -44,12 +44,15 @@ int main()
         [MetasequoiaPreferencesWindowController setCandidatePanelStyle:1];
         [MetasequoiaPreferencesWindowController setCandidatePageSize:5];
         [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:NO];
+        [MetasequoiaPreferencesWindowController setEnglishInputMode:YES];
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 1,
                 "The vertical candidate layout preference was not stored.");
         require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 5,
                 "The five-candidate page-size preference was not stored.");
         require(![MetasequoiaPreferencesWindowController storedCandidateLearningEnabled],
                 "The disabled candidate-learning preference was not stored.");
+        require([MetasequoiaPreferencesWindowController storedEnglishInputMode],
+                "The English input-mode state was not stored.");
 
         MetasequoiaPreferencesWindowController *controller =
             [[MetasequoiaPreferencesWindowController alloc] init];
@@ -108,6 +111,9 @@ int main()
         [MetasequoiaPreferencesWindowController setCandidatePageSize:99];
         require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 9,
                 "An unsupported candidate page size was not normalized safely.");
+        [MetasequoiaPreferencesWindowController setEnglishInputMode:NO];
+        require(![MetasequoiaPreferencesWindowController storedEnglishInputMode],
+                "The Chinese input-mode state was not stored.");
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- add persistent Chinese/direct-English input modes to the input menu
- toggle modes with Shift+Space and commit an active Chinese composition before switching
- skip dictionary/session preparation while direct-English mode is active

## Verification
- ./scripts/build.sh
- ctest --test-dir build --output-on-failure (11/11)
- codesign --verify --deep --strict --verbose=2 build/MetasequoiaIME.app
- Orca computer: selected 水杉 in TextEdit, verified direct English nihao, switched back to Chinese, and verified active composition commits before English passthrough
- independent code review: no blocking findings