### PR TITLE
ci: run tests natively on Intel macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,16 @@ permissions:
 
 jobs:
   macos:
-    name: macOS arm64
-    runs-on: macos-15
+    name: macOS 15 ${{ matrix.architecture }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            architecture: arm64
+          - runner: macos-15-intel
+            architecture: x86_64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -57,6 +57,17 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("macos-universal$ASSET_SUFFIX.pkg", release_publisher)
         self.assertIn("asset_suffix=-unsigned", signing_detector)
         self.assertIn("timeout-minutes: 30", workflow)
+        ci_workflow = (PROJECT_ROOT / ".github/workflows/ci.yml").read_text()
+        self.assertIn(
+            """        include:
+          - runner: macos-15
+            architecture: arm64
+          - runner: macos-15-intel
+            architecture: x86_64
+""",
+            ci_workflow,
+        )
+        self.assertIn("runs-on: ${{ matrix.runner }}", ci_workflow)
         self.assertIn("gh release upload", release_publisher)
         self.assertIn("gh release edit", release_publisher)
         self.assertIn("METASEQUOIA_REQUIRE_RELEASE_SIGNING", workflow)


### PR DESCRIPTION
## Summary
- run the CI suite on both GitHub-hosted macOS 15 arm64 and Intel runners
- keep both matrix jobs running to expose architecture-specific failures
- lock the runner/architecture pairing in release configuration tests

## Verification
- official actions/runner-images metadata confirms `macos-15` arm64 and `macos-15-intel` x64 labels
- workflow YAML parses successfully
- `ctest --test-dir build -E "^release_package$" --output-on-failure` (11/11 passed)
- release configuration test passed
- independent review: no Critical/Important findings

Local Rosetta execution was unavailable (`Bad CPU type in executable`), so the PR Intel runner is the authoritative x86_64 runtime check.