### PR TITLE
fix(release): verify artifacts before publishing

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -30,6 +30,32 @@ if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
+archive="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.zip"
+installer="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.pkg"
+for artifact in "$installer" "$installer.sha256" "$archive" "$archive.sha256"; do
+    if [[ ! -f "$artifact" ]]; then
+        printf 'Release artifact is missing: %s\n' "$artifact" >&2
+        exit 1
+    fi
+done
+(
+    cd "$dist_dir"
+    verify_checksum_manifest() {
+        local artifact_name=$1
+        local manifest_name=$2
+        local expected_line
+        local manifest_line
+        expected_line=$(shasum -a 256 "$artifact_name")
+        manifest_line=$(command cat "$manifest_name")
+        if [[ "$manifest_line" != "$expected_line" ]]; then
+            printf 'Release checksum verification FAILED for %s.\n' "$artifact_name" >&2
+            return 1
+        fi
+    }
+    verify_checksum_manifest "$(basename "$installer")" "$(basename "$installer.sha256")"
+    verify_checksum_manifest "$(basename "$archive")" "$(basename "$archive.sha256")"
+)
+
 mode_marker="<!-- metasequoia-release-mode:$release_mode -->"
 opposite_marker="<!-- metasequoia-release-mode:$opposite_mode -->"
 current_notes=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq '.body // ""')
@@ -51,15 +77,6 @@ if [[ "$current_notes" != *"$mode_marker"* ]]; then
     } > "$release_notes"
     gh release edit "$TAG_NAME" --repo "$GH_REPO" --notes-file "$release_notes"
 fi
-
-archive="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.zip"
-installer="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.pkg"
-for artifact in "$installer" "$installer.sha256" "$archive" "$archive.sha256"; do
-    if [[ ! -f "$artifact" ]]; then
-        printf 'Release artifact is missing: %s\n' "$artifact" >&2
-        exit 1
-    fi
-done
 
 gh release upload "$TAG_NAME" --repo "$GH_REPO" "$installer" "$installer.sha256" "$archive" "$archive.sha256" --clobber
 gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false

--- a/tests/ReleaseAutomationTests.py
+++ b/tests/ReleaseAutomationTests.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import subprocess
@@ -155,7 +156,14 @@ class ReleaseSigningModeTests(unittest.TestCase):
 
 
 class ReleasePublicationTests(unittest.TestCase):
-    def run_publication(self, signing_enabled, asset_suffix, existing_notes=""):
+    def run_publication(
+        self,
+        signing_enabled,
+        asset_suffix,
+        existing_notes="",
+        corrupt_checksum=False,
+        misdirected_checksum=False,
+    ):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary = Path(temporary_directory)
             fake_bin = temporary / "bin"
@@ -184,8 +192,17 @@ fi
             dist = temporary / "dist"
             dist.mkdir()
             stem = f"MetasequoiaIME-v1.2.3-macos-universal{asset_suffix}"
-            for extension in (".zip", ".zip.sha256", ".pkg", ".pkg.sha256"):
-                (dist / f"{stem}{extension}").touch()
+            for extension in (".zip", ".pkg"):
+                artifact = dist / f"{stem}{extension}"
+                artifact.write_bytes(f"test {extension} artifact\n".encode())
+                digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+                if corrupt_checksum and extension == ".pkg":
+                    digest = "0" * 64
+                (dist / f"{stem}{extension}.sha256").write_text(f"{digest}  {artifact.name}\n")
+            if misdirected_checksum:
+                archive = dist / f"{stem}.zip"
+                archive_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+                (dist / f"{stem}.pkg.sha256").write_text(f"{archive_digest}  {archive.name}\n")
             environment = os.environ.copy()
             environment.update(
                 {
@@ -249,6 +266,21 @@ fi
         self.assertIn("metasequoia-release-mode:signed", notes)
         self.assertNotIn("WARNING", notes)
         self.assertIn("macos-universal.pkg", calls)
+
+    def test_corrupt_artifact_is_rejected_before_release_metadata_or_assets_change(self):
+        result, calls, notes = self.run_publication("false", "-unsigned", corrupt_checksum=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("FAILED", result.stdout + result.stderr)
+        self.assertEqual(calls, "")
+        self.assertEqual(notes, "")
+
+    def test_checksum_for_another_artifact_is_rejected_before_release_changes(self):
+        result, calls, notes = self.run_publication("false", "-unsigned", misdirected_checksum=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(calls, "")
+        self.assertEqual(notes, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- verify ZIP and PKG checksum manifests before any GitHub release mutation
- require each manifest to match the explicitly expected artifact and filename
- reject corrupt or redirected checksum manifests before upload

## Verification
- `python3 -m unittest tests.ReleaseAutomationTests.ReleasePublicationTests`
- `ctest --test-dir build --output-on-failure --timeout 240 -R "^(release_automation|release_configuration)$"`
- `bash -n scripts/publish-release.sh`
- `git diff --check`
- independent review: no Critical/Important findings