### PR TITLE
feat(ios): add host app and keyboard extension shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
       - name: Validate keyboard configuration
         run: python3 platforms/ios/tests/ProjectConfigurationTests.py
       - name: Generate Xcode project
-        run: xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
+        run: |
+          mkdir -p build/ios
+          xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
       - name: Build host app and keyboard extension
         run: |
           xcodebuild \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,27 @@ jobs:
           test "$(/usr/libexec/PlistBuddy -c 'Print :TISInputSourceID' build/MetasequoiaIME.app/Contents/Info.plist)" = "com.houko.inputmethod.MetasequoiaIME"
           test "$(/usr/libexec/PlistBuddy -c 'Print :TISIntendedLanguage' build/MetasequoiaIME.app/Contents/Info.plist)" = "zh-Hans"
           test "$(/usr/libexec/PlistBuddy -c 'Print :ComponentInputModeDict:tsInputModeListKey:com.houko.inputmethod.MetasequoiaIME.Hans:tsInputModeScriptKey' build/MetasequoiaIME.app/Contents/Info.plist)" = "smSimpChinese"
+
+  ios:
+    name: iOS Simulator
+    runs-on: macos-15
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install project generator
+        run: brew install xcodegen
+      - name: Validate keyboard configuration
+        run: python3 platforms/ios/tests/ProjectConfigurationTests.py
+      - name: Generate Xcode project
+        run: xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
+      - name: Build host app and keyboard extension
+        run: |
+          xcodebuild \
+            -project build/ios/MetasequoiaImeIOS.xcodeproj \
+            -scheme MetasequoiaImeIOS \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build/ios-derived \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/platforms/ios/App/Resources/Info.plist
+++ b/platforms/ios/App/Resources/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>水杉输入法</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/platforms/ios/App/Sources/MetasequoiaImeApp.swift
+++ b/platforms/ios/App/Sources/MetasequoiaImeApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MetasequoiaImeApp: App {
+  var body: some Scene {
+    WindowGroup {
+      OnboardingView()
+    }
+  }
+}

--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import UIKit
+
+struct OnboardingView: View {
+  @State private var sampleText = ""
+
+  private let steps = [
+    ("1", "打开键盘设置", "前往“设置 → 通用 → 键盘 → 键盘”。"),
+    ("2", "添加水杉输入法", "选择“添加新键盘”，再选择水杉输入法。"),
+    ("3", "切换并开始输入", "在输入框长按地球键，选择水杉输入法。"),
+  ]
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 28) {
+        header
+
+        VStack(spacing: 0) {
+          ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+            stepRow(
+              number: step.0, title: step.1, detail: step.2, drawsLine: index < steps.count - 1)
+          }
+        }
+        .padding(.horizontal, 20)
+        .background(.background, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+
+        Button(action: openSettings) {
+          Label("打开系统设置", systemImage: "gearshape.fill")
+            .font(.headline)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 15)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.white)
+        .background(
+          MetasequoiaTheme.forest, in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+        )
+        .accessibilityHint("打开水杉输入法的系统设置页面")
+
+        VStack(alignment: .leading, spacing: 10) {
+          Text("启用后试一试")
+            .font(.headline)
+            .foregroundStyle(MetasequoiaTheme.ink)
+          TextField("在这里试试水杉键盘", text: $sampleText)
+            .textFieldStyle(.plain)
+            .padding(.horizontal, 16)
+            .frame(minHeight: 52)
+            .background(.background, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay {
+              RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(MetasequoiaTheme.needle.opacity(0.35), lineWidth: 1)
+            }
+            .accessibilityIdentifier("keyboardTryoutField")
+        }
+
+        Text("键盘扩展默认不请求“允许完全访问”。输入内容保留在设备上。")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, alignment: .center)
+      }
+      .padding(.horizontal, 22)
+      .padding(.vertical, 30)
+    }
+    .background(MetasequoiaTheme.mist.ignoresSafeArea())
+    .tint(MetasequoiaTheme.forest)
+  }
+
+  private var header: some View {
+    HStack(alignment: .center, spacing: 18) {
+      MetasequoiaMark()
+        .stroke(
+          MetasequoiaTheme.forest,
+          style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round)
+        )
+        .frame(width: 58, height: 76)
+        .padding(12)
+        .background(.background, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .accessibilityHidden(true)
+
+      VStack(alignment: .leading, spacing: 5) {
+        Text("水杉输入法")
+          .font(.system(.largeTitle, design: .rounded).weight(.bold))
+          .foregroundStyle(MetasequoiaTheme.ink)
+        Text("同一颗引擎，原生 iOS 键盘")
+          .font(.subheadline.weight(.medium))
+          .foregroundStyle(MetasequoiaTheme.needle)
+      }
+    }
+  }
+
+  private func stepRow(number: String, title: String, detail: String, drawsLine: Bool) -> some View
+  {
+    HStack(alignment: .top, spacing: 16) {
+      VStack(spacing: 0) {
+        Text(number)
+          .font(.system(.headline, design: .rounded).weight(.bold))
+          .foregroundStyle(.white)
+          .frame(width: 34, height: 34)
+          .background(MetasequoiaTheme.cone, in: Circle())
+        if drawsLine {
+          Rectangle()
+            .fill(MetasequoiaTheme.needle.opacity(0.3))
+            .frame(width: 2, height: 54)
+        }
+      }
+
+      VStack(alignment: .leading, spacing: 5) {
+        Text(title)
+          .font(.headline)
+          .foregroundStyle(MetasequoiaTheme.ink)
+        Text(detail)
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(.top, 5)
+
+      Spacer(minLength: 0)
+    }
+    .padding(.top, 18)
+  }
+
+  private func openSettings() {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+    UIApplication.shared.open(url)
+  }
+}
+
+#Preview {
+  OnboardingView()
+}

--- a/platforms/ios/KeyboardExtension/Resources/Info.plist
+++ b/platforms/ios/KeyboardExtension/Resources/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>水杉输入法</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>IsASCIICapable</key>
+            <true/>
+            <key>PrefersRightToLeft</key>
+            <false/>
+            <key>PrimaryLanguage</key>
+            <string>zh-Hans</string>
+            <key>RequestsOpenAccess</key>
+            <false/>
+        </dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.keyboard-service</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).KeyboardViewController</string>
+    </dict>
+</dict>
+</plist>

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -1,0 +1,143 @@
+import UIKit
+
+@MainActor
+final class KeyboardViewController: UIInputViewController {
+  private let letterRows = [
+    Array("qwertyuiop"),
+    Array("asdfghjkl"),
+    Array("zxcvbnm"),
+  ]
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = MetasequoiaTheme.keyboardBackground
+    installKeyboard()
+  }
+
+  private func installKeyboard() {
+    let root = UIStackView()
+    root.axis = .vertical
+    root.spacing = 7
+    root.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(root)
+
+    NSLayoutConstraint.activate([
+      root.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 5),
+      root.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -5),
+      root.topAnchor.constraint(equalTo: view.topAnchor, constant: 7),
+      root.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -7),
+      view.heightAnchor.constraint(greaterThanOrEqualToConstant: 270),
+    ])
+
+    root.addArrangedSubview(makeCandidateStrip())
+    for row in letterRows {
+      root.addArrangedSubview(makeLetterRow(row))
+    }
+    root.addArrangedSubview(makeActionRow())
+  }
+
+  private func makeCandidateStrip() -> UIView {
+    let container = UIView()
+    container.backgroundColor = MetasequoiaTheme.keyBackground.withAlphaComponent(0.82)
+    container.layer.cornerRadius = 12
+
+    let label = UILabel()
+    label.text = "水杉输入法 · iOS 预览"
+    label.font = .preferredFont(forTextStyle: .subheadline)
+    label.textColor = MetasequoiaTheme.forestUIColor
+    label.adjustsFontForContentSizeCategory = true
+    label.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(label)
+
+    NSLayoutConstraint.activate([
+      container.heightAnchor.constraint(equalToConstant: 38),
+      label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
+      label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -14),
+      label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+    ])
+    return container
+  }
+
+  private func makeLetterRow(_ letters: [Character]) -> UIStackView {
+    let row = makeRow()
+    for letter in letters {
+      let text = String(letter)
+      row.addArrangedSubview(
+        makeKey(title: text, accessibilityLabel: text.uppercased()) { [weak self] in
+          self?.textDocumentProxy.insertText(text)
+        })
+    }
+    return row
+  }
+
+  private func makeActionRow() -> UIStackView {
+    let row = makeRow()
+    row.addArrangedSubview(
+      makeSymbolKey(symbol: "globe", accessibilityLabel: "下一个键盘") { [weak self] in
+        self?.advanceToNextInputMode()
+      })
+    row.addArrangedSubview(
+      makeSymbolKey(symbol: "delete.left", accessibilityLabel: "删除") { [weak self] in
+        self?.textDocumentProxy.deleteBackward()
+      })
+
+    let space = makeKey(title: "空格", accessibilityLabel: "空格") { [weak self] in
+      self?.textDocumentProxy.insertText(" ")
+    }
+    space.widthAnchor.constraint(greaterThanOrEqualToConstant: 120).isActive = true
+    row.addArrangedSubview(space)
+
+    let enter = makeKey(title: "换行", accessibilityLabel: "换行", emphasized: true) { [weak self] in
+      self?.textDocumentProxy.insertText("\n")
+    }
+    row.addArrangedSubview(enter)
+    return row
+  }
+
+  private func makeRow() -> UIStackView {
+    let row = UIStackView()
+    row.axis = .horizontal
+    row.alignment = .fill
+    row.distribution = .fillEqually
+    row.spacing = 6
+    return row
+  }
+
+  private func makeSymbolKey(
+    symbol: String, accessibilityLabel: String, action: @escaping () -> Void
+  ) -> UIButton {
+    var configuration = UIButton.Configuration.plain()
+    configuration.image = UIImage(systemName: symbol)
+    configuration.baseForegroundColor = .label
+    configuration.background.backgroundColor = MetasequoiaTheme.keyBackground
+    configuration.background.cornerRadius = 8
+    let button = UIButton(configuration: configuration, primaryAction: UIAction { _ in action() })
+    button.accessibilityLabel = accessibilityLabel
+    return button
+  }
+
+  private func makeKey(
+    title: String,
+    accessibilityLabel: String,
+    emphasized: Bool = false,
+    action: @escaping () -> Void
+  ) -> UIButton {
+    var configuration = UIButton.Configuration.plain()
+    configuration.title = title
+    configuration.baseForegroundColor = emphasized ? .white : .label
+    configuration.background.backgroundColor =
+      emphasized
+      ? UIColor(red: 167 / 255, green: 103 / 255, blue: 59 / 255, alpha: 1)
+      : MetasequoiaTheme.keyBackground
+    configuration.background.cornerRadius = 8
+    configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
+      attributes in
+      var attributes = attributes
+      attributes.font = .preferredFont(forTextStyle: .title3)
+      return attributes
+    }
+    let button = UIButton(configuration: configuration, primaryAction: UIAction { _ in action() })
+    button.accessibilityLabel = accessibilityLabel
+    return button
+  }
+}

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -1,7 +1,17 @@
 # iOS frontend
 
-This directory is reserved for the native iOS host app, custom keyboard extension, iOS-only shared UI, and their tests.
+This directory contains the native iOS host app, custom keyboard extension, iOS-only shared UI, and their tests. `project.yml` is the reproducible XcodeGen source of truth; generated `.xcodeproj` files are build artifacts and are not committed.
 
 The iOS frontend will consume `MetasequoiaImeEngine` through `shared/apple-bridge`. It must not import AppKit, InputMethodKit, Sparkle, macOS registration helpers, or macOS installer code. The first functional keyboard will operate locally without Open Access; App Group and network-related capabilities require a later, explicit design and review.
 
 See [Apple platform architecture](../../docs/apple-platform-architecture.md) for ownership boundaries and the progressive pull-request sequence.
+
+Generate and build the current shell for the Simulator from the repository root:
+
+```sh
+brew install xcodegen
+xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
+xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaImeIOS -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/ios-derived CODE_SIGNING_ALLOWED=NO build
+```
+
+The current keyboard shell inserts direct lowercase text and exposes Space, Return, Backspace, and the required next-keyboard control. Composition and candidates are intentionally deferred to the engine-bridge pull request.

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -10,6 +10,7 @@ Generate and build the current shell for the Simulator from the repository root:
 
 ```sh
 brew install xcodegen
+mkdir -p build/ios
 xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
 xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaImeIOS -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/ios-derived CODE_SIGNING_ALLOWED=NO build
 ```

--- a/platforms/ios/SharedUI/MetasequoiaTheme.swift
+++ b/platforms/ios/SharedUI/MetasequoiaTheme.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import UIKit
+
+enum MetasequoiaTheme {
+  static let forest = Color(red: 24 / 255, green: 92 / 255, blue: 72 / 255)
+  static let needle = Color(red: 77 / 255, green: 138 / 255, blue: 114 / 255)
+  static let mist = Color(red: 243 / 255, green: 247 / 255, blue: 245 / 255)
+  static let cone = Color(red: 167 / 255, green: 103 / 255, blue: 59 / 255)
+  static let ink = Color(red: 20 / 255, green: 35 / 255, blue: 29 / 255)
+
+  static let forestUIColor = UIColor { traits in
+    traits.userInterfaceStyle == .dark
+      ? UIColor(red: 97 / 255, green: 180 / 255, blue: 145 / 255, alpha: 1)
+      : UIColor(red: 24 / 255, green: 92 / 255, blue: 72 / 255, alpha: 1)
+  }
+
+  static let keyboardBackground = UIColor { traits in
+    traits.userInterfaceStyle == .dark
+      ? UIColor(red: 24 / 255, green: 30 / 255, blue: 27 / 255, alpha: 1)
+      : UIColor(red: 232 / 255, green: 239 / 255, blue: 235 / 255, alpha: 1)
+  }
+
+  static let keyBackground = UIColor { traits in
+    traits.userInterfaceStyle == .dark
+      ? UIColor(red: 48 / 255, green: 56 / 255, blue: 52 / 255, alpha: 1)
+      : .white
+  }
+}
+
+struct MetasequoiaMark: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    let centerX = rect.midX
+    path.move(to: CGPoint(x: centerX, y: rect.minY + rect.height * 0.08))
+    path.addLine(to: CGPoint(x: centerX, y: rect.maxY * 0.9))
+
+    for level in 0..<4 {
+      let y = rect.minY + rect.height * (0.25 + CGFloat(level) * 0.18)
+      let reach = rect.width * (0.2 + CGFloat(level) * 0.08)
+      path.move(to: CGPoint(x: centerX, y: y - rect.height * 0.11))
+      path.addLine(to: CGPoint(x: centerX - reach, y: y))
+      path.move(to: CGPoint(x: centerX, y: y - rect.height * 0.11))
+      path.addLine(to: CGPoint(x: centerX + reach, y: y))
+    }
+    return path
+  }
+}

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -1,0 +1,52 @@
+name: MetasequoiaImeIOS
+
+options:
+  bundleIdPrefix: com.houko.metasequoiaime
+  createIntermediateGroups: true
+  deploymentTarget:
+    iOS: "15.0"
+
+settings:
+  base:
+    CURRENT_PROJECT_VERSION: 1
+    MARKETING_VERSION: 0.1.0
+    SWIFT_VERSION: 6.0
+    IPHONEOS_DEPLOYMENT_TARGET: 15.0
+
+targets:
+  MetasequoiaImeIOS:
+    type: application
+    platform: iOS
+    sources:
+      - path: platforms/ios/App/Sources
+      - path: platforms/ios/SharedUI
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: $(PROJECT_DIR)/../../platforms/ios/App/Resources/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios
+        PRODUCT_NAME: MetasequoiaIME
+    dependencies:
+      - target: MetasequoiaKeyboard
+
+  MetasequoiaKeyboard:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: platforms/ios/KeyboardExtension/Sources
+      - path: platforms/ios/SharedUI
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Resources/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios.keyboard
+        PRODUCT_NAME: MetasequoiaKeyboard
+
+schemes:
+  MetasequoiaImeIOS:
+    build:
+      targets:
+        MetasequoiaImeIOS: all
+        MetasequoiaKeyboard: all
+    run:
+      config: Debug

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -39,6 +39,11 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn('TextField("在这里试试水杉键盘"', onboarding)
         self.assertIn('.accessibilityIdentifier("keyboardTryoutField")', onboarding)
 
+    def test_ci_creates_the_generated_project_output_directory(self):
+        workflow = (IOS_ROOT.parents[1] / ".github/workflows/ci.yml").read_text()
+
+        self.assertIn("mkdir -p build/ios", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -1,0 +1,44 @@
+import plistlib
+import unittest
+from pathlib import Path
+
+
+IOS_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProjectConfigurationTests(unittest.TestCase):
+    def test_project_defines_distinct_host_and_keyboard_identifiers(self):
+        project = (IOS_ROOT / "project.yml").read_text()
+
+        self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios\n", project)
+        self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios.keyboard\n", project)
+        self.assertIn("deploymentTarget:\n    iOS: \"15.0\"", project)
+
+    def test_keyboard_is_local_and_declares_the_system_extension_contract(self):
+        with (IOS_ROOT / "KeyboardExtension/Resources/Info.plist").open("rb") as info_file:
+            info = plistlib.load(info_file)
+
+        extension = info["NSExtension"]
+        attributes = extension["NSExtensionAttributes"]
+        self.assertEqual(extension["NSExtensionPointIdentifier"], "com.apple.keyboard-service")
+        self.assertEqual(extension["NSExtensionPrincipalClass"], "$(PRODUCT_MODULE_NAME).KeyboardViewController")
+        self.assertEqual(attributes["PrimaryLanguage"], "zh-Hans")
+        self.assertFalse(attributes["RequestsOpenAccess"])
+
+    def test_keyboard_exposes_required_document_and_next_keyboard_actions(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("textDocumentProxy.insertText", controller)
+        self.assertIn("textDocumentProxy.deleteBackward", controller)
+        self.assertIn("advanceToNextInputMode()", controller)
+        self.assertNotIn("URLSession", controller)
+
+    def test_onboarding_exposes_a_regular_text_field_for_keyboard_tryout(self):
+        onboarding = (IOS_ROOT / "App/Sources/OnboardingView.swift").read_text()
+
+        self.assertIn('TextField("在这里试试水杉键盘"', onboarding)
+        self.assertIn('.accessibilityIdentifier("keyboardTryoutField")', onboarding)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a reproducible XcodeGen project with an iOS host app and custom keyboard extension
- add native onboarding, a keyboard tryout field, shared Apple visual theme, and a QWERTY shell
- keep the extension local-first with `RequestsOpenAccess=false`
- add an iOS Simulator build job and configuration contract tests

## Scope

This PR intentionally inserts direct lowercase text only. Engine composition and candidate routing will follow in the next incremental PR through `shared/apple-bridge`.

## Verification

- `python3 platforms/ios/tests/ProjectConfigurationTests.py` (4 tests)
- `xcrun swift-format lint --strict` on all new Swift sources
- generic iOS Simulator build with code signing disabled
- source and built extension plists validated with `plutil`
- Orca iPhone 17 Pro: host layout inspected, Settings link opened, keyboard discovered and added, custom keyboard selected, `q` insertion and Backspace verified
- Safari address field correctly excluded the third-party keyboard under iOS restricted-field behavior
