### PR TITLE
fix(release): publish unsigned fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,21 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Validate release credentials
+      - name: Check out trusted release automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .release-automation
+          sparse-checkout: |
+            scripts/detect-release-signing.sh
+            scripts/publish-release.sh
+          persist-credentials: false
+      - name: Stage trusted release automation
+        run: |
+          install -m 0755 .release-automation/scripts/detect-release-signing.sh "$RUNNER_TEMP/detect-release-signing.sh"
+          install -m 0755 .release-automation/scripts/publish-release.sh "$RUNNER_TEMP/publish-release.sh"
+      - name: Determine release signing mode
+        id: signing
         env:
           MACOS_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_BASE64 }}
           MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
@@ -92,35 +106,27 @@ jobs:
           MACOS_NOTARY_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARY_APP_SPECIFIC_PASSWORD }}
           MACOS_DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
           MACOS_DEVELOPER_ID_INSTALLER: ${{ secrets.MACOS_DEVELOPER_ID_INSTALLER }}
-        run: |
-          set -euo pipefail
-          required_secrets=(
-            MACOS_DEVELOPER_ID_CERTIFICATE_BASE64
-            MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD
-            MACOS_SIGNING_KEYCHAIN_PASSWORD
-            MACOS_NOTARY_APPLE_ID
-            MACOS_NOTARY_TEAM_ID
-            MACOS_NOTARY_APP_SPECIFIC_PASSWORD
-            MACOS_DEVELOPER_ID_APPLICATION
-            MACOS_DEVELOPER_ID_INSTALLER
-          )
-          for required in "${required_secrets[@]}"; do
-            if [[ -z "${!required}" ]]; then
-              echo "Missing required GitHub Actions secret: $required" >&2
-              exit 1
-            fi
-          done
+        run: exec "$RUNNER_TEMP/detect-release-signing.sh"
       - name: Check out release tag
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.prepare.outputs.tag_name }}
           submodules: recursive
+          fetch-depth: 0
           persist-credentials: false
+      - name: Verify release tag provenance
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor HEAD refs/remotes/origin/main; then
+            echo "Release tag must point to a commit in main history." >&2
+            exit 1
+          fi
       - name: Remove unused runner taps
         run: if brew tap | grep -Fxq aws/tap; then brew untap aws/tap; fi
       - name: Install dependencies
         run: brew install boost fmt spdlog
       - name: Import Developer ID signing certificates
+        if: ${{ steps.signing.outputs.signing_enabled == 'true' }}
         env:
           CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
@@ -158,17 +164,17 @@ jobs:
       - name: Package release
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
-          METASEQUOIA_REQUIRE_RELEASE_SIGNING: true
+          METASEQUOIA_REQUIRE_RELEASE_SIGNING: ${{ steps.signing.outputs.signing_enabled }}
           METASEQUOIA_DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
           METASEQUOIA_DEVELOPER_ID_INSTALLER: ${{ secrets.MACOS_DEVELOPER_ID_INSTALLER }}
-          METASEQUOIA_NOTARY_PROFILE: metasequoia-notary
+          METASEQUOIA_NOTARY_PROFILE: ${{ steps.signing.outputs.signing_enabled == 'true' && 'metasequoia-notary' || '' }}
+          METASEQUOIA_RELEASE_ASSET_SUFFIX: ${{ steps.signing.outputs.asset_suffix }}
         run: scripts/package_release.sh "$TAG_NAME" build/MetasequoiaIME.app dist
       - name: Upload and publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
-        run: |
-          archive="dist/MetasequoiaIME-$TAG_NAME-macos-universal.zip"
-          installer="dist/MetasequoiaIME-$TAG_NAME-macos-universal.pkg"
-          gh release upload "$TAG_NAME" "$installer" "$installer.sha256" "$archive" "$archive.sha256" --clobber
-          gh release edit "$TAG_NAME" --draft=false
+          ASSET_SUFFIX: ${{ steps.signing.outputs.asset_suffix }}
+          SIGNING_ENABLED: ${{ steps.signing.outputs.signing_enabled }}
+        run: exec "$RUNNER_TEMP/publish-release.sh"

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ Merges to `main` update a Release Please pull request from conventional commit h
 - `MetasequoiaIME-vX.Y.Z-macos-universal.zip`
 - `MetasequoiaIME-vX.Y.Z-macos-universal.zip.sha256`
 
+When Apple release credentials are not configured, the workflow publishes the same four assets with `-unsigned` before the file extension and adds a warning to the GitHub Release. Unsigned artifacts are intended for testing and may require explicit approval in macOS privacy and security settings.
+
 Download the `.pkg` and its checksum, verify it, then double-click the package to open the native macOS Installer. The package installs the current user's copy in `~/Library/Input Methods` and does not require administrator privileges. Log out after installation so macOS refreshes its input source cache.
 
 ```sh
 shasum -a 256 -c MetasequoiaIME-vX.Y.Z-macos-universal.pkg.sha256
 ```
 
-Release builds are signed with a Developer ID Application identity, signed as an installer with a Developer ID Installer identity, and notarized before publication. The release workflow requires these repository secrets and fails before downloading build dependencies when any are missing:
+When all of the following repository secrets are configured, release builds are signed with a Developer ID Application identity, signed as an installer with a Developer ID Installer identity, and notarized before publication. With none configured, the workflow publishes clearly labeled unsigned artifacts. A partial configuration fails before downloading build dependencies so it cannot produce ambiguously labeled assets.
 
 - `MACOS_DEVELOPER_ID_CERTIFICATE_BASE64`
 - `MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD`

--- a/scripts/detect-release-signing.sh
+++ b/scripts/detect-release-signing.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"
+
+required_secrets=(
+    MACOS_DEVELOPER_ID_CERTIFICATE_BASE64
+    MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD
+    MACOS_SIGNING_KEYCHAIN_PASSWORD
+    MACOS_NOTARY_APPLE_ID
+    MACOS_NOTARY_TEAM_ID
+    MACOS_NOTARY_APP_SPECIFIC_PASSWORD
+    MACOS_DEVELOPER_ID_APPLICATION
+    MACOS_DEVELOPER_ID_INSTALLER
+)
+
+configured_count=0
+missing_secrets=()
+for required in "${required_secrets[@]}"; do
+    if [[ -n "${!required:-}" ]]; then
+        configured_count=$((configured_count + 1))
+    else
+        missing_secrets+=("$required")
+    fi
+done
+
+if ((configured_count == 0)); then
+    printf '%s\n' 'signing_enabled=false' 'asset_suffix=-unsigned' >> "$GITHUB_OUTPUT"
+    printf '%s\n' '### Release signing' '' 'Apple signing credentials are not configured. Publishing clearly labeled **unsigned** artifacts.' >> "$GITHUB_STEP_SUMMARY"
+    exit 0
+fi
+
+if ((configured_count != ${#required_secrets[@]})); then
+    printf '%s\n' 'Release signing is partially configured; refusing to publish ambiguous artifacts.' >&2
+    printf 'Missing GitHub Actions secret: %s\n' "${missing_secrets[@]}" >&2
+    exit 1
+fi
+
+printf '%s\n' 'signing_enabled=true' 'asset_suffix=' >> "$GITHUB_OUTPUT"
+printf '%s\n' '### Release signing' '' 'Publishing Developer ID signed and notarized artifacts.' >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 package_root=${0:A:h}
 source_bundle="$package_root/MetasequoiaIME.app"
+unsigned_marker="$package_root/UNSIGNED_BUILD.txt"
 destination_root="$HOME/Library/Input Methods"
 destination_bundle="$destination_root/MetasequoiaIME.app"
 
@@ -11,8 +12,28 @@ if [[ ! -d "$source_bundle" ]]; then
     exit 1
 fi
 
-codesign --verify --deep --strict --verbose=2 "$source_bundle"
-spctl --assess --type execute --verbose=2 "$source_bundle"
+unsigned_release=false
+if [[ -f "$unsigned_marker" ]]; then
+    unsigned_release=true
+    print -u2 "WARNING: This build is not Developer ID signed or notarized. macOS may block it until you explicitly allow it in Privacy & Security settings."
+    printf '%s' "Type I UNDERSTAND to install this unsigned build: "
+    confirmation=""
+    IFS= read -r confirmation || true
+    if [[ "$confirmation" != "I UNDERSTAND" ]]; then
+        print -u2 "Unsigned installation cancelled."
+        exit 1
+    fi
+fi
+
+verify_bundle() {
+    local bundle=$1
+    codesign --verify --deep --strict --verbose=2 "$bundle"
+    if [[ "$unsigned_release" != true ]]; then
+        spctl --assess --type execute --verbose=2 "$bundle"
+    fi
+}
+
+verify_bundle "$source_bundle"
 mkdir -p "$destination_root"
 staging_root=$(mktemp -d "$destination_root/.MetasequoiaIME.installing.XXXXXX")
 backup_root=$(mktemp -d "$destination_root/.MetasequoiaIME.backup.XXXXXX")
@@ -36,8 +57,7 @@ cleanup() {
 
 trap cleanup EXIT
 ditto "$source_bundle" "$staging_bundle"
-codesign --verify --deep --strict --verbose=2 "$staging_bundle"
-spctl --assess --type execute --verbose=2 "$staging_bundle"
+verify_bundle "$staging_bundle"
 pkill -x MetasequoiaIME 2>/dev/null || true
 if [[ -e "$destination_bundle" ]]; then
     mv "$destination_bundle" "$backup_bundle"
@@ -45,8 +65,10 @@ if [[ -e "$destination_bundle" ]]; then
 fi
 mv "$staging_bundle" "$destination_bundle"
 moved_new=true
-codesign --verify --deep --strict --verbose=2 "$destination_bundle"
-spctl --assess --type execute --verbose=2 "$destination_bundle"
+verify_bundle "$destination_bundle"
 install_complete=true
 print "Installed $destination_bundle"
+if [[ "$unsigned_release" == true ]]; then
+    print "If macOS blocks the input method, approve it in System Settings > Privacy & Security before enabling it."
+fi
 print "Log out and back in, then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit."

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -18,10 +18,29 @@ require_release_signing=${METASEQUOIA_REQUIRE_RELEASE_SIGNING:-false}
 application_identity=${METASEQUOIA_DEVELOPER_ID_APPLICATION:-}
 installer_identity=${METASEQUOIA_DEVELOPER_ID_INSTALLER:-}
 notary_profile=${METASEQUOIA_NOTARY_PROFILE:-}
+asset_suffix=${METASEQUOIA_RELEASE_ASSET_SUFFIX:-}
+
+if [[ "$require_release_signing" != true && "$require_release_signing" != false ]]; then
+    print -u2 "METASEQUOIA_REQUIRE_RELEASE_SIGNING must be true or false."
+    exit 1
+fi
 
 if [[ "$require_release_signing" == true ]]; then
     if [[ -z "$application_identity" || -z "$installer_identity" || -z "$notary_profile" ]]; then
         print -u2 "Commercial release signing requires METASEQUOIA_DEVELOPER_ID_APPLICATION, METASEQUOIA_DEVELOPER_ID_INSTALLER, and METASEQUOIA_NOTARY_PROFILE."
+        exit 1
+    fi
+    if [[ -n "$asset_suffix" ]]; then
+        print -u2 "Signed release artifacts must not use an asset suffix."
+        exit 1
+    fi
+else
+    if [[ "$asset_suffix" != -unsigned ]]; then
+        print -u2 "Unsigned release artifacts require METASEQUOIA_RELEASE_ASSET_SUFFIX=-unsigned."
+        exit 1
+    fi
+    if [[ -n "$application_identity" || -n "$installer_identity" || -n "$notary_profile" ]]; then
+        print -u2 "Unsigned release packaging does not accept signing identities or a notary profile."
         exit 1
     fi
 fi
@@ -45,9 +64,9 @@ mkdir -p "$output_dir"
 staging_root=$(mktemp -d "$output_dir/.package.XXXXXX")
 trap 'rm -rf "$staging_root"' EXIT
 package_root="$staging_root/MetasequoiaIME-$tag_name"
-archive_path="$output_dir/MetasequoiaIME-$tag_name-macos-universal.zip"
+archive_path="$output_dir/MetasequoiaIME-$tag_name-macos-universal$asset_suffix.zip"
 checksum_path="$archive_path.sha256"
-installer_path="$output_dir/MetasequoiaIME-$tag_name-macos-universal.pkg"
+installer_path="$output_dir/MetasequoiaIME-$tag_name-macos-universal$asset_suffix.pkg"
 installer_checksum_path="$installer_path.sha256"
 component_package="$staging_root/MetasequoiaIME.pkg"
 distribution_file="$staging_root/Distribution.xml"
@@ -58,6 +77,14 @@ ditto "$source_bundle" "$package_root/MetasequoiaIME.app"
 ditto "$project_root/scripts/install-release.sh" "$package_root/Install.command"
 ditto "$project_root/LICENSE" "$package_root/LICENSE"
 ditto "$project_root/THIRD_PARTY_NOTICES.txt" "$package_root/THIRD_PARTY_NOTICES.txt"
+if [[ "$asset_suffix" == -unsigned ]]; then
+    printf '%s\n' \
+        'UNSIGNED TEST BUILD' \
+        '' \
+        'This build is not Developer ID signed or notarized. macOS may block it until you explicitly allow it in System Settings > Privacy & Security.' \
+        'Install.command requires typed confirmation before installing this build.' \
+        > "$package_root/UNSIGNED_BUILD.txt"
+fi
 chmod +x "$package_root/Install.command"
 rm -f "$archive_path" "$checksum_path" "$installer_path" "$installer_checksum_path"
 if [[ -n "$notary_profile" ]]; then

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO is required}"
+: "${TAG_NAME:?TAG_NAME is required}"
+: "${SIGNING_ENABLED:?SIGNING_ENABLED is required}"
+if [[ ${ASSET_SUFFIX+x} != x ]]; then
+    printf '%s\n' "ASSET_SUFFIX is required." >&2
+    exit 1
+fi
+
+dist_dir=${DIST_DIR:-dist}
+case "$SIGNING_ENABLED:$ASSET_SUFFIX" in
+    true:)
+        release_mode=signed
+        opposite_mode=unsigned
+        ;;
+    false:-unsigned)
+        release_mode=unsigned
+        opposite_mode=signed
+        ;;
+    *)
+        printf '%s\n' "Release signing mode and asset suffix do not agree." >&2
+        exit 1
+        ;;
+esac
+
+if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    printf '%s\n' "Tag must use the vMAJOR.MINOR.PATCH format." >&2
+    exit 1
+fi
+
+mode_marker="<!-- metasequoia-release-mode:$release_mode -->"
+opposite_marker="<!-- metasequoia-release-mode:$opposite_mode -->"
+current_notes=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq '.body // ""')
+if [[ "$current_notes" == *"$opposite_marker"* ]]; then
+    printf '%s\n' "Release $TAG_NAME is already locked to $opposite_mode artifacts; refusing to switch it to $release_mode." >&2
+    exit 1
+fi
+
+if [[ "$current_notes" != *"$mode_marker"* ]]; then
+    release_notes=${RUNNER_TEMP:-${TMPDIR:-/tmp}}/metasequoia-release-notes.md
+    {
+        if [[ -n "$current_notes" ]]; then
+            printf '%s\n\n' "$current_notes"
+        fi
+        printf '%s\n' "$mode_marker"
+        if [[ "$release_mode" == unsigned ]]; then
+            printf '%s\n' '> [!WARNING] These macOS artifacts are not Developer ID signed or notarized because release signing credentials were not configured. The asset filenames are marked unsigned.'
+        fi
+    } > "$release_notes"
+    gh release edit "$TAG_NAME" --repo "$GH_REPO" --notes-file "$release_notes"
+fi
+
+archive="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.zip"
+installer="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.pkg"
+for artifact in "$installer" "$installer.sha256" "$archive" "$archive.sha256"; do
+    if [[ ! -f "$artifact" ]]; then
+        printf 'Release artifact is missing: %s\n' "$artifact" >&2
+        exit 1
+    fi
+done
+
+gh release upload "$TAG_NAME" --repo "$GH_REPO" "$installer" "$installer.sha256" "$archive" "$archive.sha256" --clobber
+gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false

--- a/tests/ReleaseAutomationTests.py
+++ b/tests/ReleaseAutomationTests.py
@@ -9,6 +9,16 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 BASE_SHA = "1" * 40
 HEAD_SHA = "2" * 40
+SIGNING_SECRETS = (
+    "MACOS_DEVELOPER_ID_CERTIFICATE_BASE64",
+    "MACOS_DEVELOPER_ID_CERTIFICATE_PASSWORD",
+    "MACOS_SIGNING_KEYCHAIN_PASSWORD",
+    "MACOS_NOTARY_APPLE_ID",
+    "MACOS_NOTARY_TEAM_ID",
+    "MACOS_NOTARY_APP_SPECIFIC_PASSWORD",
+    "MACOS_DEVELOPER_ID_APPLICATION",
+    "MACOS_DEVELOPER_ID_INSTALLER",
+)
 
 
 class ReleaseAutomationTests(unittest.TestCase):
@@ -94,6 +104,151 @@ fi
         self.assertIn("run watch 9001", calls)
         self.assertNotIn("pr merge 42", calls)
         self.assertEqual(output, "")
+
+
+class ReleaseSigningModeTests(unittest.TestCase):
+    def run_detection(self, configured_secrets=()):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            output = temporary / "github-output"
+            summary = temporary / "github-summary"
+            environment = os.environ.copy()
+            for secret in SIGNING_SECRETS:
+                environment.pop(secret, None)
+            environment.update({secret: "configured" for secret in configured_secrets})
+            environment["GITHUB_OUTPUT"] = str(output)
+            environment["GITHUB_STEP_SUMMARY"] = str(summary)
+            result = subprocess.run(
+                [PROJECT_ROOT / "scripts/detect-release-signing.sh"],
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            return (
+                result,
+                output.read_text() if output.exists() else "",
+                summary.read_text() if summary.exists() else "",
+            )
+
+    def test_missing_credentials_selects_clearly_labeled_unsigned_release(self):
+        result, output, summary = self.run_detection()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "signing_enabled=false\nasset_suffix=-unsigned\n")
+        self.assertIn("unsigned", summary.lower())
+
+    def test_complete_credentials_selects_signed_and_notarized_release(self):
+        result, output, summary = self.run_detection(SIGNING_SECRETS)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "signing_enabled=true\nasset_suffix=\n")
+        self.assertIn("signed and notarized", summary.lower())
+
+    def test_partial_credentials_fail_instead_of_publishing_ambiguous_artifacts(self):
+        result, output, summary = self.run_detection(SIGNING_SECRETS[:2])
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(output, "")
+        self.assertEqual(summary, "")
+        self.assertIn("partially configured", result.stderr)
+        self.assertIn("MACOS_DEVELOPER_ID_APPLICATION", result.stderr)
+
+
+class ReleasePublicationTests(unittest.TestCase):
+    def run_publication(self, signing_enabled, asset_suffix, existing_notes=""):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            fake_bin = temporary / "bin"
+            fake_bin.mkdir()
+            log = temporary / "gh.log"
+            captured_notes = temporary / "notes.md"
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                """#!/bin/bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_GH_LOG"
+if [[ "$1 $2" == "release view" ]]; then
+    printf '%s' "$FAKE_EXISTING_NOTES"
+elif [[ "$1 $2" == "release edit" && "$*" == *"--notes-file"* ]]; then
+    while (($#)); do
+        if [[ "$1" == "--notes-file" ]]; then
+            cp "$2" "$FAKE_CAPTURED_NOTES"
+            exit 0
+        fi
+        shift
+    done
+fi
+"""
+            )
+            fake_gh.chmod(0o755)
+            dist = temporary / "dist"
+            dist.mkdir()
+            stem = f"MetasequoiaIME-v1.2.3-macos-universal{asset_suffix}"
+            for extension in (".zip", ".zip.sha256", ".pkg", ".pkg.sha256"):
+                (dist / f"{stem}{extension}").touch()
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{fake_bin}:{environment['PATH']}",
+                    "GH_REPO": "houko/MetasequoiaImeMac",
+                    "TAG_NAME": "v1.2.3",
+                    "ASSET_SUFFIX": asset_suffix,
+                    "SIGNING_ENABLED": signing_enabled,
+                    "DIST_DIR": str(dist),
+                    "RUNNER_TEMP": str(temporary),
+                    "FAKE_GH_LOG": str(log),
+                    "FAKE_EXISTING_NOTES": existing_notes,
+                    "FAKE_CAPTURED_NOTES": str(captured_notes),
+                }
+            )
+            result = subprocess.run(
+                [PROJECT_ROOT / "scripts/publish-release.sh"],
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            return (
+                result,
+                log.read_text() if log.exists() else "",
+                captured_notes.read_text() if captured_notes.exists() else "",
+            )
+
+    def test_unsigned_publication_records_mode_before_uploading_labeled_assets(self):
+        result, calls, notes = self.run_publication("false", "-unsigned", "Existing notes")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("metasequoia-release-mode:unsigned", notes)
+        self.assertIn("not Developer ID signed or notarized", notes)
+        self.assertLess(calls.index("--notes-file"), calls.index("release upload"))
+        self.assertIn("macos-universal-unsigned.pkg", calls)
+        self.assertIn("--draft=false", calls)
+
+    def test_same_mode_retry_keeps_notes_and_reuploads_with_clobber(self):
+        marker = "Existing notes\n\n<!-- metasequoia-release-mode:unsigned -->\n"
+        result, calls, notes = self.run_publication("false", "-unsigned", marker)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("--notes-file", calls)
+        self.assertIn("--clobber", calls)
+        self.assertEqual(notes, "")
+
+    def test_cross_mode_retry_is_rejected_before_assets_change(self):
+        marker = "<!-- metasequoia-release-mode:unsigned -->"
+        result, calls, notes = self.run_publication("true", "", marker)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already locked to unsigned", result.stderr)
+        self.assertNotIn("release upload", calls)
+        self.assertNotIn("release edit", calls)
+        self.assertEqual(notes, "")
+
+    def test_signed_publication_records_signed_mode_without_unsigned_warning(self):
+        result, calls, notes = self.run_publication("true", "")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("metasequoia-release-mode:signed", notes)
+        self.assertNotIn("WARNING", notes)
+        self.assertIn("macos-universal.pkg", calls)
 
 
 if __name__ == "__main__":

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import subprocess
 import unittest
@@ -51,16 +52,29 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("--match-head-commit", merge_release_pr)
         self.assertTrue(merge_release_pr.startswith("#!/usr/bin/env bash\n"))
         self.assertIn("scripts/package_release.sh", workflow)
-        self.assertIn("macos-universal.pkg", workflow)
+        signing_detector = (PROJECT_ROOT / "scripts/detect-release-signing.sh").read_text()
+        release_publisher = (PROJECT_ROOT / "scripts/publish-release.sh").read_text()
+        self.assertIn("macos-universal$ASSET_SUFFIX.pkg", release_publisher)
+        self.assertIn("asset_suffix=-unsigned", signing_detector)
         self.assertIn("timeout-minutes: 30", workflow)
-        self.assertIn("gh release upload", workflow)
-        self.assertIn("gh release edit", workflow)
+        self.assertIn("gh release upload", release_publisher)
+        self.assertIn("gh release edit", release_publisher)
         self.assertIn("METASEQUOIA_REQUIRE_RELEASE_SIGNING", workflow)
+        self.assertIn("scripts/detect-release-signing.sh", workflow)
+        self.assertIn("steps.signing.outputs.signing_enabled", workflow)
+        self.assertIn("steps.signing.outputs.asset_suffix", workflow)
+        self.assertIn("metasequoia-release-mode", release_publisher)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertNotIn("ref: ${{ github.sha }}", workflow)
+        self.assertIn("$RUNNER_TEMP/detect-release-signing.sh", workflow)
+        self.assertIn("$RUNNER_TEMP/publish-release.sh", workflow)
+        self.assertIn("git merge-base --is-ancestor HEAD refs/remotes/origin/main", workflow)
+        self.assertLess(workflow.index("name: Determine release signing mode"), workflow.index("name: Check out release tag"))
+        self.assertLess(workflow.index("name: Verify release tag provenance"), workflow.index("name: Import Developer ID signing certificates"))
         self.assertIn("security import", workflow)
         self.assertIn("notarytool store-credentials", workflow)
-        self.assertIn("name: Validate release credentials", workflow)
-        self.assertLess(workflow.index("name: Validate release credentials"), workflow.index("name: Install dependencies"))
-        self.assertIn("Missing required GitHub Actions secret: $required", workflow)
+        self.assertIn("name: Determine release signing mode", workflow)
+        self.assertLess(workflow.index("name: Determine release signing mode"), workflow.index("name: Install dependencies"))
         self.assertIn("Developer ID Application", readme)
         self.assertIn("notarized", readme.lower())
         self.assertIn("全拼 or 小鹤双拼", readme)
@@ -174,6 +188,32 @@ class ReleaseConfigurationTests(unittest.TestCase):
             ["bash", "-n", str(PROJECT_ROOT / "scripts/merge-release-pr.sh")], capture_output=True, text=True
         )
         self.assertEqual(result.returncode, 0, result.stderr)
+        for relative_path in ("scripts/detect-release-signing.sh", "scripts/publish-release.sh"):
+            result = subprocess.run(
+                ["bash", "-n", str(PROJECT_ROOT / relative_path)], capture_output=True, text=True
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_package_script_refuses_ambiguously_named_unsigned_assets(self):
+        environment = os.environ.copy()
+        for variable in (
+            "METASEQUOIA_REQUIRE_RELEASE_SIGNING",
+            "METASEQUOIA_DEVELOPER_ID_APPLICATION",
+            "METASEQUOIA_DEVELOPER_ID_INSTALLER",
+            "METASEQUOIA_NOTARY_PROFILE",
+            "METASEQUOIA_RELEASE_ASSET_SUFFIX",
+        ):
+            environment.pop(variable, None)
+
+        result = subprocess.run(
+            [PROJECT_ROOT / "scripts/package_release.sh", "v1.2.3"],
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("require METASEQUOIA_RELEASE_ASSET_SUFFIX=-unsigned", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/ReleasePackageTests.py
+++ b/tests/ReleasePackageTests.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import plistlib
 import subprocess
 import sys
@@ -10,6 +11,12 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SIGNING_ENVIRONMENT = (
+    "METASEQUOIA_REQUIRE_RELEASE_SIGNING",
+    "METASEQUOIA_DEVELOPER_ID_APPLICATION",
+    "METASEQUOIA_DEVELOPER_ID_INSTALLER",
+    "METASEQUOIA_NOTARY_PROFILE",
+)
 
 
 def sha256_file(path):
@@ -72,8 +79,16 @@ class ReleasePackageTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             output = Path(temporary_directory) / "output"
-            subprocess.run([PROJECT_ROOT / "scripts/package_release.sh", f"v{version}", bundle, output], check=True)
-            archive = output / f"MetasequoiaIME-v{version}-macos-universal.zip"
+            environment = os.environ.copy()
+            for variable in SIGNING_ENVIRONMENT:
+                environment.pop(variable, None)
+            environment["METASEQUOIA_RELEASE_ASSET_SUFFIX"] = "-unsigned"
+            subprocess.run(
+                [PROJECT_ROOT / "scripts/package_release.sh", f"v{version}", bundle, output],
+                check=True,
+                env=environment,
+            )
+            archive = output / f"MetasequoiaIME-v{version}-macos-universal-unsigned.zip"
             checksum = archive.with_suffix(f"{archive.suffix}.sha256")
             digest, filename = checksum.read_text().split()
             actual_digest = hashlib.sha256()
@@ -89,6 +104,7 @@ class ReleasePackageTests(unittest.TestCase):
                 package_root = f"MetasequoiaIME-v{version}/"
                 self.assertIn(f"{package_root}MetasequoiaIME.app/Contents/Info.plist", names)
                 self.assertIn(f"{package_root}Install.command", names)
+                self.assertIn(f"{package_root}UNSIGNED_BUILD.txt", names)
                 self.assertIn(f"{package_root}LICENSE", names)
                 self.assertIn(f"{package_root}THIRD_PARTY_NOTICES.txt", names)
                 self.assertIn(
@@ -100,9 +116,44 @@ class ReleasePackageTests(unittest.TestCase):
                 self.assertFalse(any(name.endswith("register_input_source.swift") for name in names))
                 install_command = release_zip.read(f"{package_root}Install.command").decode()
                 self.assertIn("spctl --assess --type execute", install_command)
+                self.assertIn("Type I UNDERSTAND", install_command)
                 self.assertNotIn("xattr", install_command)
 
-            installer_package = output / f"MetasequoiaIME-v{version}-macos-universal.pkg"
+                extracted = Path(temporary_directory) / "extracted"
+                subprocess.run(["ditto", "-x", "-k", archive, extracted], check=True)
+                fake_bin = Path(temporary_directory) / "bin"
+                fake_bin.mkdir()
+                fake_pkill = fake_bin / "pkill"
+                fake_pkill.write_text("#!/bin/sh\nexit 0\n")
+                fake_pkill.chmod(0o755)
+                test_home = Path(temporary_directory) / "home"
+                install_environment = os.environ.copy()
+                install_environment["HOME"] = str(test_home)
+                install_environment["PATH"] = f"{fake_bin}:{install_environment['PATH']}"
+                rejected_install = subprocess.run(
+                    ["zsh", extracted / package_root / "Install.command"],
+                    input="no\n",
+                    capture_output=True,
+                    text=True,
+                    env=install_environment,
+                )
+                self.assertNotEqual(rejected_install.returncode, 0)
+                self.assertIn("Unsigned installation cancelled", rejected_install.stderr)
+                self.assertFalse((test_home / "Library/Input Methods/MetasequoiaIME.app").exists())
+                install_result = subprocess.run(
+                    ["zsh", extracted / package_root / "Install.command"],
+                    input="I UNDERSTAND\n",
+                    capture_output=True,
+                    text=True,
+                    env=install_environment,
+                )
+                self.assertEqual(install_result.returncode, 0, install_result.stderr)
+                self.assertIn("not Developer ID signed or notarized", install_result.stderr)
+                self.assertTrue(
+                    (test_home / "Library/Input Methods/MetasequoiaIME.app/Contents/Info.plist").is_file()
+                )
+
+            installer_package = output / f"MetasequoiaIME-v{version}-macos-universal-unsigned.pkg"
             installer_checksum = installer_package.with_suffix(f"{installer_package.suffix}.sha256")
             self.assertTrue(installer_package.is_file())
             self.assertTrue(installer_checksum.is_file())


### PR DESCRIPTION
## Summary
- publish clearly labeled unsigned zip/pkg assets when no Apple signing secrets are configured
- retain signed and notarized releases when all credentials exist, and reject partial credential setup
- isolate secret-aware automation from release-tag code and verify release tag provenance
- make unsigned ZIP installation explicit and test safe retry/publication behavior

## Verification
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure --timeout 20 (11/11)
- actionlint .github/workflows/release.yml
- codesign --verify --deep --strict --verbose=2 build/MetasequoiaIME.app
- lipo ... -verify_arch arm64 x86_64
- independent review: no remaining Critical/Important after trusted ref fix