### PR TITLE
fix(settings): restore evolving defaults

### DIFF
--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -704,15 +704,41 @@ void ConfigureCard(NSBox *card)
 - (void)restoreDefaults:(id)sender
 {
     (void)sender;
-    [MetasequoiaPreferencesWindowController setStoredScheme:0];
-    [MetasequoiaPreferencesWindowController setAutocorrectEnabled:YES];
-    [MetasequoiaPreferencesWindowController setHelpcodeEnabled:YES];
-    [MetasequoiaPreferencesWindowController setChinesePunctuationEnabled:YES];
-    [MetasequoiaPreferencesWindowController setCandidatePanelStyle:0];
-    [MetasequoiaPreferencesWindowController setCandidatePageSize:9];
-    [MetasequoiaPreferencesWindowController setCandidateFontSize:18];
-    [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:YES];
-    [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:YES];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    for (NSString *key in @[
+             kSchemePreferenceKey,
+             kAutocorrectPreferenceKey,
+             kHelpcodePreferenceKey,
+             kChinesePunctuationPreferenceKey,
+             kCandidatePanelStylePreferenceKey,
+             kCandidatePageSizePreferenceKey,
+             kCandidateFontSizePreferenceKey,
+             kCandidateLearningPreferenceKey,
+             kInputModeShortcutPreferenceKey,
+         ])
+    {
+        [defaults removeObjectForKey:key];
+    }
+
+    NSNotificationCenter *notifications = [NSNotificationCenter defaultCenter];
+    [notifications postNotificationName:@"MetasequoiaInputSchemeDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedScheme])];
+    [notifications postNotificationName:@"MetasequoiaQuanpinAutocorrectDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedAutocorrectEnabled])];
+    [notifications postNotificationName:@"MetasequoiaHelpcodeDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedHelpcodeEnabled])];
+    [notifications postNotificationName:@"MetasequoiaChinesePunctuationDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled])];
+    [notifications postNotificationName:@"MetasequoiaCandidatePanelStyleDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedCandidatePanelStyle])];
+    [notifications postNotificationName:@"MetasequoiaCandidatePageSizeDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedCandidatePageSize])];
+    [notifications postNotificationName:@"MetasequoiaCandidateFontSizeDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedCandidateFontSize])];
+    [notifications postNotificationName:@"MetasequoiaCandidateLearningDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedCandidateLearningEnabled])];
+    [notifications postNotificationName:@"MetasequoiaInputModeShortcutDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled])];
     [self refreshControls];
 }
 

--- a/tests/PreferencesWindowTests.mm
+++ b/tests/PreferencesWindowTests.mm
@@ -214,6 +214,47 @@ int main()
         [MetasequoiaPreferencesWindowController setCandidateFontSize:99];
         require([MetasequoiaPreferencesWindowController storedCandidateFontSize] == 18,
                 "An unsupported candidate font size was not normalized safely.");
+        [MetasequoiaPreferencesWindowController setStoredScheme:1];
+        [MetasequoiaPreferencesWindowController setAutocorrectEnabled:NO];
+        [MetasequoiaPreferencesWindowController setHelpcodeEnabled:NO];
+        [MetasequoiaPreferencesWindowController setChinesePunctuationEnabled:NO];
+        [MetasequoiaPreferencesWindowController setCandidatePanelStyle:1];
+        [MetasequoiaPreferencesWindowController setCandidatePageSize:5];
+        [MetasequoiaPreferencesWindowController setCandidateFontSize:20];
+        [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:NO];
+        [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:NO];
+        [MetasequoiaPreferencesWindowController setEnglishInputMode:YES];
+        NSButton *restoreDefaultsButton = FindButtonWithTitle(controller.window.contentView, @"恢复默认设置");
+        require(restoreDefaultsButton != nil, "The settings window did not expose the restore-defaults button.");
+        [restoreDefaultsButton performClick:nil];
+        require([MetasequoiaPreferencesWindowController storedScheme] == 0 &&
+                    [MetasequoiaPreferencesWindowController storedAutocorrectEnabled] &&
+                    [MetasequoiaPreferencesWindowController storedHelpcodeEnabled] &&
+                    [MetasequoiaPreferencesWindowController storedChinesePunctuationEnabled] &&
+                    [MetasequoiaPreferencesWindowController storedCandidatePanelStyle] == 0 &&
+                    [MetasequoiaPreferencesWindowController storedCandidatePageSize] == 9 &&
+                    [MetasequoiaPreferencesWindowController storedCandidateFontSize] == 18 &&
+                    [MetasequoiaPreferencesWindowController storedCandidateLearningEnabled] &&
+                    [MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled],
+                "Restoring defaults did not restore every visible setting.");
+        NSArray<NSString *> *preferenceKeys = @[
+            @"MetasequoiaImeInputScheme",
+            @"MetasequoiaImeQuanpinAutocorrect",
+            @"MetasequoiaImeHelpcodeEnabled",
+            @"MetasequoiaImeChinesePunctuation",
+            @"MetasequoiaImeCandidatePanelStyle",
+            @"MetasequoiaImeCandidatePageSize",
+            @"MetasequoiaImeCandidateFontSize",
+            @"MetasequoiaImeCandidateLearning",
+            @"MetasequoiaImeInputModeShortcutEnabled",
+        ];
+        for (NSString *key in preferenceKeys)
+        {
+            require([[NSUserDefaults standardUserDefaults] objectForKey:key] == nil,
+                    "Restoring defaults left a persisted override that can pin an obsolete default.");
+        }
+        require([MetasequoiaPreferencesWindowController storedEnglishInputMode],
+                "Restoring configurable defaults unexpectedly changed the current input mode.");
         [MetasequoiaPreferencesWindowController setEnglishInputMode:NO];
         require(![MetasequoiaPreferencesWindowController storedEnglishInputMode],
                 "The Chinese input-mode state was not stored.");


### PR DESCRIPTION
## Summary
- make Restore Defaults remove visible preference overrides instead of pinning today's values
- emit the same effective-value notifications after reset and preserve the current input mode
- cover the real settings button and all nine configurable defaults

## Verification
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure --timeout 240` (13/13 passed)
- computer-use: toggled autocorrect off, clicked Restore Defaults, observed it return on with all 32 controls accessible
- `git diff --check`
- independent review: no Critical/Important findings