### PR TITLE
fix(input): stop swallowing rejected characters

### DIFF
--- a/src/InputSession.cpp
+++ b/src/InputSession.cpp
@@ -26,10 +26,11 @@ KeyResult InputSession::handle_character(char character)
         return {};
     }
 
+    const std::string previous_preedit = preedit();
     const auto unsigned_character = static_cast<unsigned char>(character);
     const ImeKeyCode key_code = character == '\'' ? ImeKey::Apostrophe : static_cast<ImeKeyCode>(std::toupper(unsigned_character));
     engine_.handle_key(key_code, 0, static_cast<ImeCharacter>(unsigned_character));
-    return {true, std::nullopt};
+    return {preedit() != previous_preedit, std::nullopt};
 }
 
 KeyResult InputSession::handle_candidate_key(char character)

--- a/tests/InputSessionTests.cpp
+++ b/tests/InputSessionTests.cpp
@@ -110,6 +110,29 @@ int main()
         require(!verify_unlearned_session.candidates().empty() && verify_unlearned_session.candidates().front().word == "不好",
                 "A selected candidate was learned while candidate learning was disabled.");
 
+        metasequoia::mac::InputSession wubi_session(SchemeType::Wubi);
+        require(!wubi_session.handle_character('z').handled && wubi_session.preedit().empty(),
+                "An unsupported Wubi letter was swallowed.");
+        type(wubi_session, "abcd");
+        require(!wubi_session.handle_character('e').handled && wubi_session.preedit() == "abcd",
+                "A Wubi letter beyond the four-code limit was swallowed.");
+        require(!wubi_session.handle_character('\'').handled && wubi_session.preedit() == "abcd",
+                "An unsupported Wubi apostrophe was swallowed.");
+
+        metasequoia::mac::InputSession shuangpin_character_session(SchemeType::Shuangpin);
+        require(shuangpin_character_session.handle_character('n').handled && shuangpin_character_session.preedit() == "n",
+                "A valid Shuangpin letter was rejected.");
+        metasequoia::mac::InputSession japanese_character_session(SchemeType::JapaneseRomaji);
+        require(japanese_character_session.handle_character('k').handled && japanese_character_session.preedit() == "k",
+                "A valid Japanese romaji letter was rejected.");
+        metasequoia::mac::InputSession duplicate_apostrophe_session;
+        type(duplicate_apostrophe_session, "ni");
+        require(duplicate_apostrophe_session.handle_character('\'').handled,
+                "The first Pinyin apostrophe was rejected.");
+        require(!duplicate_apostrophe_session.handle_character('\'').handled &&
+                    duplicate_apostrophe_session.preedit() == "ni'",
+                "A duplicate Pinyin apostrophe was swallowed.");
+
         metasequoia::mac::InputSession uppercase_session;
         require(!uppercase_session.handle_character('N').handled,
                 "An uppercase letter was swallowed while no composition was active.");


### PR DESCRIPTION
## Summary
- report character events as handled only when the active engine scheme accepts them
- let macOS receive unsupported Wubi keys and characters beyond the four-code limit after committing the current composition
- cover accepted and rejected character paths across Wubi, Quanpin, Shuangpin, and Japanese romaji

## Verification
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure` (12/12 passed)
- `cmake --build build --target MetasequoiaImeMacTests --parallel`
- `ctest --test-dir build -R "^input_session$" --output-on-failure`
- independent review: no Critical/Important findings