### PR TITLE
fix(install): stop forcing logout after pkg install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           path: .release-automation
           sparse-checkout: |
+            resources/InstallerDistribution.xml.in
             scripts/detect-release-signing.sh
             scripts/install-release.sh
             scripts/uninstall.sh
@@ -96,6 +97,7 @@ jobs:
           persist-credentials: false
       - name: Stage trusted release automation
         run: |
+          install -m 0644 .release-automation/resources/InstallerDistribution.xml.in "$RUNNER_TEMP/InstallerDistribution.xml.in"
           install -m 0755 .release-automation/scripts/detect-release-signing.sh "$RUNNER_TEMP/detect-release-signing.sh"
           install -m 0755 .release-automation/scripts/install-release.sh "$RUNNER_TEMP/install-release.sh"
           install -m 0755 .release-automation/scripts/uninstall.sh "$RUNNER_TEMP/uninstall.sh"
@@ -178,6 +180,7 @@ jobs:
           METASEQUOIA_PROJECT_ROOT: ${{ github.workspace }}
           METASEQUOIA_RELEASE_INSTALL_SCRIPT: ${{ runner.temp }}/install-release.sh
           METASEQUOIA_RELEASE_UNINSTALL_SCRIPT: ${{ runner.temp }}/uninstall.sh
+          METASEQUOIA_INSTALLER_DISTRIBUTION: ${{ runner.temp }}/InstallerDistribution.xml.in
         run: exec "$RUNNER_TEMP/package-release.sh" "$TAG_NAME" build/MetasequoiaIME.app dist
       - name: Upload and publish release
         env:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Merges to `main` update a Release Please pull request from conventional commit h
 
 When Apple release credentials are not configured, the workflow publishes the same four assets with `-unsigned` before the file extension and adds a warning to the GitHub Release. Unsigned artifacts are intended for testing and may require explicit approval in macOS privacy and security settings.
 
-Download the `.pkg` and its checksum, verify it, then double-click the package to open the native macOS Installer. The package installs the current user's copy in `~/Library/Input Methods` and does not require administrator privileges. Log out after installation so macOS refreshes its input source cache.
+Download the `.pkg` and its checksum, verify it, then double-click the package to open the native macOS Installer. The package installs the current user's copy in `~/Library/Input Methods`; the native Installer may request administrator authorization. It will not log out or restart the Mac automatically. macOS may require you to log out and back in at a convenient time before the newly copied input method appears.
 
 ```sh
 shasum -a 256 -c MetasequoiaIME-vX.Y.Z-macos-universal.pkg.sha256
@@ -80,7 +80,7 @@ When all of the following repository secrets are configured, release builds are 
 
 Local development builds remain ad-hoc signed. After installation, enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit.
 
-The ZIP provides the same current-user destination through `Install.command` when a command-line installation is preferred. The installer always verifies the bundle's code signature before replacing an existing installation, then registers that exact bundle with macOS so it is available to add without logging out. Signed releases must also pass Gatekeeper; clearly marked unsigned builds instead require typing `I UNDERSTAND` and may need explicit approval in System Settings > Privacy & Security.
+The ZIP provides the same current-user destination through `Install.command` and is the recommended option when 水杉 should be available immediately without logging out or administrator privileges. The installer always verifies the bundle's code signature before replacing an existing installation, then registers that exact bundle with macOS so it is available to add without logging out. Signed releases must also pass Gatekeeper; clearly marked unsigned builds instead require typing `I UNDERSTAND` and may need explicit approval in System Settings > Privacy & Security.
 
 Verify the ZIP checksum, extract it, and run `Install.command`:
 

--- a/resources/InstallerDistribution.xml.in
+++ b/resources/InstallerDistribution.xml.in
@@ -16,5 +16,5 @@
     <choice id="default" title="Metasequoia IME">
         <pkg-ref id="com.houko.inputmethod.MetasequoiaIME.pkg"/>
     </choice>
-    <pkg-ref id="com.houko.inputmethod.MetasequoiaIME.pkg" version="@VERSION@" onConclusion="RequireLogout">MetasequoiaIME.pkg</pkg-ref>
+    <pkg-ref id="com.houko.inputmethod.MetasequoiaIME.pkg" version="@VERSION@">MetasequoiaIME.pkg</pkg-ref>
 </installer-gui-script>

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -7,6 +7,8 @@ install_script=${METASEQUOIA_RELEASE_INSTALL_SCRIPT:-$project_root/scripts/insta
 install_script=${install_script:A}
 uninstall_script=${METASEQUOIA_RELEASE_UNINSTALL_SCRIPT:-$project_root/scripts/uninstall.sh}
 uninstall_script=${uninstall_script:A}
+installer_distribution=${METASEQUOIA_INSTALLER_DISTRIBUTION:-$project_root/resources/InstallerDistribution.xml.in}
+installer_distribution=${installer_distribution:A}
 tag_name=${1:-}
 source_bundle=${2:-$project_root/build/MetasequoiaIME.app}
 output_dir=${3:-$project_root/dist}
@@ -62,7 +64,10 @@ if [[ ! -f "$uninstall_script" ]]; then
     print -u2 "Release uninstall script not found at $uninstall_script"
     exit 1
 fi
-
+if [[ ! -f "$installer_distribution" ]]; then
+    print -u2 "Installer distribution template not found at $installer_distribution"
+    exit 1
+fi
 bundle_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$source_bundle/Contents/Info.plist")
 if [[ "$bundle_version" != "$version" ]]; then
     print -u2 "Bundle version $bundle_version does not match tag $tag_name."
@@ -162,7 +167,7 @@ fi
 ditto -c -k --keepParent "$package_root" "$archive_path"
 (cd "$staging_root" && shasum -a 256 "$archive_name") > "$checksum_path"
 pkgbuild --component "$packaged_bundle" --identifier com.houko.inputmethod.MetasequoiaIME.pkg --version "$version" --install-location "Library/Input Methods" "$component_package"
-sed "s/@VERSION@/$version/g" "$project_root/resources/InstallerDistribution.xml.in" > "$distribution_file"
+sed "s/@VERSION@/$version/g" "$installer_distribution" > "$distribution_file"
 mkdir -p "$installer_resources"
 ditto "$project_root/LICENSE" "$installer_resources/LICENSE"
 ditto "$project_root/THIRD_PARTY_NOTICES.txt" "$installer_resources/THIRD_PARTY_NOTICES.txt"
@@ -184,6 +189,9 @@ fi
 printf '%s\n' \
     '' \
     'Installation scope: current user (~/Library/Input Methods).' \
+    'The native Installer may request administrator authorization.' \
+    'The installer will not log out or restart the Mac automatically.' \
+    'macOS may list a newly copied input method only after you log out and back in at a convenient time.' \
     '' \
     'Uninstall from Terminal with:' \
     '"$HOME/Library/Input Methods/MetasequoiaIME.app/Contents/Resources/Uninstall.command"' \

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -90,10 +90,12 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertNotIn("ref: ${{ github.sha }}", workflow)
         self.assertIn("$RUNNER_TEMP/detect-release-signing.sh", workflow)
         self.assertIn("$RUNNER_TEMP/package-release.sh", workflow)
+        self.assertIn("$RUNNER_TEMP/InstallerDistribution.xml.in", workflow)
         self.assertIn("$RUNNER_TEMP/uninstall.sh", workflow)
         self.assertIn("METASEQUOIA_PROJECT_ROOT", workflow)
         self.assertIn("METASEQUOIA_RELEASE_INSTALL_SCRIPT", workflow)
         self.assertIn("METASEQUOIA_RELEASE_UNINSTALL_SCRIPT", workflow)
+        self.assertIn("METASEQUOIA_INSTALLER_DISTRIBUTION", workflow)
         self.assertIn("$RUNNER_TEMP/publish-release.sh", workflow)
         self.assertIn("git merge-base --is-ancestor HEAD refs/remotes/origin/main", workflow)
         self.assertLess(workflow.index("name: Determine release signing mode"), workflow.index("name: Check out release tag"))
@@ -108,7 +110,10 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("enable full-pinyin autocorrection", readme)
         self.assertIn("native 水杉输入法设置 panel", readme)
         self.assertIn("current user's copy in `~/Library/Input Methods`", readme)
-        self.assertIn("does not require administrator privileges", readme)
+        self.assertIn("may request administrator authorization", readme)
+        self.assertIn("without logging out or administrator privileges", readme)
+        self.assertIn("will not log out or restart the Mac automatically", readme)
+        self.assertIn("recommended option when 水杉 should be available immediately", readme)
         self.assertNotIn("installs the input method system-wide", readme)
         self.assertIn("InputMethodServerPreferencesWindowControllerClass", info_plist)
         self.assertIn("@METASEQUOIA_IME_DICTIONARY_SHA256@", info_plist)
@@ -261,7 +266,10 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "branch"), "feat/macos-portability")
 
     def test_release_scripts_have_valid_zsh_syntax(self):
-        for relative_path in ("scripts/install-release.sh", "scripts/package_release.sh"):
+        for relative_path in (
+            "scripts/install-release.sh",
+            "scripts/package_release.sh",
+        ):
             result = subprocess.run(["zsh", "-n", str(PROJECT_ROOT / relative_path)], capture_output=True, text=True)
             self.assertEqual(result.returncode, 0, result.stderr)
         result = subprocess.run(

--- a/tests/ReleasePackageTests.py
+++ b/tests/ReleasePackageTests.py
@@ -431,6 +431,14 @@ class ReleasePackageTests(unittest.TestCase):
             )
             fake_xcrun.chmod(0o755)
 
+            legacy_project_root = temporary / "legacy-project-root"
+            legacy_project_root.mkdir()
+            shutil.copy2(PROJECT_ROOT / "LICENSE", legacy_project_root / "LICENSE")
+            shutil.copy2(
+                PROJECT_ROOT / "THIRD_PARTY_NOTICES.txt",
+                legacy_project_root / "THIRD_PARTY_NOTICES.txt",
+            )
+
             output = temporary / "output"
             environment = os.environ.copy()
             environment.update(
@@ -442,12 +450,15 @@ class ReleasePackageTests(unittest.TestCase):
                     "METASEQUOIA_DEVELOPER_ID_INSTALLER": "Developer ID Installer: Test",
                     "METASEQUOIA_NOTARY_PROFILE": "metasequoia-test-notary",
                     "METASEQUOIA_RELEASE_ASSET_SUFFIX": "",
-                    "METASEQUOIA_PROJECT_ROOT": str(PROJECT_ROOT),
+                    "METASEQUOIA_PROJECT_ROOT": str(legacy_project_root),
                     "METASEQUOIA_RELEASE_INSTALL_SCRIPT": str(
                         PROJECT_ROOT / "scripts/install-release.sh"
                     ),
                     "METASEQUOIA_RELEASE_UNINSTALL_SCRIPT": str(
                         PROJECT_ROOT / "scripts/uninstall.sh"
+                    ),
+                    "METASEQUOIA_INSTALLER_DISTRIBUTION": str(
+                        PROJECT_ROOT / "resources/InstallerDistribution.xml.in"
                     ),
                 }
             )
@@ -877,6 +888,13 @@ class ReleasePackageTests(unittest.TestCase):
             self.assertEqual(domains.attrib["enable_localSystem"], "false")
             self.assertEqual(distribution.find("license").attrib["file"], "LICENSE")
             self.assertEqual(distribution.find("readme").attrib["file"], "InstallerReadMe.txt")
+            package_reference = next(
+                reference
+                for reference in distribution.findall("pkg-ref")
+                if reference.attrib.get("id") == "com.houko.inputmethod.MetasequoiaIME.pkg"
+                and reference.text
+            )
+            self.assertNotIn("onConclusion", package_reference.attrib)
             installer_readme = (expanded_package / "Resources/InstallerReadMe.txt").read_text()
             self.assertIn("UNSIGNED TEST BUILD", installer_readme)
             self.assertIn("not Developer ID signed or notarized", installer_readme)
@@ -884,6 +902,8 @@ class ReleasePackageTests(unittest.TestCase):
             self.assertIn("Third-party notices", installer_readme)
             self.assertIn("MetasequoiaImeEngine", installer_readme)
             self.assertIn("Contents/Resources/Uninstall.command", installer_readme)
+            self.assertIn("may request administrator authorization", installer_readme)
+            self.assertIn("will not log out or restart the Mac automatically", installer_readme)
 
             component_info_path = next(expanded_package.glob("*.pkg/PackageInfo"))
             component_info = ElementTree.parse(component_info_path).getroot()
@@ -891,6 +911,7 @@ class ReleasePackageTests(unittest.TestCase):
             self.assertEqual(component_info.attrib["version"], version)
             self.assertEqual(component_info.attrib["install-location"], "Library/Input Methods")
             self.assertEqual(component_info.attrib["relocatable"], "false")
+            self.assertEqual(component_info.attrib["auth"], "root")
             upgrade_bundle = component_info.find("upgrade-bundle/bundle")
             self.assertIsNotNone(upgrade_bundle)
             self.assertEqual(upgrade_bundle.attrib["id"], "com.houko.inputmethod.MetasequoiaIME")
@@ -900,6 +921,7 @@ class ReleasePackageTests(unittest.TestCase):
             )
             self.assertTrue(packaged_uninstaller.is_file())
             self.assertTrue(os.access(packaged_uninstaller, os.X_OK))
+            self.assertFalse((component_info_path.parent / "Scripts").exists())
             self.assertTrue(
                 (
                     component_info_path.parent


### PR DESCRIPTION
## Summary
- remove `RequireLogout` so the native Installer never forces logout or restart
- stage the fixed Distribution template from the trusted default branch for legacy draft rebuilds
- document the PKG authorization/manual-refresh behavior and recommend `Install.command` for immediate user-level registration

## Verification
- `python3 tests/ReleasePackageTests.py build/MetasequoiaIME.app` (7/7 passed)
- post-rebase `release_package` passed against v0.21.0 sources
- post-rebase remaining CTest suite passed (14/14)
- expanded package asserts no forced conclusion, no package scripts, and `auth=root` is documented
- independent review: no Critical or Important findings