### PR TITLE
feat(dictionary): reset learned data safely

### DIFF
--- a/src/DictionaryInstaller.h
+++ b/src/DictionaryInstaller.h
@@ -7,3 +7,6 @@ BOOL PrepareMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString 
                                   NSError **error);
 BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
                                   NSError **error);
+// The caller must first quiesce every input session that can hold an open dictionary handle.
+BOOL ResetMetasequoiaLearnedData(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
+                                 NSError **error);

--- a/src/DictionaryInstaller.mm
+++ b/src/DictionaryInstaller.mm
@@ -1,12 +1,34 @@
 #import "DictionaryInstaller.h"
 
 #include "../vendor/MetasequoiaImeEngine/user_dictionary/user_dictionary_journal.h"
+#include "../vendor/MetasequoiaImeEngine/googlepinyinime-rev/src/include/pinyinime.h"
 
 #include <sqlite3.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
 
 namespace
 {
 NSString *const MetasequoiaDictionaryErrorDomain = @"com.houko.inputmethod.MetasequoiaIME.dictionary";
+NSString *const MetasequoiaResetMarkerName = @".metasequoia-learning-reset.plist";
+NSString *const MetasequoiaResetPreparedPhase = @"prepared";
+NSString *const MetasequoiaResetBackedUpPhase = @"backed-up";
+NSString *const MetasequoiaResetRollingBackPhase = @"rolling-back";
+NSString *const MetasequoiaResetCommittedPhase = @"committed";
+
+NSArray<NSString *> *MutableDictionaryFileNames()
+{
+    static NSArray<NSString *> *fileNames = @[
+        @"msime.db", @"msime.db-wal", @"msime.db-shm", @"msime.db-journal", @"msime.db.sha256",
+        @"msime_user.db", @"msime_user.db-wal", @"msime_user.db-shm", @"msime_user.db-journal",
+        @"msime_english.db", @"msime_english.db-wal", @"msime_english.db-shm",
+        @"msime_english.db-journal", @"user_dict.dat",
+    ];
+    return fileNames;
+}
 
 BOOL Fail(NSError **error, NSInteger code, NSString *description)
 {
@@ -15,6 +37,15 @@ BOOL Fail(NSError **error, NSInteger code, NSString *description)
         *error = [NSError errorWithDomain:MetasequoiaDictionaryErrorDomain
                                      code:code
                                  userInfo:@{NSLocalizedDescriptionKey: description}];
+    }
+    return NO;
+}
+
+BOOL FailWithErrno(NSError **error, int errorNumber)
+{
+    if (error != nullptr)
+    {
+        *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errorNumber userInfo:nil];
     }
     return NO;
 }
@@ -62,6 +93,281 @@ BOOL IsUsableDictionary(NSURL *dictionary)
     sqlite3_close(database);
     return schemaValid;
 }
+
+NSString *ResetBackupName(NSString *fileName, NSString *identifier)
+{
+    return [NSString stringWithFormat:@".%@.reset-backup.%@", fileName, identifier];
+}
+
+NSURL *ResetTemporaryDictionary(NSURL *dataDirectory, NSString *identifier)
+{
+    return [dataDirectory URLByAppendingPathComponent:
+                              [@".msime.db.resetting." stringByAppendingString:identifier]];
+}
+
+NSURL *ResetTemporaryFingerprint(NSURL *dataDirectory, NSString *identifier)
+{
+    return [dataDirectory URLByAppendingPathComponent:
+                              [@".msime.db.sha256.resetting." stringByAppendingString:identifier]];
+}
+
+BOOL SyncURL(NSURL *url, BOOL directory, NSError **error)
+{
+    int flags = O_RDONLY | O_CLOEXEC;
+#ifdef O_DIRECTORY
+    if (directory)
+    {
+        flags |= O_DIRECTORY;
+    }
+#else
+    (void)directory;
+#endif
+    const int descriptor = open(url.fileSystemRepresentation, flags);
+    if (descriptor < 0)
+    {
+        return FailWithErrno(error, errno);
+    }
+    int result = fcntl(descriptor, F_FULLFSYNC);
+    int errorNumber = errno;
+    if (result != 0 && (errorNumber == EINVAL || errorNumber == ENOTSUP))
+    {
+        result = fsync(descriptor);
+        errorNumber = errno;
+    }
+    close(descriptor);
+    return result == 0 ? YES : FailWithErrno(error, errorNumber);
+}
+
+BOOL RemoveIfPresent(NSFileManager *fileManager, NSURL *url, NSError **error)
+{
+    return ![fileManager fileExistsAtPath:url.path] || [fileManager removeItemAtURL:url error:error];
+}
+
+BOOL WriteResetMarker(NSURL *dataDirectory, NSString *identifier, NSString *phase,
+                      NSArray<NSString *> *originalFileNames, NSError **error)
+{
+    NSDictionary *marker = @{
+        @"version": @1,
+        @"identifier": identifier,
+        @"phase": phase,
+        @"originalFileNames": originalFileNames,
+    };
+    NSData *data = [NSPropertyListSerialization dataWithPropertyList:marker
+                                                               format:NSPropertyListBinaryFormat_v1_0
+                                                              options:0
+                                                                error:error];
+    if (data == nil)
+    {
+        return NO;
+    }
+
+    NSURL *markerURL = [dataDirectory URLByAppendingPathComponent:MetasequoiaResetMarkerName];
+    NSURL *temporaryMarker = [dataDirectory
+        URLByAppendingPathComponent:[@".metasequoia-learning-reset.tmp." stringByAppendingString:NSUUID.UUID.UUIDString]];
+    if (![data writeToURL:temporaryMarker options:0 error:error] || !SyncURL(temporaryMarker, NO, error))
+    {
+        [[NSFileManager defaultManager] removeItemAtURL:temporaryMarker error:nil];
+        return NO;
+    }
+    if (rename(temporaryMarker.fileSystemRepresentation, markerURL.fileSystemRepresentation) != 0)
+    {
+        const int errorNumber = errno;
+        [[NSFileManager defaultManager] removeItemAtURL:temporaryMarker error:nil];
+        return FailWithErrno(error, errorNumber);
+    }
+    return SyncURL(dataDirectory, YES, error);
+}
+
+NSDictionary *ReadResetMarker(NSURL *markerURL, NSError **error)
+{
+    NSData *data = [NSData dataWithContentsOfURL:markerURL options:0 error:error];
+    if (data == nil)
+    {
+        return nil;
+    }
+    id marker = [NSPropertyListSerialization propertyListWithData:data
+                                                          options:NSPropertyListImmutable
+                                                           format:nil
+                                                            error:error];
+    if (![marker isKindOfClass:[NSDictionary class]])
+    {
+        Fail(error, 7, @"The learned-data reset recovery marker is invalid.");
+        return nil;
+    }
+    return marker;
+}
+
+BOOL ValidateResetMarker(NSDictionary *marker, NSString **identifier, NSString **phase,
+                         NSArray<NSString *> **originalFileNames, NSError **error)
+{
+    id version = marker[@"version"];
+    id markerIdentifier = marker[@"identifier"];
+    id markerPhase = marker[@"phase"];
+    id names = marker[@"originalFileNames"];
+    if (![version isKindOfClass:[NSNumber class]] || [version integerValue] != 1 ||
+        ![markerIdentifier isKindOfClass:[NSString class]] ||
+        [[NSUUID alloc] initWithUUIDString:markerIdentifier] == nil ||
+        ![markerPhase isKindOfClass:[NSString class]] ||
+        (![markerPhase isEqualToString:MetasequoiaResetPreparedPhase] &&
+         ![markerPhase isEqualToString:MetasequoiaResetBackedUpPhase] &&
+         ![markerPhase isEqualToString:MetasequoiaResetRollingBackPhase] &&
+         ![markerPhase isEqualToString:MetasequoiaResetCommittedPhase]) ||
+        ![names isKindOfClass:[NSArray class]])
+    {
+        return Fail(error, 7, @"The learned-data reset recovery marker is invalid.");
+    }
+
+    NSSet<NSString *> *allowedNames = [NSSet setWithArray:MutableDictionaryFileNames()];
+    NSMutableSet<NSString *> *seenNames = [NSMutableSet set];
+    for (id name in names)
+    {
+        if (![name isKindOfClass:[NSString class]] || ![allowedNames containsObject:name] ||
+            [seenNames containsObject:name])
+        {
+            return Fail(error, 7, @"The learned-data reset recovery marker is invalid.");
+        }
+        [seenNames addObject:name];
+    }
+    *identifier = markerIdentifier;
+    *phase = markerPhase;
+    *originalFileNames = names;
+    return YES;
+}
+
+BOOL RecoverPreparedReset(NSFileManager *fileManager, NSURL *dataDirectory, NSString *identifier,
+                          NSArray<NSString *> *originalFileNames, BOOL rollbackWasStarted, NSError **error)
+{
+    NSSet<NSString *> *originalNames = [NSSet setWithArray:originalFileNames];
+    for (NSString *fileName in MutableDictionaryFileNames())
+    {
+        NSURL *original = [dataDirectory URLByAppendingPathComponent:fileName];
+        NSURL *backup = [dataDirectory URLByAppendingPathComponent:ResetBackupName(fileName, identifier)];
+        if ([fileManager fileExistsAtPath:backup.path])
+        {
+            if (!RemoveIfPresent(fileManager, original, error) ||
+                ![fileManager moveItemAtURL:backup toURL:original error:error])
+            {
+                return NO;
+            }
+        }
+        else if ([originalNames containsObject:fileName] &&
+                 ![fileManager fileExistsAtPath:original.path])
+        {
+            return Fail(error, 9, rollbackWasStarted
+                                      ? @"A learned-data reset rollback cannot find an original or backup file."
+                                      : @"A prepared learned-data reset cannot find an original or backup file.");
+        }
+        else if (![originalNames containsObject:fileName] &&
+                 ([fileName isEqualToString:@"msime.db"] || [fileName isEqualToString:@"msime.db.sha256"]) &&
+                 !RemoveIfPresent(fileManager, original, error))
+        {
+            return NO;
+        }
+    }
+    if (!RemoveIfPresent(fileManager, ResetTemporaryDictionary(dataDirectory, identifier), error) ||
+        !RemoveIfPresent(fileManager, ResetTemporaryFingerprint(dataDirectory, identifier), error))
+    {
+        return NO;
+    }
+    return SyncURL(dataDirectory, YES, error);
+}
+
+BOOL CleanupCommittedReset(NSFileManager *fileManager, NSURL *dataDirectory, NSString *identifier,
+                           NSArray<NSString *> *originalFileNames, NSError **error)
+{
+    for (NSString *fileName in originalFileNames)
+    {
+        NSURL *backup = [dataDirectory URLByAppendingPathComponent:ResetBackupName(fileName, identifier)];
+        if (!RemoveIfPresent(fileManager, backup, error))
+        {
+            return NO;
+        }
+    }
+    if (!RemoveIfPresent(fileManager, ResetTemporaryDictionary(dataDirectory, identifier), error) ||
+        !RemoveIfPresent(fileManager, ResetTemporaryFingerprint(dataDirectory, identifier), error))
+    {
+        return NO;
+    }
+    return SyncURL(dataDirectory, YES, error);
+}
+
+BOOL CleanupOrphanedResetTemporaryFiles(NSFileManager *fileManager, NSURL *dataDirectory, NSError **error)
+{
+    NSArray<NSURL *> *contents = [fileManager contentsOfDirectoryAtURL:dataDirectory
+                                             includingPropertiesForKeys:nil
+                                                                options:0
+                                                                  error:error];
+    if (contents == nil)
+    {
+        return NO;
+    }
+    BOOL removedFile = NO;
+    for (NSURL *item in contents)
+    {
+        NSString *name = item.lastPathComponent;
+        if (![name hasPrefix:@".msime.db.resetting."] &&
+            ![name hasPrefix:@".msime.db.sha256.resetting."] &&
+            ![name hasPrefix:@".metasequoia-learning-reset.tmp."])
+        {
+            continue;
+        }
+        if (![fileManager removeItemAtURL:item error:error])
+        {
+            return NO;
+        }
+        removedFile = YES;
+    }
+    return !removedFile || SyncURL(dataDirectory, YES, error);
+}
+
+BOOL RecoverLearningReset(NSFileManager *fileManager, NSURL *dataDirectory, NSError **error)
+{
+    NSURL *markerURL = [dataDirectory URLByAppendingPathComponent:MetasequoiaResetMarkerName];
+    if (![fileManager fileExistsAtPath:markerURL.path])
+    {
+        return CleanupOrphanedResetTemporaryFiles(fileManager, dataDirectory, error);
+    }
+
+    NSDictionary *marker = ReadResetMarker(markerURL, error);
+    NSString *identifier = nil;
+    NSString *phase = nil;
+    NSArray<NSString *> *originalFileNames = nil;
+    if (marker == nil || !ValidateResetMarker(marker, &identifier, &phase, &originalFileNames, error))
+    {
+        return NO;
+    }
+
+    if ([phase isEqualToString:MetasequoiaResetBackedUpPhase])
+    {
+        for (NSString *fileName in originalFileNames)
+        {
+            NSURL *backup = [dataDirectory URLByAppendingPathComponent:ResetBackupName(fileName, identifier)];
+            if (![fileManager fileExistsAtPath:backup.path])
+            {
+                return Fail(error, 9, @"A durable learned-data reset backup is missing.");
+            }
+        }
+        if (!WriteResetMarker(dataDirectory, identifier, MetasequoiaResetRollingBackPhase,
+                              originalFileNames, error))
+        {
+            return NO;
+        }
+        phase = MetasequoiaResetRollingBackPhase;
+    }
+
+    const BOOL recovered = [phase isEqualToString:MetasequoiaResetCommittedPhase]
+                               ? CleanupCommittedReset(fileManager, dataDirectory, identifier,
+                                                       originalFileNames, error)
+                               : RecoverPreparedReset(fileManager, dataDirectory, identifier,
+                                                      originalFileNames,
+                                                      [phase isEqualToString:MetasequoiaResetRollingBackPhase], error);
+    if (!recovered || ![fileManager removeItemAtURL:markerURL error:error] ||
+        !CleanupOrphanedResetTemporaryFiles(fileManager, dataDirectory, error))
+    {
+        return NO;
+    }
+    return SyncURL(dataDirectory, YES, error);
+}
 } // namespace
 
 BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
@@ -79,6 +385,14 @@ BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString 
     @synchronized([NSFileManager class])
     {
         NSFileManager *fileManager = [NSFileManager defaultManager];
+        if (![fileManager createDirectoryAtURL:dataDirectory
+                    withIntermediateDirectories:YES
+                                     attributes:nil
+                                          error:error] ||
+            !RecoverLearningReset(fileManager, dataDirectory, error))
+        {
+            return NO;
+        }
         NSDictionary<NSFileAttributeKey, id> *sourceAttributes =
             [fileManager attributesOfItemAtPath:source.path error:error];
         if (sourceAttributes == nil || sourceAttributes.fileSize == 0)
@@ -87,14 +401,6 @@ BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString 
             {
                 return Fail(error, 2, @"The bundled msime.db dictionary is empty.");
             }
-            return NO;
-        }
-
-        if (![fileManager createDirectoryAtURL:dataDirectory
-                    withIntermediateDirectories:YES
-                                     attributes:nil
-                                          error:error])
-        {
             return NO;
         }
 
@@ -180,9 +486,204 @@ BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString 
     }
 }
 
+BOOL ResetMetasequoiaLearnedData(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
+                                 NSError **error)
+{
+    if (error != nullptr)
+    {
+        *error = nil;
+    }
+    if (source == nil || dataDirectory == nil || dictionaryFingerprint.length == 0)
+    {
+        return Fail(error, 5, @"The bundled dictionary metadata is incomplete.");
+    }
+    if (!IsUsableDictionary(source))
+    {
+        return Fail(error, 6, @"The bundled dictionary cannot be used to reset learned data.");
+    }
+
+    @synchronized([NSFileManager class])
+    {
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        if (![fileManager createDirectoryAtURL:dataDirectory
+                    withIntermediateDirectories:YES
+                                     attributes:nil
+                                          error:error] ||
+            !RecoverLearningReset(fileManager, dataDirectory, error))
+        {
+            return NO;
+        }
+
+        NSString *identifier = NSUUID.UUID.UUIDString;
+        NSURL *temporaryDictionary = ResetTemporaryDictionary(dataDirectory, identifier);
+        NSURL *temporaryFingerprint = ResetTemporaryFingerprint(dataDirectory, identifier);
+        if (![fileManager copyItemAtURL:source toURL:temporaryDictionary error:error])
+        {
+            return NO;
+        }
+        if (![dictionaryFingerprint writeToURL:temporaryFingerprint
+                                    atomically:YES
+                                      encoding:NSUTF8StringEncoding
+                                         error:error])
+        {
+            [fileManager removeItemAtURL:temporaryDictionary error:nil];
+            return NO;
+        }
+        if (!SyncURL(temporaryDictionary, NO, error) || !SyncURL(temporaryFingerprint, NO, error) ||
+            !SyncURL(dataDirectory, YES, error))
+        {
+            [fileManager removeItemAtURL:temporaryDictionary error:nil];
+            [fileManager removeItemAtURL:temporaryFingerprint error:nil];
+            return NO;
+        }
+
+        user_dictionary::close_default_user_database();
+        ime_pinyin::im_close_decoder();
+
+        NSMutableArray<NSString *> *originalFileNames = [NSMutableArray array];
+        for (NSString *fileName in MutableDictionaryFileNames())
+        {
+            NSURL *original = [dataDirectory URLByAppendingPathComponent:fileName isDirectory:NO];
+            if ([fileManager fileExistsAtPath:original.path])
+            {
+                [originalFileNames addObject:fileName];
+            }
+        }
+        if (!WriteResetMarker(dataDirectory, identifier, MetasequoiaResetPreparedPhase,
+                              originalFileNames, error))
+        {
+            [fileManager removeItemAtURL:temporaryDictionary error:nil];
+            [fileManager removeItemAtURL:temporaryFingerprint error:nil];
+            return NO;
+        }
+
+        for (NSString *fileName in originalFileNames)
+        {
+            NSURL *original = [dataDirectory URLByAppendingPathComponent:fileName isDirectory:NO];
+            NSURL *backup = [dataDirectory URLByAppendingPathComponent:ResetBackupName(fileName, identifier)
+                                                           isDirectory:NO];
+            if (![fileManager moveItemAtURL:original toURL:backup error:error])
+            {
+                NSError *operationError = error == nullptr ? nil : *error;
+                NSError *recoveryError = nil;
+                if (!RecoverLearningReset(fileManager, dataDirectory, &recoveryError))
+                {
+                    return Fail(error, 8,
+                                [NSString stringWithFormat:@"The learned-data reset failed and rollback could not finish: %@",
+                                                           recoveryError.localizedDescription]);
+                }
+                if (error != nullptr)
+                {
+                    *error = operationError;
+                }
+                return NO;
+            }
+        }
+
+        if (!SyncURL(dataDirectory, YES, error))
+        {
+            NSError *operationError = error == nullptr ? nil : *error;
+            NSError *recoveryError = nil;
+            if (!RecoverLearningReset(fileManager, dataDirectory, &recoveryError))
+            {
+                return Fail(error, 8,
+                            [NSString stringWithFormat:@"The learned-data reset failed and rollback could not finish: %@",
+                                                       recoveryError.localizedDescription]);
+            }
+            if (error != nullptr)
+            {
+                *error = operationError;
+            }
+            return NO;
+        }
+        if (!WriteResetMarker(dataDirectory, identifier, MetasequoiaResetBackedUpPhase,
+                              originalFileNames, error))
+        {
+            NSError *operationError = error == nullptr ? nil : *error;
+            NSError *recoveryError = nil;
+            if (!RecoverLearningReset(fileManager, dataDirectory, &recoveryError))
+            {
+                return Fail(error, 8,
+                            [NSString stringWithFormat:@"The learned-data reset failed and rollback could not finish: %@",
+                                                       recoveryError.localizedDescription]);
+            }
+            if (error != nullptr)
+            {
+                *error = operationError;
+            }
+            return NO;
+        }
+
+        NSURL *destination = [dataDirectory URLByAppendingPathComponent:@"msime.db" isDirectory:NO];
+        NSURL *fingerprintFile = [dataDirectory URLByAppendingPathComponent:@"msime.db.sha256" isDirectory:NO];
+        if (![fileManager moveItemAtURL:temporaryDictionary toURL:destination error:error] ||
+            ![fileManager moveItemAtURL:temporaryFingerprint toURL:fingerprintFile error:error] ||
+            !SyncURL(destination, NO, error) || !SyncURL(fingerprintFile, NO, error) ||
+            !SyncURL(dataDirectory, YES, error))
+        {
+            NSError *operationError = error == nullptr ? nil : *error;
+            NSError *recoveryError = nil;
+            if (!RecoverLearningReset(fileManager, dataDirectory, &recoveryError))
+            {
+                return Fail(error, 8,
+                            [NSString stringWithFormat:@"The learned-data reset failed and rollback could not finish: %@",
+                                                       recoveryError.localizedDescription]);
+            }
+            if (error != nullptr)
+            {
+                *error = operationError;
+            }
+            return NO;
+        }
+
+        if (!WriteResetMarker(dataDirectory, identifier, MetasequoiaResetCommittedPhase,
+                              originalFileNames, error))
+        {
+            NSError *operationError = error == nullptr ? nil : *error;
+            NSError *recoveryError = nil;
+            if (!RecoverLearningReset(fileManager, dataDirectory, &recoveryError))
+            {
+                return Fail(error, 8,
+                            [NSString stringWithFormat:@"The learned-data reset failed and rollback could not finish: %@",
+                                                       recoveryError.localizedDescription]);
+            }
+            if (error != nullptr)
+            {
+                *error = operationError;
+            }
+            return NO;
+        }
+
+        NSError *cleanupError = nil;
+        if (!RecoverLearningReset(fileManager, dataDirectory, &cleanupError))
+        {
+            NSLog(@"Learned-data reset committed; deferred cleanup remains pending (%@:%ld).",
+                  cleanupError.domain, static_cast<long>(cleanupError.code));
+        }
+        return YES;
+    }
+}
+
 BOOL PrepareMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString *dictionaryFingerprint,
                                   NSError **error)
 {
+    if (dataDirectory == nil)
+    {
+        return Fail(error, 1, @"The bundled dictionary metadata is incomplete.");
+    }
+    @synchronized([NSFileManager class])
+    {
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        if (![fileManager createDirectoryAtURL:dataDirectory
+                    withIntermediateDirectories:YES
+                                     attributes:nil
+                                          error:error] ||
+            !RecoverLearningReset(fileManager, dataDirectory, error))
+        {
+            return NO;
+        }
+    }
+
     NSError *installError = nil;
     if (InstallMetasequoiaDictionary(source, dataDirectory, dictionaryFingerprint, &installError))
     {

--- a/tests/DictionaryInstallerTests.mm
+++ b/tests/DictionaryInstallerTests.mm
@@ -4,6 +4,7 @@
 
 #include <sqlite3.h>
 
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 
@@ -60,6 +61,49 @@ std::int64_t ReadWeight(NSURL *url, const char *word)
     sqlite3_finalize(statement);
     sqlite3_close(database);
     return weight;
+}
+
+bool ContainsUserDictionaryOperation(NSURL *url, const char *value)
+{
+    sqlite3 *database = nullptr;
+    Require(sqlite3_open_v2(url.fileSystemRepresentation, &database, SQLITE_OPEN_READONLY, nullptr) == SQLITE_OK,
+            "Failed to open the user dictionary journal.");
+    sqlite3_stmt *statement = nullptr;
+    Require(sqlite3_prepare_v2(database,
+                               "SELECT 1 FROM user_dictionary_operations WHERE value=?1 LIMIT 1",
+                               -1, &statement, nullptr) == SQLITE_OK,
+            "Failed to prepare the user dictionary journal query.");
+    Require(sqlite3_bind_text(statement, 1, value, -1, SQLITE_TRANSIENT) == SQLITE_OK,
+            "Failed to bind the user dictionary journal query.");
+    const bool found = sqlite3_step(statement) == SQLITE_ROW;
+    sqlite3_finalize(statement);
+    sqlite3_close(database);
+    return found;
+}
+
+void WriteResetMarker(NSURL *directory, NSString *identifier, NSString *phase,
+                      NSArray<NSString *> *originalFileNames)
+{
+    NSDictionary *marker = @{
+        @"version": @1,
+        @"identifier": identifier,
+        @"phase": phase,
+        @"originalFileNames": originalFileNames,
+    };
+    NSError *error = nil;
+    NSData *data = [NSPropertyListSerialization dataWithPropertyList:marker
+                                                               format:NSPropertyListBinaryFormat_v1_0
+                                                              options:0
+                                                                error:&error];
+    Require(data != nil, error.localizedDescription.UTF8String);
+    NSURL *markerURL = [directory URLByAppendingPathComponent:@".metasequoia-learning-reset.plist"];
+    Require([data writeToURL:markerURL options:0 error:&error], error.localizedDescription.UTF8String);
+}
+
+NSURL *ResetBackup(NSURL *directory, NSString *fileName, NSString *identifier)
+{
+    return [directory URLByAppendingPathComponent:
+                          [NSString stringWithFormat:@".%@.reset-backup.%@", fileName, identifier]];
 }
 
 NSURL *CreateDirectory(NSURL *root, NSString *name)
@@ -124,6 +168,274 @@ int main()
                 error.localizedDescription.UTF8String);
         Require(ReadWeight(replayDestination, "拟好") == 999,
                 "The user dictionary journal was not replayed onto the upgraded dictionary.");
+
+        NSURL *resetDirectory = CreateDirectory(root, @"reset-learning");
+        NSURL *resetSource = [root URLByAppendingPathComponent:@"reset-source.db"];
+        NSURL *resetDestination = [resetDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(resetSource,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','你好',200);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',100);");
+        ExecuteSql(resetDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','你好',200);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',999);");
+        WriteString(@"old-fingerprint", [resetDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        Require(setenv("METASEQUOIA_IME_DATA_DIR", resetDirectory.fileSystemRepresentation, 1) == 0,
+                "Failed to set the reset test data directory.");
+        const std::string resetUserDatabase = user_dictionary::default_user_db_path();
+        Require(user_dictionary::record_upsert(resetUserDatabase, user_dictionary::DictionaryKind::Pinyin,
+                                               "ni'hao", "旧学习", 999),
+                "Failed to keep the default user database open before reset.");
+        WriteString(@"journal-wal", [resetDirectory URLByAppendingPathComponent:@"msime_user.db-wal"]);
+        WriteString(@"journal-rollback", [resetDirectory URLByAppendingPathComponent:@"msime_user.db-journal"]);
+        WriteString(@"english", [resetDirectory URLByAppendingPathComponent:@"msime_english.db"]);
+        WriteString(@"decoder-learning", [resetDirectory URLByAppendingPathComponent:@"user_dict.dat"]);
+        error = nil;
+        Require(ResetMetasequoiaLearnedData(resetSource, resetDirectory, @"reset-fingerprint", &error),
+                error.localizedDescription.UTF8String);
+        Require(ReadWeight(resetDestination, "拟好") == 100,
+                "Resetting learned data did not restore the bundled candidate weight.");
+        Require(ReadString([resetDirectory URLByAppendingPathComponent:@"msime.db.sha256"]) ==
+                    "reset-fingerprint",
+                "Resetting learned data did not install the bundled dictionary fingerprint.");
+        for (NSString *learnedFile in @[@"msime_user.db", @"msime_user.db-wal", @"msime_user.db-journal",
+                                        @"msime_english.db", @"user_dict.dat"])
+        {
+            Require(![fileManager fileExistsAtPath:[resetDirectory URLByAppendingPathComponent:learnedFile].path],
+                    "Resetting learned data left a learned-data file behind.");
+        }
+        Require(user_dictionary::record_upsert(user_dictionary::default_user_db_path(),
+                                               user_dictionary::DictionaryKind::Pinyin,
+                                               "ni'hao", "重新学习", 200),
+                "The default user database did not reopen after reset.");
+        user_dictionary::close_default_user_database();
+        NSURL *reopenedUserDatabase = [resetDirectory URLByAppendingPathComponent:@"msime_user.db"];
+        Require(ContainsUserDictionaryOperation(reopenedUserDatabase, "重新学习") &&
+                    !ContainsUserDictionaryOperation(reopenedUserDatabase, "旧学习"),
+                "Learning after reset used the database handle from before reset.");
+        NSArray<NSURL *> *remainingFiles = [fileManager contentsOfDirectoryAtURL:resetDirectory
+                                                       includingPropertiesForKeys:nil
+                                                                          options:0
+                                                                            error:&error];
+        Require(remainingFiles != nil, error.localizedDescription.UTF8String);
+        for (NSURL *remainingFile in remainingFiles)
+        {
+            Require([remainingFile.lastPathComponent rangeOfString:@"reset-backup"].location == NSNotFound &&
+                        [remainingFile.lastPathComponent rangeOfString:@"resetting"].location == NSNotFound,
+                    "Resetting learned data left a temporary or backup file behind.");
+        }
+
+        NSString *preparedIdentifier = @"1516EAA2-7229-44D3-90F5-930475E184E3";
+        NSURL *preparedDirectory = CreateDirectory(root, @"reset-learning-prepared-recovery");
+        NSURL *preparedDestination = [preparedDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(preparedDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',100);");
+        ExecuteSql(ResetBackup(preparedDirectory, @"msime.db", preparedIdentifier),
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',555);");
+        WriteString(@"new-fingerprint", [preparedDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        WriteString(@"prepared-old", ResetBackup(preparedDirectory, @"msime.db.sha256", preparedIdentifier));
+        WriteString(@"old-journal", ResetBackup(preparedDirectory, @"msime_user.db", preparedIdentifier));
+        WriteString(@"temporary",
+                    [preparedDirectory URLByAppendingPathComponent:
+                                           [@".msime.db.resetting." stringByAppendingString:preparedIdentifier]]);
+        WriteResetMarker(preparedDirectory, preparedIdentifier, @"prepared",
+                         @[@"msime.db", @"msime.db.sha256", @"msime_user.db"]);
+        error = nil;
+        Require(PrepareMetasequoiaDictionary(resetSource, preparedDirectory, @"prepared-old", &error),
+                error.localizedDescription.UTF8String);
+        Require(ReadWeight(preparedDestination, "拟好") == 555 &&
+                    ReadString([preparedDirectory URLByAppendingPathComponent:@"msime_user.db"]) == "old-journal",
+                "Startup recovery did not roll back an interrupted prepared reset.");
+        Require(![fileManager fileExistsAtPath:
+                                  [preparedDirectory URLByAppendingPathComponent:@".metasequoia-learning-reset.plist"].path] &&
+                    ![fileManager fileExistsAtPath:ResetBackup(preparedDirectory, @"msime.db", preparedIdentifier).path],
+                "Prepared reset recovery left transaction artifacts behind.");
+
+        NSString *missingBackupIdentifier = @"85DF9BC5-E4DF-4EC1-A84F-FCB50E8E029C";
+        NSURL *missingBackupDirectory = CreateDirectory(root, @"reset-learning-missing-durable-backup");
+        NSURL *missingBackupDestination = [missingBackupDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(missingBackupDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',600);");
+        WriteString(@"new-before-crash",
+                    [missingBackupDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        WriteResetMarker(missingBackupDirectory, missingBackupIdentifier, @"backed-up",
+                         @[@"msime.db", @"msime.db.sha256"]);
+        error = nil;
+        Require(!PrepareMetasequoiaDictionary(resetSource, missingBackupDirectory,
+                                              @"new-before-crash", &error),
+                "Recovery accepted a post-backup reset whose durable backup was missing.");
+        Require(error != nil && ReadWeight(missingBackupDestination, "拟好") == 600 &&
+                    [fileManager fileExistsAtPath:
+                                     [missingBackupDirectory URLByAppendingPathComponent:@".metasequoia-learning-reset.plist"].path],
+                "Missing-backup recovery modified data or discarded its recovery marker.");
+
+        NSString *partialRollbackIdentifier = @"6102874A-C0DC-4F89-825A-6303C797841C";
+        NSURL *partialRollbackDirectory = CreateDirectory(root, @"reset-learning-partial-rollback");
+        NSURL *partialRollbackDestination = [partialRollbackDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(partialRollbackDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',650);");
+        WriteString(@"new-fingerprint",
+                    [partialRollbackDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        WriteString(@"partial-old",
+                    ResetBackup(partialRollbackDirectory, @"msime.db.sha256", partialRollbackIdentifier));
+        WriteString(@"partial-journal",
+                    ResetBackup(partialRollbackDirectory, @"msime_user.db", partialRollbackIdentifier));
+        WriteResetMarker(partialRollbackDirectory, partialRollbackIdentifier, @"rolling-back",
+                         @[@"msime.db", @"msime.db.sha256", @"msime_user.db"]);
+        error = nil;
+        Require(PrepareMetasequoiaDictionary(resetSource, partialRollbackDirectory, @"partial-old", &error),
+                error.localizedDescription.UTF8String);
+        Require(ReadWeight(partialRollbackDestination, "拟好") == 650 &&
+                    ReadString([partialRollbackDirectory URLByAppendingPathComponent:@"msime_user.db"]) ==
+                        "partial-journal" &&
+                    ![fileManager fileExistsAtPath:
+                                      [partialRollbackDirectory URLByAppendingPathComponent:
+                                                                    @".metasequoia-learning-reset.plist"].path],
+                "A partially completed rollback could not resume idempotently.");
+
+        NSString *committedIdentifier = @"E2E812BF-E105-4FC4-A15D-340C2A49B09B";
+        NSURL *committedDirectory = CreateDirectory(root, @"reset-learning-committed-recovery");
+        NSURL *committedDestination = [committedDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(committedDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',100);");
+        ExecuteSql(ResetBackup(committedDirectory, @"msime.db", committedIdentifier),
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',666);");
+        WriteString(@"committed-new", [committedDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        WriteString(@"committed-old", ResetBackup(committedDirectory, @"msime.db.sha256", committedIdentifier));
+        WriteString(@"old-journal", ResetBackup(committedDirectory, @"msime_user.db", committedIdentifier));
+        WriteResetMarker(committedDirectory, committedIdentifier, @"committed",
+                         @[@"msime.db", @"msime.db.sha256", @"msime_user.db"]);
+        error = nil;
+        Require(PrepareMetasequoiaDictionary(resetSource, committedDirectory, @"committed-new", &error),
+                error.localizedDescription.UTF8String);
+        Require(ReadWeight(committedDestination, "拟好") == 100 &&
+                    ![fileManager fileExistsAtPath:[committedDirectory URLByAppendingPathComponent:@"msime_user.db"].path],
+                "Startup recovery did not finish cleanup for a committed reset.");
+        Require(![fileManager fileExistsAtPath:
+                                  [committedDirectory URLByAppendingPathComponent:@".metasequoia-learning-reset.plist"].path] &&
+                    ![fileManager fileExistsAtPath:ResetBackup(committedDirectory, @"msime.db", committedIdentifier).path],
+                "Committed reset recovery left transaction artifacts behind.");
+
+        NSString *retryIdentifier = @"80557816-5344-46AA-A085-01CBB6382E20";
+        NSURL *retryDirectory = CreateDirectory(root, @"reset-learning-cleanup-retry");
+        NSURL *retryDestination = [retryDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(retryDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',700);");
+        WriteString(@"retry-current", [retryDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        NSURL *retryBackup = ResetBackup(retryDirectory, @"msime_user.db", retryIdentifier);
+        WriteString(@"deferred-cleanup", retryBackup);
+        Require([fileManager setAttributes:@{NSFileImmutable: @YES}
+                                    ofItemAtPath:retryBackup.path
+                                           error:&error],
+                error.localizedDescription.UTF8String);
+        WriteResetMarker(retryDirectory, retryIdentifier, @"committed", @[@"msime_user.db"]);
+        error = nil;
+        Require(!PrepareMetasequoiaDictionary(resetSource, retryDirectory, @"retry-current", &error),
+                "Committed reset cleanup unexpectedly removed an immutable backup.");
+        Require(error != nil && [fileManager fileExistsAtPath:retryBackup.path] &&
+                    [fileManager fileExistsAtPath:
+                                     [retryDirectory URLByAppendingPathComponent:@".metasequoia-learning-reset.plist"].path],
+                "Failed committed cleanup did not retain enough state to retry.");
+        Require([fileManager setAttributes:@{NSFileImmutable: @NO}
+                                    ofItemAtPath:retryBackup.path
+                                           error:&error],
+                error.localizedDescription.UTF8String);
+        error = nil;
+        Require(PrepareMetasequoiaDictionary(resetSource, retryDirectory, @"retry-current", &error),
+                error.localizedDescription.UTF8String);
+        Require(ReadWeight(retryDestination, "拟好") == 700 &&
+                    ![fileManager fileExistsAtPath:retryBackup.path] &&
+                    ![fileManager fileExistsAtPath:
+                                      [retryDirectory URLByAppendingPathComponent:@".metasequoia-learning-reset.plist"].path],
+                "Startup recovery did not retry deferred committed cleanup.");
+
+        NSURL *orphanDirectory = CreateDirectory(root, @"reset-learning-orphan-cleanup");
+        NSURL *orphanDestination = [orphanDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(orphanDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',777);");
+        WriteString(@"orphan-current", [orphanDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        NSURL *orphanTemporary =
+            [orphanDirectory URLByAppendingPathComponent:@".msime.db.resetting.65DB8CE4-0550-4D9B-BB94-AE347215465A"];
+        WriteString(@"orphan", orphanTemporary);
+        error = nil;
+        Require(PrepareMetasequoiaDictionary(resetSource, orphanDirectory, @"orphan-current", &error),
+                error.localizedDescription.UTF8String);
+        Require(ReadWeight(orphanDestination, "拟好") == 777 &&
+                    ![fileManager fileExistsAtPath:orphanTemporary.path],
+                "Startup recovery did not remove an orphaned pre-transaction temporary file.");
+
+        NSURL *invalidMarkerDirectory = CreateDirectory(root, @"reset-learning-invalid-marker");
+        NSURL *invalidMarkerDestination = [invalidMarkerDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(invalidMarkerDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',888);");
+        WriteString(@"invalid-marker-current",
+                    [invalidMarkerDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        WriteString(@"not-a-property-list",
+                    [invalidMarkerDirectory URLByAppendingPathComponent:@".metasequoia-learning-reset.plist"]);
+        error = nil;
+        Require(!PrepareMetasequoiaDictionary(resetSource, invalidMarkerDirectory,
+                                              @"invalid-marker-current", &error),
+                "A corrupt reset marker was ignored during startup recovery.");
+        Require(error != nil && ReadWeight(invalidMarkerDestination, "拟好") == 888,
+                "A corrupt reset marker changed the working dictionary.");
+
+        NSURL *resetFailureDirectory = CreateDirectory(root, @"reset-learning-failure");
+        NSURL *resetFailureDestination = [resetFailureDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(resetFailureDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',321);");
+        NSURL *resetFailureJournal = [resetFailureDirectory URLByAppendingPathComponent:@"msime_user.db"];
+        WriteString(@"keep-journal", resetFailureJournal);
+        NSURL *resetFailureFingerprint =
+            [resetFailureDirectory URLByAppendingPathComponent:@"msime.db.sha256"];
+        WriteString(@"keep-fingerprint", resetFailureFingerprint);
+        NSURL *invalidResetSource = [root URLByAppendingPathComponent:@"invalid-reset-source.db"];
+        WriteString(@"not-a-dictionary", invalidResetSource);
+        error = nil;
+        Require(!ResetMetasequoiaLearnedData(invalidResetSource, resetFailureDirectory, @"new-fingerprint",
+                                             &error),
+                "A corrupt bundled dictionary unexpectedly reset learned data.");
+        Require(error != nil, "A rejected learned-data reset did not return an error.");
+        Require(ReadWeight(resetFailureDestination, "拟好") == 321,
+                "A failed learned-data reset changed the working dictionary.");
+        Require(ReadString(resetFailureJournal) == "keep-journal" &&
+                    ReadString(resetFailureFingerprint) == "keep-fingerprint",
+                "A failed learned-data reset removed persistent learning metadata.");
+
+        NSURL *rollbackDirectory = CreateDirectory(root, @"reset-learning-rollback");
+        NSURL *rollbackDestination = [rollbackDirectory URLByAppendingPathComponent:@"msime.db"];
+        ExecuteSql(rollbackDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',444);");
+        NSURL *rollbackFingerprint = [rollbackDirectory URLByAppendingPathComponent:@"msime.db.sha256"];
+        WriteString(@"rollback-fingerprint", rollbackFingerprint);
+        NSURL *immutableJournal = [rollbackDirectory URLByAppendingPathComponent:@"msime_user.db"];
+        WriteString(@"immutable-journal", immutableJournal);
+        Require([fileManager setAttributes:@{NSFileImmutable: @YES}
+                                    ofItemAtPath:immutableJournal.path
+                                           error:&error],
+                error.localizedDescription.UTF8String);
+        error = nil;
+        Require(!ResetMetasequoiaLearnedData(resetSource, rollbackDirectory, @"new-fingerprint", &error),
+                "A learned-data reset unexpectedly ignored an immutable journal.");
+        Require([fileManager setAttributes:@{NSFileImmutable: @NO}
+                                    ofItemAtPath:immutableJournal.path
+                                           error:&error],
+                error.localizedDescription.UTF8String);
+        Require(ReadWeight(rollbackDestination, "拟好") == 444 &&
+                    ReadString(rollbackFingerprint) == "rollback-fingerprint" &&
+                    ReadString(immutableJournal) == "immutable-journal",
+                "A mid-reset failure did not roll back the working dictionary and learning metadata.");
 
         NSURL *failureDirectory = CreateDirectory(root, @"failure");
         NSURL *failureDestination = [failureDirectory URLByAppendingPathComponent:@"msime.db"];


### PR DESCRIPTION
## Summary
- add a quiesced learned-data reset that restores the bundled dictionary and removes all user-learning stores
- close persistent SQLite and Google Pinyin decoder handles before replacing files
- make reset crash- and power-loss-safe with F_FULLFSYNC barriers plus prepared, backed-up, rolling-back, and committed recovery phases
- recover interrupted transactions on dictionary preparation and reject corrupt or incomplete durable state
- update the Engine submodule to the merged lifecycle API from houko/MetasequoiaImeEngine#1

## Verification
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure` (11/11)
- `codesign --verify --deep --strict --verbose=2 build/MetasequoiaIME.app`
- independent review: no Critical/Important findings

## Scope
This PR provides the safe reset core only. Input-session coordination and the confirmation UI will follow in a separate PR.