### PR TITLE
docs(apple): define the cross-platform architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.25)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "Minimum supported macOS version")
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "macOS target architectures")
 
-project(MetasequoiaImeMac VERSION 0.24.0 LANGUAGES CXX OBJCXX) # x-release-please-version
+project(MetasequoiaImeApple VERSION 0.24.0 LANGUAGES CXX OBJCXX) # x-release-please-version
 
 include(CTest)
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 Metasequoia IME for macOS processes keystrokes, pre-edit text, and candidates locally on the user's Mac. The application does not send typed text, candidates, learned words, preferences, diagnostics, analytics, or crash reports over the network. It does not include cloud synchronization.
 
-The app contacts GitHub's public Releases API at most once per day to discover new stable versions, and when the user manually requests an update check. The request does not include typed text, preferences, or dictionary data. GitHub may receive the IP address and standard network request metadata. Opening an available update uses the corresponding fixed page under `github.com/houko/MetasequoiaImeMac`.
+The app contacts GitHub's public Releases API at most once per day to discover new stable versions, and when the user manually requests an update check. The request does not include typed text, preferences, or dictionary data. GitHub may receive the IP address and standard network request metadata. Opening an available update uses the corresponding fixed page under `github.com/houko/MetasequoiaImeApple`.
 
 The input method stores its settings in the current user's macOS preferences. When candidate learning is enabled, learned word-frequency changes are stored locally under `~/Library/Application Support/metasequoiaime/`. The bundled dictionary is copied to the same directory so it can be upgraded safely. These files are available only through the permissions of the local macOS account; users should protect that account and its backups as they would other personal data.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-# Metasequoia IME for macOS
+# Metasequoia IME for Apple platforms
 
-This repository contains the native macOS frontend for Metasequoia IME. It uses InputMethodKit and AppKit, embeds the shared C++ engine directly, and does not port the Windows TSF or WebView2 host.
+This repository contains the native Apple-platform frontends for Metasequoia IME. The released macOS frontend uses InputMethodKit and AppKit. An iOS host app and custom keyboard extension are being added incrementally. Both platforms consume the same C++ composition engine while keeping their lifecycle, input routing, candidate presentation, settings, and accessibility UI native and independent.
+
+The target module boundaries and migration sequence are documented in [Apple platform architecture](docs/apple-platform-architecture.md). The current `src/`, `resources/`, `scripts/`, and `tests/` directories still contain the macOS implementation; a follow-up pull request will move them under `platforms/macos/` without changing runtime behavior.
+
+## Platform status
+
+| Platform | Status | Native frontend |
+|---|---|---|
+| macOS 12+ | Released | InputMethodKit and AppKit |
+| iOS | In development | Host app and `UIInputViewController` keyboard extension |
+
+The iOS work does not port the Windows TSF or WebView2 host. It reuses `MetasequoiaImeEngine` and supplies an iOS-specific UI and text-document adapter.
 
 The current release supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, composition commit on focus changes, and Shift+Space switching between Chinese and direct English input.
 
@@ -15,8 +26,8 @@ The current release supports full-pinyin composition, live candidates from the o
 ## Build
 
 ```sh
-git clone --recursive https://github.com/houko/MetasequoiaImeMac.git
-cd MetasequoiaImeMac
+git clone --recursive https://github.com/houko/MetasequoiaImeApple.git
+cd MetasequoiaImeApple
 brew install cmake boost fmt spdlog
 ./scripts/build.sh
 ```
@@ -117,8 +128,8 @@ PKG installations keep the same helper inside the installed application bundle, 
 
 ## License
 
-Metasequoia IME for macOS is distributed under the GNU General Public License version 3. Release archives, installer packages, and the application bundle include the applicable GPL and third-party license notices; see `LICENSE` and `THIRD_PARTY_NOTICES.txt`.
+Metasequoia IME for Apple platforms is distributed under the GNU General Public License version 3. Release archives, installer packages, and application bundles include the applicable GPL and third-party license notices; see `LICENSE` and `THIRD_PARTY_NOTICES.txt`.
 
 ## Privacy and security
 
-Input processing and candidate learning are local to the user's Mac; see [PRIVACY.md](PRIVACY.md) for the data-handling details. Report suspected vulnerabilities privately according to [SECURITY.md](SECURITY.md), not through a public issue.
+Input processing and candidate learning are local to the device; see [PRIVACY.md](PRIVACY.md) for the data-handling details. Report suspected vulnerabilities privately according to [SECURITY.md](SECURITY.md), not through a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Security fixes are provided for the latest published version of Metasequoia IME 
 
 Do not open a public issue for a suspected vulnerability or include sensitive proof-of-concept data in public discussions.
 
-Email `suzukaze.haduki@gmail.com` with the subject `MetasequoiaImeMac security report`. Include the affected version, macOS version and architecture, expected and observed behavior, reproduction steps, and the security impact. Attach only the minimum data needed to reproduce the issue; never include real text typed with the input method, credentials, signing material, or other personal data.
+Email `suzukaze.haduki@gmail.com` with the subject `MetasequoiaImeApple security report`. Include the affected version, platform version and architecture, expected and observed behavior, reproduction steps, and the security impact. Attach only the minimum data needed to reproduce the issue; never include real text typed with the input method, credentials, signing material, or other personal data.
 
 The maintainer will coordinate disclosure and remediation with the reporter. Please allow time for a fixed release to become available before publishing technical details.
 

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -4,7 +4,7 @@ Metasequoia IME for macOS — Third-Party Notices
 This application embeds MetasequoiaImeEngine, which is distributed under
 the GNU General Public License version 3. The complete license is provided
 in GPL-3.0.txt. Source code is available from:
-https://github.com/houko/MetasequoiaImeMac
+https://github.com/houko/MetasequoiaImeApple
 https://github.com/houko/MetasequoiaImeEngine
 
 The application also incorporates the following components:

--- a/docs/apple-platform-architecture.md
+++ b/docs/apple-platform-architecture.md
@@ -1,0 +1,114 @@
+# Apple platform architecture
+
+## Goal
+
+Metasequoia IME uses one composition engine across macOS and iOS, with a separate native frontend for each platform. The shared layer owns input-method behavior; platform layers own operating-system integration and presentation.
+
+This repository is named `MetasequoiaImeApple` because it contains Apple-platform adapters and applications. The reusable engine remains in the independent `MetasequoiaImeEngine` repository so Windows, Apple, and future frontends do not depend on an Apple application project.
+
+## Ownership boundaries
+
+| Layer | Owns | Must not own |
+|---|---|---|
+| `MetasequoiaImeEngine` | Composition state, schemes, candidate generation, candidate selection, punctuation policy, learning, dictionary access | AppKit, UIKit, InputMethodKit, text-document APIs, platform windows |
+| Apple bridge | Stable C++/Objective-C++ boundary, UTF-8/String conversion, platform-neutral result models | Candidate window state, preferences UI, operating-system lifecycle |
+| macOS frontend | InputMethodKit events, marked text, native candidate panel, macOS settings, registration, Sparkle updates | A second composition state machine or copied engine policy |
+| iOS keyboard extension | `UIInputViewController`, key grid, candidate UI, `textDocumentProxy`, next-keyboard control, extension lifecycle | macOS update/registration code or persistent engine behavior duplicated in Swift |
+| iOS host app | Onboarding, keyboard-enablement guidance, settings, privacy disclosure, optional App Group migration | Direct insertion into another app's document |
+
+The engine is the only authority for a composition and its candidates. A platform frontend translates native events into engine calls, renders the returned state, and inserts committed text through the platform API.
+
+```text
+MetasequoiaImeEngine (C++17)
+          |
+          v
+shared/apple-bridge
+       /       \
+      v         v
+macOS frontend  iOS keyboard extension
+InputMethodKit  UIInputViewController
+      |         |
+      v         v
+macOS settings  iOS host app/settings
+```
+
+## Target repository layout
+
+The migration will converge on this layout:
+
+```text
+MetasequoiaImeApple/
+├── platforms/
+│   ├── macos/
+│   │   ├── src/
+│   │   ├── resources/
+│   │   ├── scripts/
+│   │   └── tests/
+│   └── ios/
+│       ├── App/
+│       │   ├── Sources/
+│       │   └── Resources/
+│       ├── KeyboardExtension/
+│       │   ├── Sources/
+│       │   └── Resources/
+│       ├── SharedUI/
+│       └── Tests/
+├── shared/
+│   └── apple-bridge/
+│       ├── include/
+│       ├── src/
+│       └── tests/
+├── vendor/
+│   ├── MetasequoiaImeEngine/
+│   └── MetasequoiaImeDict/
+├── cmake/
+├── docs/
+└── CMakeLists.txt
+```
+
+`SharedUI` is limited to intentionally identical iOS app/extension components such as colors and small Swift value types. It is not shared with macOS. UI code is not moved into the C++ engine.
+
+## iOS operating constraints
+
+The iOS frontend is a custom keyboard extension. It inserts and removes text only through `textDocumentProxy`, and it must expose the system next-keyboard action when required. Secure text fields, phone-pad fields, and applications that reject third-party keyboards can replace or disable the extension; those are operating-system boundaries rather than engine failures.
+
+The first usable keyboard will run entirely on-device without Open Access. App Group configuration and `RequestsOpenAccess` will be introduced only in a later, explicit feature when shared settings or dictionaries require them. Network access is not part of the base architecture.
+
+Extension memory and startup time are stricter than on macOS. The bridge therefore creates engine state lazily, avoids background services, and tears down platform objects with the extension lifecycle. Dictionary packaging and memory measurements must be verified on a real device before declaring the iOS frontend production-ready.
+
+## Stable product identities
+
+Repository and source-directory names may change, but these published identities remain stable unless a migration is designed separately:
+
+- macOS bundle and input-source identifiers
+- macOS application name `MetasequoiaIME.app`
+- existing release asset names and Sparkle signing key
+- user preferences and learned-data locations
+- engine database and user-dictionary formats
+
+The canonical update feed uses the renamed repository URL. GitHub redirects the previous repository URL, so already released macOS builds continue to find updates.
+
+The iOS host app, keyboard extension, App Group, and signing identifiers will be introduced as new identities. They must not reuse the macOS input-source identifier.
+
+## Pull-request sequence
+
+Each step must leave the existing macOS release build usable:
+
+1. Move the platform-neutral input session into `MetasequoiaImeEngine` and consume it from macOS.
+2. Rename the repository and document the cross-platform ownership boundaries.
+3. Move the current macOS files under `platforms/macos/`; update build, packaging, release, and test paths without changing behavior.
+4. Add the iOS host app and keyboard-extension shell, including onboarding and the required next-keyboard control. Keep input local and use a deterministic placeholder layout until the engine bridge is connected.
+5. Add `shared/apple-bridge`, link the engine into the keyboard extension, and cover character input, backspace, raw commit, leading-candidate commit, cancel, and candidate selection.
+6. Add the native iOS candidate surface and device-level keyboard interaction tests.
+7. Add settings and dictionary/language features incrementally, introducing App Group or Open Access only when a reviewed requirement needs them.
+
+Behavior changes are not bundled into directory-move pull requests. macOS and iOS UI work remain separate so each can be reviewed and verified against its platform lifecycle.
+
+## Verification gates
+
+The root CI will eventually contain two independent jobs:
+
+- macOS: arm64 and x86_64 CMake build, shared-engine tests, native frontend tests, bundle validation, signing validation, and release-package tests.
+- iOS: iPhone Simulator build for the host app and keyboard extension, bridge tests, extension Info.plist validation, and UI smoke tests through the Orca iOS emulator.
+
+Shared-engine behavior is tested in `MetasequoiaImeEngine`. Apple bridge tests verify type conversion and lifecycle boundaries. Platform tests verify event routing and native UI behavior without copying the engine's candidate policy tests.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "MetasequoiaImeMac",
+      "package-name": "MetasequoiaImeApple",
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "version-file": "version.txt",

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -72,7 +72,7 @@
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>SUFeedURL</key>
-    <string>https://github.com/houko/MetasequoiaImeMac/releases/latest/download/appcast.xml</string>
+    <string>https://github.com/houko/MetasequoiaImeApple/releases/latest/download/appcast.xml</string>
     <key>SUEnableAutomaticChecks</key>
     <true/>
     <key>SUPublicEDKey</key>

--- a/tests/ReleaseAutomationTests.py
+++ b/tests/ReleaseAutomationTests.py
@@ -34,7 +34,7 @@ class ReleaseAutomationTests(unittest.TestCase):
 set -euo pipefail
 print -r -- "$*" >> "$FAKE_GH_LOG"
 if [[ "$1 $2" == "pr view" ]]; then
-    print -r -- "{\\"number\\":42,\\"state\\":\\"OPEN\\",\\"isDraft\\":false,\\"headRefName\\":\\"release-please--branches--main--components--MetasequoiaImeMac\\",\\"headRefOid\\":\\"$FAKE_HEAD_SHA\\",\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"$FAKE_BASE_SHA\\",\\"title\\":\\"chore(main): release 1.2.3\\"}"
+    print -r -- "{\\"number\\":42,\\"state\\":\\"OPEN\\",\\"isDraft\\":false,\\"headRefName\\":\\"release-please--branches--main--components--MetasequoiaImeApple\\",\\"headRefOid\\":\\"$FAKE_HEAD_SHA\\",\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"$FAKE_BASE_SHA\\",\\"title\\":\\"chore(main): release 1.2.3\\"}"
 elif [[ "$1 $2" == "workflow run" ]]; then
     exit 0
 elif [[ "$1 $2" == "run list" ]]; then
@@ -53,14 +53,14 @@ fi
             )
             fake_gh.chmod(0o755)
             release_pr = {
-                "headBranchName": "release-please--branches--main--components--MetasequoiaImeMac",
+                "headBranchName": "release-please--branches--main--components--MetasequoiaImeApple",
                 "number": 42,
             }
             environment = os.environ.copy()
             environment.update(
                 {
                     "PATH": f"{temporary}:{environment['PATH']}",
-                    "GH_REPO": "houko/MetasequoiaImeMac",
+                    "GH_REPO": "houko/MetasequoiaImeApple",
                     "RELEASE_PR": json.dumps(release_pr),
                     "GITHUB_OUTPUT": str(output),
                     "FAKE_GH_LOG": str(log),
@@ -216,7 +216,7 @@ fi
             environment.update(
                 {
                     "PATH": f"{fake_bin}:{environment['PATH']}",
-                    "GH_REPO": "houko/MetasequoiaImeMac",
+                    "GH_REPO": "houko/MetasequoiaImeApple",
                     "TAG_NAME": "v1.2.3",
                     "ASSET_SUFFIX": asset_suffix,
                     "SIGNING_ENABLED": signing_enabled,
@@ -344,7 +344,7 @@ while (($#)); do
     shift
 done
 cat > "$output" <<'XML'
-<?xml version="1.0"?><rss><channel><item><enclosure url="https://github.com/houko/MetasequoiaImeMac/releases/download/v1.2.3/MetasequoiaIME-v1.2.3-macos-universal-unsigned-update.zip" sparkle:edSignature="test-signature" /></item></channel></rss>
+<?xml version="1.0"?><rss><channel><item><enclosure url="https://github.com/houko/MetasequoiaImeApple/releases/download/v1.2.3/MetasequoiaIME-v1.2.3-macos-universal-unsigned-update.zip" sparkle:edSignature="test-signature" /></item></channel></rss>
 XML
 """
             )
@@ -368,7 +368,7 @@ fi
                     "SPARKLE_TOOLS_DIR": str(tools),
                     "SPARKLE_ED_PRIVATE_KEY": private_key,
                     "FAKE_SPARKLE_LOG": str(log),
-                    "GH_REPO": "houko/MetasequoiaImeMac",
+                    "GH_REPO": "houko/MetasequoiaImeApple",
                 }
             )
             result = subprocess.run(

--- a/tests/ReleaseConfigurationTests.py
+++ b/tests/ReleaseConfigurationTests.py
@@ -31,7 +31,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
     def test_release_version_matches_cmake_project_version(self):
         manifest = json.loads((PROJECT_ROOT / ".release-please-manifest.json").read_text())
         cmake = (PROJECT_ROOT / "CMakeLists.txt").read_text()
-        project_line = next(line for line in cmake.splitlines() if line.startswith("project(MetasequoiaImeMac "))
+        project_line = next(line for line in cmake.splitlines() if line.startswith("project(MetasequoiaImeApple "))
         match = re.search(r"VERSION ([0-9]+\.[0-9]+\.[0-9]+)", project_line)
 
         self.assertIsNotNone(match)
@@ -283,7 +283,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("SECURITY.md", privacy)
         self.assertIn("latest published version", security)
         self.assertIn("Do not open a public issue", security)
-        self.assertIn("MetasequoiaImeMac security report", security)
+        self.assertIn("MetasequoiaImeApple security report", security)
         self.assertIn("PRIVACY.md", readme)
         self.assertIn("SECURITY.md", readme)
 


### PR DESCRIPTION
## Summary

- renames the project identity and canonical repository links to MetasequoiaImeApple
- documents one shared C++ engine with independent native macOS and iOS frontends
- defines the target directory layout, platform ownership boundaries, stable product identities, iOS constraints, CI gates, and progressive PR sequence
- keeps iOS status explicitly marked as in development

## Verification

- ReleaseAutomationTests.py: 16 passed
- ReleaseConfigurationTests.py: 6 passed
- rebased onto the merged shared-session change

## Compatibility

Existing macOS bundle identifiers, artifact names, preferences, learned data, and Sparkle signing identity remain unchanged. GitHub redirects the previous repository URL for already released clients.