### PR TITLE
fix(dictionary): validate bundled database before upgrade

### DIFF
--- a/src/DictionaryInstaller.mm
+++ b/src/DictionaryInstaller.mm
@@ -403,10 +403,10 @@ BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString 
             }
             return NO;
         }
-
         NSURL *destination = [dataDirectory URLByAppendingPathComponent:@"msime.db" isDirectory:NO];
         NSURL *fingerprintFile = [dataDirectory URLByAppendingPathComponent:@"msime.db.sha256" isDirectory:NO];
         const BOOL destinationExists = [fileManager fileExistsAtPath:destination.path];
+        NSString *installedFingerprint = nil;
         if (destinationExists)
         {
             NSDictionary<NSFileAttributeKey, id> *destinationAttributes =
@@ -416,20 +416,25 @@ BOOL InstallMetasequoiaDictionary(NSURL *source, NSURL *dataDirectory, NSString 
                 return NO;
             }
 
-            NSString *installedFingerprint =
+            installedFingerprint =
                 [NSString stringWithContentsOfURL:fingerprintFile encoding:NSUTF8StringEncoding error:nil];
             if (destinationAttributes.fileSize > 0 && [installedFingerprint isEqualToString:dictionaryFingerprint])
             {
                 return YES;
             }
+        }
 
-            if (installedFingerprint == nil && [fileManager contentsEqualAtPath:source.path andPath:destination.path])
-            {
-                return [dictionaryFingerprint writeToURL:fingerprintFile
-                                              atomically:YES
-                                                encoding:NSUTF8StringEncoding
-                                                   error:error];
-            }
+        if (!IsUsableDictionary(source))
+        {
+            return Fail(error, 2, @"The bundled msime.db dictionary is invalid.");
+        }
+        if (destinationExists && installedFingerprint == nil &&
+            [fileManager contentsEqualAtPath:source.path andPath:destination.path])
+        {
+            return [dictionaryFingerprint writeToURL:fingerprintFile
+                                          atomically:YES
+                                            encoding:NSUTF8StringEncoding
+                                               error:error];
         }
 
         NSString *temporaryName = [@".msime.db.installing." stringByAppendingString:NSUUID.UUID.UUIDString];

--- a/tests/DictionaryInstallerTests.mm
+++ b/tests/DictionaryInstallerTests.mm
@@ -134,17 +134,25 @@ int main()
         NSURL *sameSizeDirectory = CreateDirectory(root, @"same-size");
         NSURL *sameSizeSource = [root URLByAppendingPathComponent:@"same-size-source.db"];
         NSURL *sameSizeDestination = [sameSizeDirectory URLByAppendingPathComponent:@"msime.db"];
-        WriteString(@"new-data", sameSizeSource);
-        WriteString(@"old-data", sameSizeDestination);
+        ExecuteSql(sameSizeSource,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',100);");
+        ExecuteSql(sameSizeDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','拟好',200);");
+        Require([[fileManager attributesOfItemAtPath:sameSizeSource.path error:&error] fileSize] ==
+                    [[fileManager attributesOfItemAtPath:sameSizeDestination.path error:&error] fileSize],
+                "The same-size update fixture dictionaries have different sizes.");
         Require(InstallMetasequoiaDictionary(sameSizeSource, sameSizeDirectory, @"new-fingerprint", &error),
                 error.localizedDescription.UTF8String);
-        Require(ReadString(sameSizeDestination) == "new-data",
+        Require(ReadWeight(sameSizeDestination, "拟好") == 100,
                 "A same-size dictionary update was incorrectly skipped.");
 
-        WriteString(@"learned-data", sameSizeDestination);
+        ExecuteSql(sameSizeDestination, "UPDATE tbl_2_n SET weight=999 WHERE value='拟好';");
+        WriteString(@"unused corrupt source", sameSizeSource);
         Require(InstallMetasequoiaDictionary(sameSizeSource, sameSizeDirectory, @"new-fingerprint", &error),
-                error.localizedDescription.UTF8String);
-        Require(ReadString(sameSizeDestination) == "learned-data",
+                "A matching dictionary fingerprint did not use the no-update fast path.");
+        Require(ReadWeight(sameSizeDestination, "拟好") == 999,
                 "A matching dictionary fingerprint overwrote learned data.");
 
         NSURL *replayDirectory = CreateDirectory(root, @"replay");
@@ -449,6 +457,30 @@ int main()
         Require(!PrepareMetasequoiaDictionary(missingSource, failureDirectory, @"missing", &error),
                 "A corrupt existing dictionary was accepted as an update fallback.");
         Require(error != nil, "A rejected dictionary fallback did not preserve the update error.");
+
+        NSURL *corruptSourceDirectory = CreateDirectory(root, @"corrupt-source");
+        NSURL *corruptSource = [root URLByAppendingPathComponent:@"corrupt-source.db"];
+        NSURL *preservedDestination =
+            [corruptSourceDirectory URLByAppendingPathComponent:@"msime.db"];
+        WriteString(@"not a SQLite dictionary", corruptSource);
+        ExecuteSql(preservedDestination,
+                   "CREATE TABLE tbl_2_n(key TEXT, jp TEXT, value TEXT, weight INTEGER);"
+                   "INSERT INTO tbl_2_n VALUES('ni''hao','nh','你好',321);");
+        WriteString(@"old-fingerprint",
+                    [corruptSourceDirectory URLByAppendingPathComponent:@"msime.db.sha256"]);
+        error = nil;
+        Require(!InstallMetasequoiaDictionary(corruptSource, corruptSourceDirectory,
+                                              @"new-fingerprint", &error),
+                "A nonempty corrupt bundled dictionary unexpectedly replaced the working dictionary.");
+        Require(ReadWeight(preservedDestination, "你好") == 321,
+                "A corrupt bundled dictionary damaged the working dictionary.");
+        error = nil;
+        Require(PrepareMetasequoiaDictionary(corruptSource, corruptSourceDirectory,
+                                             @"new-fingerprint", &error),
+                "A valid working dictionary was not used after bundled dictionary validation failed.");
+        Require(error == nil, "A successful corrupt-source fallback leaked the validation error.");
+        Require(ReadWeight(preservedDestination, "你好") == 321,
+                "Corrupt-source fallback did not preserve the working dictionary.");
 
         NSURL *replayFailureDirectory = CreateDirectory(root, @"replay-failure");
         NSURL *replayFailureSource = [root URLByAppendingPathComponent:@"replay-failure-source.db"];


### PR DESCRIPTION
## Summary
- reject corrupt nonempty bundled SQLite dictionaries before copy, replay, or replacement
- preserve the fingerprint-matched no-update fast path to avoid scanning the 97 MB database on normal startup
- preserve a usable installed dictionary when bundled upgrade validation fails

## Verification
- `cmake --build build --target MetasequoiaDictionaryInstallerTests --parallel`
- `ctest --test-dir build -R ^dictionary_installer$ --output-on-failure`
- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure` (13/13 passed)
- independent static review: no findings