### PR TITLE
docs(release): recommend immediate install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Merges to `main` update a Release Please pull request from conventional commit h
 
 When Apple release credentials are not configured, the workflow publishes the same four assets with `-unsigned` before the file extension and adds a warning to the GitHub Release. Unsigned artifacts are intended for testing and may require explicit approval in macOS privacy and security settings.
 
-Download the `.pkg` and its checksum, verify it, then double-click the package to open the native macOS Installer. The package installs the current user's copy in `~/Library/Input Methods`; the native Installer may request administrator authorization. It will not log out or restart the Mac automatically. macOS may require you to log out and back in at a convenient time before the newly copied input method appears.
+For normal installation, use the ZIP and run its `Install.command`; this is the recommended path because it installs, registers, and enables the current user's input source without automatically logging out or restarting the Mac. The PKG is a compatibility option for users who prefer the native macOS Installer. It copies the same app but cannot reliably enable the current GUI user's input source, so manual enablement in System Settings may still be needed.
+
+If you choose the PKG, download it and its checksum, verify it, then double-click the package. It installs the current user's copy in `~/Library/Input Methods`; the native Installer may request administrator authorization. It will not log out or restart the Mac automatically. macOS may still require you to log out and back in at a convenient time before the newly copied input method appears.
 
 ```sh
 shasum -a 256 -c MetasequoiaIME-vX.Y.Z-macos-universal.pkg.sha256

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -58,21 +58,30 @@ done
 
 mode_marker="<!-- metasequoia-release-mode:$release_mode -->"
 opposite_marker="<!-- metasequoia-release-mode:$opposite_mode -->"
+install_guidance_marker="<!-- metasequoia-install-guidance:v1 -->"
 current_notes=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq '.body // ""')
 if [[ "$current_notes" == *"$opposite_marker"* ]]; then
     printf '%s\n' "Release $TAG_NAME is already locked to $opposite_mode artifacts; refusing to switch it to $release_mode." >&2
     exit 1
 fi
 
-if [[ "$current_notes" != *"$mode_marker"* ]]; then
+if [[ "$current_notes" != *"$mode_marker"* || "$current_notes" != *"$install_guidance_marker"* ]]; then
     release_notes=${RUNNER_TEMP:-${TMPDIR:-/tmp}}/metasequoia-release-notes.md
     {
         if [[ -n "$current_notes" ]]; then
             printf '%s\n\n' "$current_notes"
         fi
-        printf '%s\n' "$mode_marker"
-        if [[ "$release_mode" == unsigned ]]; then
-            printf '%s\n' '> [!WARNING] These macOS artifacts are not Developer ID signed or notarized because release signing credentials were not configured. The asset filenames are marked unsigned.'
+        if [[ "$current_notes" != *"$mode_marker"* ]]; then
+            printf '%s\n' "$mode_marker"
+            if [[ "$release_mode" == unsigned ]]; then
+                printf '%s\n' '> [!WARNING] These macOS artifacts are not Developer ID signed or notarized because release signing credentials were not configured. The asset filenames are marked unsigned.'
+            fi
+        fi
+        if [[ "$current_notes" != *"$install_guidance_marker"* ]]; then
+            printf '%s\n\n' "$install_guidance_marker"
+            printf '%s\n' '### Install on macOS'
+            printf '%s\n' '- **Recommended: ZIP.** Verify its `.sha256`, extract it, then run `Install.command`. It installs for the current user, registers and enables the exact input source, and does not automatically log out or restart the Mac.'
+            printf '%s\n' '- **Compatibility option: PKG.** The native Installer copies the same app but cannot reliably enable the current GUI user’s input source. After installation, enable 水杉 in System Settings > Keyboard > Text Input. The package does not force a logout or restart; macOS may still require a later logout before a newly copied input method appears.'
         fi
     } > "$release_notes"
     gh release edit "$TAG_NAME" --repo "$GH_REPO" --notes-file "$release_notes"

--- a/tests/ReleaseAutomationTests.py
+++ b/tests/ReleaseAutomationTests.py
@@ -236,18 +236,38 @@ fi
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("metasequoia-release-mode:unsigned", notes)
         self.assertIn("not Developer ID signed or notarized", notes)
+        self.assertIn("Recommended: ZIP", notes)
+        self.assertIn("Install.command", notes)
+        self.assertIn("does not automatically log out or restart", notes)
+        self.assertIn("Compatibility option: PKG", notes)
+        self.assertIn("System Settings", notes)
         self.assertLess(calls.index("--notes-file"), calls.index("release upload"))
         self.assertIn("macos-universal-unsigned.pkg", calls)
         self.assertIn("--draft=false", calls)
 
     def test_same_mode_retry_keeps_notes_and_reuploads_with_clobber(self):
-        marker = "Existing notes\n\n<!-- metasequoia-release-mode:unsigned -->\n"
+        marker = (
+            "Existing notes\n\n"
+            "<!-- metasequoia-release-mode:unsigned -->\n"
+            "<!-- metasequoia-install-guidance:v1 -->\n"
+        )
         result, calls, notes = self.run_publication("false", "-unsigned", marker)
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("--notes-file", calls)
         self.assertIn("--clobber", calls)
         self.assertEqual(notes, "")
+
+    def test_retry_adds_install_guidance_to_release_with_only_mode_marker(self):
+        marker = "Existing notes\n\n<!-- metasequoia-release-mode:unsigned -->\n"
+        result, calls, notes = self.run_publication("false", "-unsigned", marker)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Existing notes", notes)
+        self.assertEqual(notes.count("metasequoia-release-mode:unsigned"), 1)
+        self.assertIn("metasequoia-install-guidance:v1", notes)
+        self.assertIn("Recommended: ZIP", notes)
+        self.assertLess(calls.index("--notes-file"), calls.index("release upload"))
 
     def test_cross_mode_retry_is_rejected_before_assets_change(self):
         marker = "<!-- metasequoia-release-mode:unsigned -->"
@@ -265,6 +285,8 @@ fi
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("metasequoia-release-mode:signed", notes)
         self.assertNotIn("WARNING", notes)
+        self.assertIn("Recommended: ZIP", notes)
+        self.assertIn("Compatibility option: PKG", notes)
         self.assertIn("macos-universal.pkg", calls)
 
     def test_corrupt_artifact_is_rejected_before_release_metadata_or_assets_change(self):


### PR DESCRIPTION
## Summary
- mark the ZIP plus `Install.command` as the recommended immediate-install path in every release
- explain that PKG is a compatibility option that may require manual input-source enablement
- state explicitly that neither path automatically logs out or restarts macOS
- keep release-note updates idempotent across workflow retries

## Verification
- `bash -n scripts/publish-release.sh`
- `python3 -m unittest tests.ReleaseAutomationTests tests.ReleaseConfigurationTests` (18 tests)
- `git diff --check`
