### PR TITLE
feat(settings): configure input mode shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. T
 
 In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼 or 小鹤双拼, switch the native candidate window between a horizontal row and vertical list, show 5, 7, or 9 candidates per page, choose a small, standard, or large candidate font, enable full-pinyin autocorrection and auxiliary codes, switch Chinese punctuation conversion, and control whether selected candidates update learned word frequencies. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
 
-The text input menu also shows whether 水杉 is in 中文输入 or 英文输入 mode. Choose either item directly, or press Shift+Space; switching to English commits the active Chinese composition before subsequent keys pass through unchanged.
+The text input menu also shows whether 水杉 is in 中文输入 or 英文输入 mode. Choose either item directly, or press Shift+Space; switching to English commits the active Chinese composition before subsequent keys pass through unchanged. The Shift+Space shortcut is enabled by default and can be disabled in settings when it conflicts with another workflow.
 
 ## Development tests
 

--- a/src/InputModeRouting.h
+++ b/src/InputModeRouting.h
@@ -12,6 +12,11 @@ inline bool IsInputModeToggle(unsigned short keyCode, NSEventModifierFlags modif
     return keyCode == kVK_Space && (modifiers & NSEventModifierFlagShift) != 0 && competingModifiers == 0;
 }
 
+inline bool ShouldToggleInputMode(bool shortcutEnabled, unsigned short keyCode, NSEventModifierFlags modifiers)
+{
+    return shortcutEnabled && IsInputModeToggle(keyCode, modifiers);
+}
+
 inline bool ShouldPrepareInputSession(bool englishMode)
 {
     return !englishMode;

--- a/src/MetasequoiaInputController.mm
+++ b/src/MetasequoiaInputController.mm
@@ -235,7 +235,9 @@ bool SessionMatchesPreferences(const metasequoia::mac::InputSession &session, co
     }
     const NSEventModifierFlags inputModeModifiers =
         event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
-    if (metasequoia::mac::IsInputModeToggle(event.keyCode, inputModeModifiers))
+    if (metasequoia::mac::ShouldToggleInputMode(
+            [MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled], event.keyCode,
+            inputModeModifiers))
     {
         [self setEnglishInputMode:![MetasequoiaPreferencesWindowController storedEnglishInputMode] client:sender];
         return YES;

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -22,5 +22,7 @@
 + (void)setCandidateLearningEnabled:(BOOL)enabled;
 + (BOOL)storedEnglishInputMode;
 + (void)setEnglishInputMode:(BOOL)enabled;
++ (BOOL)storedInputModeShortcutEnabled;
++ (void)setInputModeShortcutEnabled:(BOOL)enabled;
 - (void)showAndActivate;
 @end

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -18,6 +18,7 @@ NSString * const kCandidatePageSizePreferenceKey = @"MetasequoiaImeCandidatePage
 NSString * const kCandidateFontSizePreferenceKey = @"MetasequoiaImeCandidateFontSize";
 NSString * const kCandidateLearningPreferenceKey = @"MetasequoiaImeCandidateLearning";
 NSString * const kEnglishInputModePreferenceKey = @"MetasequoiaImeEnglishInputMode";
+NSString * const kInputModeShortcutPreferenceKey = @"MetasequoiaImeInputModeShortcutEnabled";
 
 NSColor *MetasequoiaBrandColor()
 {
@@ -53,6 +54,7 @@ void ConfigureCard(NSBox *card)
     NSPopUpButton *_candidatePageSizeButton;
     NSPopUpButton *_candidateFontSizeButton;
     NSButton *_candidateLearningButton;
+    NSButton *_inputModeShortcutButton;
     NSTextField *_statusLabel;
 }
 
@@ -186,6 +188,19 @@ void ConfigureCard(NSBox *card)
 {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kEnglishInputModePreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaEnglishInputModeDidChangeNotification"
+                                                        object:@(enabled)];
+}
+
++ (BOOL)storedInputModeShortcutEnabled
+{
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kInputModeShortcutPreferenceKey];
+    return value == nil ? YES : [value boolValue];
+}
+
++ (void)setInputModeShortcutEnabled:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kInputModeShortcutPreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaInputModeShortcutDidChangeNotification"
                                                         object:@(enabled)];
 }
 
@@ -344,6 +359,12 @@ void ConfigureCard(NSBox *card)
     _candidateLearningButton = [NSButton checkboxWithTitle:@"记住候选词频" target:self action:@selector(candidateLearningChanged:)];
     _candidateLearningButton.translatesAutoresizingMaskIntoConstraints = NO;
 
+    _inputModeShortcutButton = [NSButton checkboxWithTitle:@"Shift+Space 切换中英文"
+                                                    target:self
+                                                    action:@selector(inputModeShortcutChanged:)];
+    _inputModeShortcutButton.accessibilityLabel = @"Shift+Space 切换中英文";
+    _inputModeShortcutButton.translatesAutoresizingMaskIntoConstraints = NO;
+
     _statusLabel = [NSTextField labelWithString:@"检查词库状态…"];
     _statusLabel.accessibilityLabel = @"词库状态";
     _statusLabel.textColor = [NSColor secondaryLabelColor];
@@ -388,6 +409,7 @@ void ConfigureCard(NSBox *card)
     [behaviorCard addSubview:_autocorrectButton];
     [behaviorCard addSubview:_helpcodeButton];
     [behaviorCard addSubview:_chinesePunctuationButton];
+    [behaviorCard addSubview:_inputModeShortcutButton];
     [behaviorCard addSubview:_candidateLearningButton];
     [settingsPanel addSubview:_statusLabel];
     [settingsPanel addSubview:restoreButton];
@@ -457,11 +479,13 @@ void ConfigureCard(NSBox *card)
         [_autocorrectButton.leadingAnchor constraintEqualToAnchor:behaviorCard.leadingAnchor constant:18.0],
         [_autocorrectButton.topAnchor constraintEqualToAnchor:behaviorCard.topAnchor constant:16.0],
         [_helpcodeButton.leadingAnchor constraintEqualToAnchor:_autocorrectButton.leadingAnchor],
-        [_helpcodeButton.topAnchor constraintEqualToAnchor:_autocorrectButton.bottomAnchor constant:12.0],
+        [_helpcodeButton.topAnchor constraintEqualToAnchor:_autocorrectButton.bottomAnchor constant:8.0],
         [_chinesePunctuationButton.leadingAnchor constraintEqualToAnchor:_autocorrectButton.leadingAnchor],
-        [_chinesePunctuationButton.topAnchor constraintEqualToAnchor:_helpcodeButton.bottomAnchor constant:12.0],
+        [_chinesePunctuationButton.topAnchor constraintEqualToAnchor:_helpcodeButton.bottomAnchor constant:8.0],
+        [_inputModeShortcutButton.leadingAnchor constraintEqualToAnchor:_autocorrectButton.leadingAnchor],
+        [_inputModeShortcutButton.topAnchor constraintEqualToAnchor:_chinesePunctuationButton.bottomAnchor constant:8.0],
         [_candidateLearningButton.leadingAnchor constraintEqualToAnchor:_autocorrectButton.leadingAnchor],
-        [_candidateLearningButton.topAnchor constraintEqualToAnchor:_chinesePunctuationButton.bottomAnchor constant:12.0],
+        [_candidateLearningButton.topAnchor constraintEqualToAnchor:_inputModeShortcutButton.bottomAnchor constant:8.0],
         [_statusLabel.topAnchor constraintEqualToAnchor:behaviorCard.bottomAnchor constant:12.0],
         [_statusLabel.leadingAnchor constraintEqualToAnchor:titleLabel.leadingAnchor],
         [_statusLabel.trailingAnchor constraintLessThanOrEqualToAnchor:settingsPanel.trailingAnchor constant:-28.0],
@@ -488,6 +512,7 @@ void ConfigureCard(NSBox *card)
     [_candidateFontSizeButton selectItemAtIndex:static_cast<NSInteger>(metasequoia::mac::CandidateFontSizeOptionIndex(
                                                         static_cast<size_t>([MetasequoiaPreferencesWindowController storedCandidateFontSize])))];
     _candidateLearningButton.state = [MetasequoiaPreferencesWindowController storedCandidateLearningEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
+    _inputModeShortcutButton.state = [MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
 }
 
 - (void)refreshDictionaryStatus
@@ -568,6 +593,12 @@ void ConfigureCard(NSBox *card)
     [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:button.state == NSControlStateValueOn];
 }
 
+- (void)inputModeShortcutChanged:(id)sender
+{
+    NSButton *button = (NSButton *)sender;
+    [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:button.state == NSControlStateValueOn];
+}
+
 - (void)restoreDefaults:(id)sender
 {
     (void)sender;
@@ -579,6 +610,7 @@ void ConfigureCard(NSBox *card)
     [MetasequoiaPreferencesWindowController setCandidatePageSize:9];
     [MetasequoiaPreferencesWindowController setCandidateFontSize:18];
     [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:YES];
+    [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:YES];
     [self refreshControls];
 }
 

--- a/tests/InputControllerKeyRoutingTests.mm
+++ b/tests/InputControllerKeyRoutingTests.mm
@@ -45,6 +45,9 @@ int main()
                 !IsInputModeToggle(kVK_ANSI_A, NSEventModifierFlagShift) &&
                 !IsInputModeToggle(kVK_Space, NSEventModifierFlagShift | NSEventModifierFlagCommand),
             "A non-toggle shortcut unexpectedly mapped to input-mode switching.");
+    require(metasequoia::mac::ShouldToggleInputMode(true, kVK_Space, NSEventModifierFlagShift) &&
+                !metasequoia::mac::ShouldToggleInputMode(false, kVK_Space, NSEventModifierFlagShift),
+            "The input-mode shortcut preference did not gate Shift+Space.");
     require(metasequoia::mac::ShouldPrepareInputSession(false) &&
                 !metasequoia::mac::ShouldPrepareInputSession(true),
             "Direct English mode did not bypass input-session preparation.");

--- a/tests/PreferencesWindowTests.mm
+++ b/tests/PreferencesWindowTests.mm
@@ -46,6 +46,7 @@ int main()
         [MetasequoiaPreferencesWindowController setCandidateFontSize:16];
         [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:NO];
         [MetasequoiaPreferencesWindowController setEnglishInputMode:YES];
+        [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:NO];
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 1,
                 "The vertical candidate layout preference was not stored.");
         require([MetasequoiaPreferencesWindowController storedCandidatePageSize] == 5,
@@ -56,6 +57,8 @@ int main()
                 "The disabled candidate-learning preference was not stored.");
         require([MetasequoiaPreferencesWindowController storedEnglishInputMode],
                 "The English input-mode state was not stored.");
+        require(![MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled],
+                "The disabled input-mode shortcut preference was not stored.");
 
         MetasequoiaPreferencesWindowController *controller =
             [[MetasequoiaPreferencesWindowController alloc] init];
@@ -102,6 +105,14 @@ int main()
         require(learningButton.state == NSControlStateValueOff,
                 "The candidate-learning control did not reflect the stored disabled value.");
 
+        NSView *shortcutView = FindViewWithAccessibilityLabel(controller.window.contentView,
+                                                               @"Shift+Space 切换中英文");
+        require([shortcutView isKindOfClass:[NSButton class]],
+                "The settings window did not expose the input-mode shortcut control.");
+        NSButton *shortcutButton = (NSButton *)shortcutView;
+        require(shortcutButton.state == NSControlStateValueOff,
+                "The input-mode shortcut control did not reflect the stored disabled value.");
+
         [styleButton selectItemAtIndex:0];
         require([NSApp sendAction:styleButton.action to:styleButton.target from:styleButton],
                 "The candidate layout control did not dispatch its action.");
@@ -125,6 +136,12 @@ int main()
                 "The candidate-learning control did not dispatch its action.");
         require([MetasequoiaPreferencesWindowController storedCandidateLearningEnabled],
                 "The candidate-learning control did not store the selected value.");
+
+        shortcutButton.state = NSControlStateValueOn;
+        require([NSApp sendAction:shortcutButton.action to:shortcutButton.target from:shortcutButton],
+                "The input-mode shortcut control did not dispatch its action.");
+        require([MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled],
+                "The input-mode shortcut control did not store the enabled value.");
 
         [MetasequoiaPreferencesWindowController setCandidatePanelStyle:99];
         require([MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 0,


### PR DESCRIPTION
## Summary
- add a native setting for enabling or disabling Shift+Space Chinese/English switching
- keep the shortcut enabled by default while allowing users to avoid conflicts
- retain the existing Chinese Space behavior when the shortcut is disabled

## Verification
- ./scripts/build.sh (11/11)
- code signature verification passed
- Orca computer: toggled the new setting in the full preferences UI with no clipping
- Orca computer + TextEdit: disabled shortcut did not switch mode and Chinese input still committed; enabled shortcut switched to direct English and passed through abc
- restored the original user defaults and removed the temporary TextEdit document
- independent code review: no blocking findings