### PR TITLE
fix(release): preserve assets on packaging failure

### DIFF
--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -69,16 +69,58 @@ fi
 codesign --verify --deep --strict --verbose=2 "$source_bundle"
 mkdir -p "$output_dir"
 staging_root=$(mktemp -d "$output_dir/.package.XXXXXX")
-trap 'rm -rf "$staging_root"' EXIT
 package_root="$staging_root/MetasequoiaIME-$tag_name"
-archive_path="$output_dir/MetasequoiaIME-$tag_name-macos-universal$asset_suffix.zip"
+archive_name="MetasequoiaIME-$tag_name-macos-universal$asset_suffix.zip"
+installer_name="MetasequoiaIME-$tag_name-macos-universal$asset_suffix.pkg"
+archive_path="$staging_root/$archive_name"
 checksum_path="$archive_path.sha256"
-installer_path="$output_dir/MetasequoiaIME-$tag_name-macos-universal$asset_suffix.pkg"
+installer_path="$staging_root/$installer_name"
 installer_checksum_path="$installer_path.sha256"
+final_archive_path="$output_dir/$archive_name"
+final_checksum_path="$final_archive_path.sha256"
+final_installer_path="$output_dir/$installer_name"
+final_installer_checksum_path="$final_installer_path.sha256"
 component_package="$staging_root/MetasequoiaIME.pkg"
 distribution_file="$staging_root/Distribution.xml"
 installer_resources="$staging_root/InstallerResources"
 installer_readme="$installer_resources/InstallerReadMe.txt"
+backup_root="$staging_root/PreviousAssets"
+publish_started=false
+publish_complete=false
+staged_assets=("$archive_path" "$checksum_path" "$installer_path" "$installer_checksum_path")
+final_assets=("$final_archive_path" "$final_checksum_path" "$final_installer_path" "$final_installer_checksum_path")
+backup_assets=("$backup_root/$archive_name" "$backup_root/$archive_name.sha256" "$backup_root/$installer_name" "$backup_root/$installer_name.sha256")
+
+cleanup() {
+    local exit_status=$?
+    trap - EXIT HUP INT TERM
+    local rollback_failed=false
+    local index
+    if [[ "$publish_started" == true && "$publish_complete" != true ]]; then
+        for index in 1 2 3 4; do
+            if [[ ! -e "${staged_assets[$index]}" && -e "${final_assets[$index]}" ]] &&
+                ! rm -f -- "${final_assets[$index]}"; then
+                rollback_failed=true
+            fi
+            if [[ -e "${backup_assets[$index]}" ]] &&
+                ! mv -f -- "${backup_assets[$index]}" "${final_assets[$index]}"; then
+                rollback_failed=true
+            fi
+        done
+    fi
+    if [[ "$rollback_failed" == true ]]; then
+        print -u2 "Release packaging rollback was incomplete. PreviousAssets are preserved at: $backup_root"
+        exit 1
+    fi
+    if ! rm -rf -- "$staging_root"; then
+        print -u2 "Release packaging cleanup was incomplete: $staging_root"
+        exit 1
+    fi
+    exit "$exit_status"
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
 mkdir -p "$package_root"
 ditto "$source_bundle" "$package_root/MetasequoiaIME.app"
@@ -94,7 +136,6 @@ if [[ "$asset_suffix" == -unsigned ]]; then
         > "$package_root/UNSIGNED_BUILD.txt"
 fi
 chmod +x "$package_root/Install.command"
-rm -f "$archive_path" "$checksum_path" "$installer_path" "$installer_checksum_path"
 if [[ -n "$notary_profile" ]]; then
     notary_input="$staging_root/MetasequoiaIME-notary.zip"
     ditto -c -k --keepParent "$package_root/MetasequoiaIME.app" "$notary_input"
@@ -103,7 +144,7 @@ if [[ -n "$notary_profile" ]]; then
     xcrun stapler validate "$package_root/MetasequoiaIME.app"
 fi
 ditto -c -k --keepParent "$package_root" "$archive_path"
-(cd "$output_dir" && shasum -a 256 "${archive_path:t}") > "$checksum_path"
+(cd "$staging_root" && shasum -a 256 "$archive_name") > "$checksum_path"
 pkgbuild --component "$package_root/MetasequoiaIME.app" --identifier com.houko.inputmethod.MetasequoiaIME.pkg --version "$version" --install-location "Library/Input Methods" "$component_package"
 sed "s/@VERSION@/$version/g" "$project_root/resources/InstallerDistribution.xml.in" > "$distribution_file"
 mkdir -p "$installer_resources"
@@ -143,8 +184,19 @@ if [[ -n "$notary_profile" ]]; then
     xcrun stapler staple "$installer_path"
     xcrun stapler validate "$installer_path"
 fi
-(cd "$output_dir" && shasum -a 256 "${installer_path:t}") > "$installer_checksum_path"
-print "$archive_path"
-print "$checksum_path"
-print "$installer_path"
-print "$installer_checksum_path"
+(cd "$staging_root" && shasum -a 256 "$installer_name") > "$installer_checksum_path"
+mkdir -p "$backup_root"
+publish_started=true
+for index in 1 2 3 4; do
+    if [[ -e "${final_assets[$index]}" ]]; then
+        mv "${final_assets[$index]}" "${backup_assets[$index]}"
+    fi
+done
+for index in 1 2 3 4; do
+    mv -f "${staged_assets[$index]}" "${final_assets[$index]}"
+done
+publish_complete=true
+print "$final_archive_path"
+print "$final_checksum_path"
+print "$final_installer_path"
+print "$final_installer_checksum_path"

--- a/tests/ReleasePackageTests.py
+++ b/tests/ReleasePackageTests.py
@@ -211,6 +211,121 @@ class ReleasePackageTests(unittest.TestCase):
                 ).is_file()
             )
 
+            asset_names = (
+                f"MetasequoiaIME-v{version}-macos-universal-unsigned.zip",
+                f"MetasequoiaIME-v{version}-macos-universal-unsigned.zip.sha256",
+                f"MetasequoiaIME-v{version}-macos-universal-unsigned.pkg",
+                f"MetasequoiaIME-v{version}-macos-universal-unsigned.pkg.sha256",
+            )
+
+            cleanup_failure_output = Path(temporary_directory) / "cleanup-failure-output"
+            cleanup_failure_output.mkdir()
+            cleanup_failing_bin = Path(temporary_directory) / "cleanup-failing-bin"
+            cleanup_failing_bin.mkdir()
+            failing_rm = cleanup_failing_bin / "rm"
+            failing_rm.write_text(
+                "#!/bin/sh\n"
+                "target=\n"
+                "for argument in \"$@\"; do target=$argument; done\n"
+                "case $target in\n"
+                "  */.package.*) exit 44 ;;\n"
+                "esac\n"
+                "exec /bin/rm \"$@\"\n"
+            )
+            failing_rm.chmod(0o755)
+            cleanup_failure_environment = environment.copy()
+            cleanup_failure_environment["PATH"] = (
+                f"{cleanup_failing_bin}:{cleanup_failure_environment['PATH']}"
+            )
+            failed_cleanup = subprocess.run(
+                [trusted_packager, f"v{version}", bundle, cleanup_failure_output],
+                capture_output=True,
+                text=True,
+                env=cleanup_failure_environment,
+            )
+            self.assertNotEqual(failed_cleanup.returncode, 0)
+            for asset_name in asset_names:
+                self.assertTrue((cleanup_failure_output / asset_name).is_file())
+            self.assertEqual(len(list(cleanup_failure_output.glob(".package.*"))), 1)
+            self.assertIn("cleanup was incomplete", failed_cleanup.stderr)
+
+            failure_output = Path(temporary_directory) / "failure-output"
+            failure_output.mkdir()
+            previous_contents = b"previous complete release asset\n"
+            for asset_name in asset_names:
+                (failure_output / asset_name).write_bytes(previous_contents)
+
+            failing_bin = Path(temporary_directory) / "failing-bin"
+            failing_bin.mkdir()
+            failing_mv = failing_bin / "mv"
+            failing_mv.write_text(
+                "#!/bin/sh\n"
+                "source_path=\n"
+                "for argument in \"$@\"; do\n"
+                "  case $argument in -*) ;; *) source_path=$argument; break ;; esac\n"
+                "done\n"
+                "case $source_path in\n"
+                "  */PreviousAssets/*)\n"
+                "    if test \"${FAIL_ROLLBACK:-false}\" = true && test ! -f \"$ROLLBACK_FAILURE_FILE\"; then\n"
+                "      printf '%s\\n' failed > \"$ROLLBACK_FAILURE_FILE\"\n"
+                "      exit 43\n"
+                "    fi\n"
+                "    ;;\n"
+                "  */.package.*/MetasequoiaIME-v*-macos-universal*)\n"
+                "    count=0\n"
+                "    test ! -f \"$MV_COUNT_FILE\" || count=$(cat \"$MV_COUNT_FILE\")\n"
+                "    count=$((count + 1))\n"
+                "    printf '%s\\n' \"$count\" > \"$MV_COUNT_FILE\"\n"
+                "    test \"$count\" -ne 2 || exit 42\n"
+                "    ;;\n"
+                "esac\n"
+                "exec /bin/mv \"$@\"\n"
+            )
+            failing_mv.chmod(0o755)
+            failure_environment = environment.copy()
+            failure_environment["PATH"] = f"{failing_bin}:{failure_environment['PATH']}"
+            failure_environment["MV_COUNT_FILE"] = str(Path(temporary_directory) / "mv-count")
+            failed_package = subprocess.run(
+                [trusted_packager, f"v{version}", bundle, failure_output],
+                capture_output=True,
+                text=True,
+                env=failure_environment,
+            )
+            self.assertNotEqual(failed_package.returncode, 0)
+            for asset_name in asset_names:
+                self.assertEqual((failure_output / asset_name).read_bytes(), previous_contents)
+            self.assertFalse(any(failure_output.glob(".package.*")))
+
+            rollback_failure_output = Path(temporary_directory) / "rollback-failure-output"
+            rollback_failure_output.mkdir()
+            for asset_name in asset_names:
+                (rollback_failure_output / asset_name).write_bytes(previous_contents)
+            rollback_failure_environment = failure_environment.copy()
+            rollback_failure_environment["MV_COUNT_FILE"] = str(
+                Path(temporary_directory) / "rollback-mv-count"
+            )
+            rollback_failure_environment["FAIL_ROLLBACK"] = "true"
+            rollback_failure_environment["ROLLBACK_FAILURE_FILE"] = str(
+                Path(temporary_directory) / "rollback-failed"
+            )
+            failed_rollback = subprocess.run(
+                [trusted_packager, f"v{version}", bundle, rollback_failure_output],
+                capture_output=True,
+                text=True,
+                env=rollback_failure_environment,
+            )
+            self.assertNotEqual(failed_rollback.returncode, 0)
+            preserved_staging = list(rollback_failure_output.glob(".package.*"))
+            self.assertEqual(len(preserved_staging), 1)
+            preserved_backup = preserved_staging[0] / "PreviousAssets"
+            for asset_name in asset_names:
+                final_asset = rollback_failure_output / asset_name
+                backup_asset = preserved_backup / asset_name
+                self.assertTrue(final_asset.exists() or backup_asset.exists())
+                preserved_asset = final_asset if final_asset.exists() else backup_asset
+                self.assertEqual(preserved_asset.read_bytes(), previous_contents)
+            self.assertIn("PreviousAssets", failed_rollback.stderr)
+
 
 if __name__ == "__main__":
     unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
## Summary
- build all four release assets in a same-filesystem staging directory before publishing
- back up and restore any existing asset set if a final publish move fails
- preserve recoverable backups when rollback itself fails, and fail when final cleanup cannot complete
- cover commit, rollback, and cleanup failures with injected filesystem errors

## Verification
- `zsh -n scripts/package_release.sh`
- `git diff --check`
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure` (12/12 passed)
- independent review: no Critical/Important findings