### PR TITLE
docs: publish security and privacy policies

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,11 @@
+# Privacy
+
+Metasequoia IME for macOS processes keystrokes, pre-edit text, and candidates locally on the user's Mac. The application does not send typed text, candidates, learned words, preferences, diagnostics, analytics, or crash reports over the network. It does not include a network service or cloud synchronization feature.
+
+The input method stores its settings in the current user's macOS preferences. When candidate learning is enabled, learned word-frequency changes are stored locally under `~/Library/Application Support/metasequoiaime/`. The bundled dictionary is copied to the same directory so it can be upgraded safely. These files are available only through the permissions of the local macOS account; users should protect that account and its backups as they would other personal data.
+
+The settings panel can disable candidate learning and can erase learned input data. If learning is disabled while a composition is active, that composition keeps the setting it started with; after it is committed or cancelled, newly started compositions do not update word frequencies. Erasing learned data removes the local learning databases and restores the bundled dictionary without deleting unrelated preferences.
+
+Metasequoia IME does not sell or share personal data. Installing or using the software does not create an account. If a future release adds any network-backed feature, this notice must be updated before that feature is shipped.
+
+Security or privacy concerns should be reported privately as described in [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the native macOS frontend for Metasequoia IME. It uses InputMethodKit and AppKit, embeds the shared C++ engine directly, and does not port the Windows TSF or WebView2 host.
 
-The current alpha supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, composition commit on focus changes, and Shift+Space switching between Chinese and direct English input.
+The current release supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, composition commit on focus changes, and Shift+Space switching between Chinese and direct English input.
 
 ## Requirements
 
@@ -90,3 +90,7 @@ shasum -a 256 -c MetasequoiaIME-vX.Y.Z-macos-universal.zip.sha256
 ## License
 
 Metasequoia IME for macOS is distributed under the GNU General Public License version 3. Release archives, installer packages, and the application bundle include the applicable GPL and third-party license notices; see `LICENSE` and `THIRD_PARTY_NOTICES.txt`.
+
+## Privacy and security
+
+Input processing and candidate learning are local to the user's Mac; see [PRIVACY.md](PRIVACY.md) for the data-handling details. Report suspected vulnerabilities privately according to [SECURITY.md](SECURITY.md), not through a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest published version of Metasequoia IME for macOS. Before reporting a problem, confirm that it still occurs with the newest release.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability or include sensitive proof-of-concept data in public discussions.
+
+Email `suzukaze.haduki@gmail.com` with the subject `MetasequoiaImeMac security report`. Include the affected version, macOS version and architecture, expected and observed behavior, reproduction steps, and the security impact. Attach only the minimum data needed to reproduce the issue; never include real text typed with the input method, credentials, signing material, or other personal data.
+
+The maintainer will coordinate disclosure and remediation with the reporter. Please allow time for a fixed release to become available before publishing technical details.
+
+For ordinary defects and feature requests that have no security or privacy impact, use the repository's public issue tracker.

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -196,6 +196,22 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("googlepinyinime-rev", notices)
         self.assertIn("utfcpp", notices)
         self.assertIn("THIRD_PARTY_NOTICES.txt", package_script)
+        privacy = (PROJECT_ROOT / "PRIVACY.md").read_text()
+        security = (PROJECT_ROOT / "SECURITY.md").read_text()
+        self.assertIn("~/Library/Application Support/metasequoiaime/", privacy)
+        self.assertIn("does not send typed text", privacy)
+        self.assertIn("does not sell or share personal data", privacy)
+        self.assertIn(
+            "If learning is disabled while a composition is active, that composition keeps the setting it started "
+            "with; after it is committed or cancelled, newly started compositions do not update word frequencies.",
+            privacy,
+        )
+        self.assertIn("SECURITY.md", privacy)
+        self.assertIn("latest published version", security)
+        self.assertIn("Do not open a public issue", security)
+        self.assertIn("MetasequoiaImeMac security report", security)
+        self.assertIn("PRIVACY.md", readme)
+        self.assertIn("SECURITY.md", readme)
 
     def test_release_scripts_have_valid_zsh_syntax(self):
         for relative_path in ("scripts/install-release.sh", "scripts/package_release.sh"):


### PR DESCRIPTION
## Summary
- publish a private vulnerability reporting path and supported-version policy
- document local-only input processing, preference and learning-data storage, and reset behavior
- describe the active-composition boundary when candidate learning is disabled
- link privacy and security policies from the README and remove the stale alpha label

## Verification
- source audit found no runtime networking, telemetry, analytics, or crash-reporting integration
- storage claims verified against NSUserDefaults and `~/Library/Application Support/metasequoiaime/` implementation
- `ctest --test-dir build -R "^release_configuration$" --output-on-failure`
- `ctest --test-dir build -E "^release_package$" --output-on-failure` (11/11 passed)
- independent review: no Critical/Important findings