### PR TITLE
feat(ios): route keyboard through shared engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,10 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
       - name: Install project generator
-        run: brew install xcodegen
+        run: brew install boost fmt spdlog xcodegen
       - name: Validate keyboard configuration
         run: python3 platforms/ios/tests/ProjectConfigurationTests.py
       - name: Generate Xcode project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ if(BUILD_TESTING)
     target_link_libraries(MetasequoiaCandidateSelectionStateTests PRIVATE MetasequoiaIme::Engine)
     target_compile_options(MetasequoiaCandidateSelectionStateTests PRIVATE -Wall -Wextra -Wpedantic -Werror)
     add_test(NAME candidate_selection_state COMMAND MetasequoiaCandidateSelectionStateTests)
+    add_executable(MetasequoiaAppleInputSessionAdapterTests
+        platforms/ios/Tests/InputSessionAdapterTests.cpp
+        shared/apple-bridge/InputSessionAdapter.cpp)
+    target_include_directories(MetasequoiaAppleInputSessionAdapterTests PRIVATE shared/apple-bridge)
+    target_link_libraries(MetasequoiaAppleInputSessionAdapterTests PRIVATE MetasequoiaIme::Engine)
+    target_compile_options(MetasequoiaAppleInputSessionAdapterTests PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    add_test(NAME apple_input_session_adapter COMMAND MetasequoiaAppleInputSessionAdapterTests)
     add_executable(MetasequoiaInputControllerKeyRoutingTests ${METASEQUOIA_MACOS_ROOT}/tests/InputControllerKeyRoutingTests.mm)
     target_compile_options(MetasequoiaInputControllerKeyRoutingTests PRIVATE -fobjc-arc -Wall -Wextra -Wpedantic -Werror)
     target_link_libraries(MetasequoiaInputControllerKeyRoutingTests PRIVATE ${APPKIT_FRAMEWORK} ${INPUT_METHOD_KIT_FRAMEWORK})

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -2,6 +2,11 @@ import UIKit
 
 @MainActor
 final class KeyboardViewController: UIInputViewController {
+  private let session = MetasequoiaInputSessionBridge()
+  private let preeditLabel = UILabel()
+  private let candidateScrollView = UIScrollView()
+  private let candidateStack = UIStackView()
+
   private let letterRows = [
     Array("qwertyuiop"),
     Array("asdfghjkl"),
@@ -12,6 +17,12 @@ final class KeyboardViewController: UIInputViewController {
     super.viewDidLoad()
     view.backgroundColor = MetasequoiaTheme.keyboardBackground
     installKeyboard()
+    updateCandidateStrip(preedit: "", candidates: [])
+  }
+
+  override func textWillChange(_ textInput: UITextInput?) {
+    super.textWillChange(textInput)
+    render(session.cancel())
   }
 
   private func installKeyboard() {
@@ -41,19 +52,40 @@ final class KeyboardViewController: UIInputViewController {
     container.backgroundColor = MetasequoiaTheme.keyBackground.withAlphaComponent(0.82)
     container.layer.cornerRadius = 12
 
-    let label = UILabel()
-    label.text = "水杉输入法 · iOS 预览"
-    label.font = .preferredFont(forTextStyle: .subheadline)
-    label.textColor = MetasequoiaTheme.forestUIColor
-    label.adjustsFontForContentSizeCategory = true
-    label.translatesAutoresizingMaskIntoConstraints = false
-    container.addSubview(label)
+    preeditLabel.font = .preferredFont(forTextStyle: .subheadline)
+    preeditLabel.textColor = MetasequoiaTheme.forestUIColor
+    preeditLabel.adjustsFontForContentSizeCategory = true
+    preeditLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    candidateStack.axis = .horizontal
+    candidateStack.spacing = 6
+    candidateStack.translatesAutoresizingMaskIntoConstraints = false
+    candidateScrollView.showsHorizontalScrollIndicator = false
+    candidateScrollView.addSubview(candidateStack)
+
+    let content = UIStackView(arrangedSubviews: [preeditLabel, candidateScrollView])
+    content.axis = .horizontal
+    content.alignment = .center
+    content.spacing = 12
+    content.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(content)
 
     NSLayoutConstraint.activate([
       container.heightAnchor.constraint(equalToConstant: 38),
-      label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
-      label.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -14),
-      label.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+      content.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
+      content.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+      content.topAnchor.constraint(equalTo: container.topAnchor),
+      content.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+      candidateStack.leadingAnchor.constraint(
+        equalTo: candidateScrollView.contentLayoutGuide.leadingAnchor),
+      candidateStack.trailingAnchor.constraint(
+        equalTo: candidateScrollView.contentLayoutGuide.trailingAnchor),
+      candidateStack.topAnchor.constraint(
+        equalTo: candidateScrollView.contentLayoutGuide.topAnchor),
+      candidateStack.bottomAnchor.constraint(
+        equalTo: candidateScrollView.contentLayoutGuide.bottomAnchor),
+      candidateStack.heightAnchor.constraint(
+        equalTo: candidateScrollView.frameLayoutGuide.heightAnchor),
     ])
     return container
   }
@@ -64,7 +96,7 @@ final class KeyboardViewController: UIInputViewController {
       let text = String(letter)
       row.addArrangedSubview(
         makeKey(title: text, accessibilityLabel: text.uppercased()) { [weak self] in
-          self?.textDocumentProxy.insertText(text)
+          self?.handleCharacter(text)
         })
     }
     return row
@@ -74,21 +106,21 @@ final class KeyboardViewController: UIInputViewController {
     let row = makeRow()
     row.addArrangedSubview(
       makeSymbolKey(symbol: "globe", accessibilityLabel: "下一个键盘") { [weak self] in
-        self?.advanceToNextInputMode()
+        self?.switchToNextKeyboard()
       })
     row.addArrangedSubview(
       makeSymbolKey(symbol: "delete.left", accessibilityLabel: "删除") { [weak self] in
-        self?.textDocumentProxy.deleteBackward()
+        self?.handleBackspace()
       })
 
     let space = makeKey(title: "空格", accessibilityLabel: "空格") { [weak self] in
-      self?.textDocumentProxy.insertText(" ")
+      self?.handleSpace()
     }
     space.widthAnchor.constraint(greaterThanOrEqualToConstant: 120).isActive = true
     row.addArrangedSubview(space)
 
     let enter = makeKey(title: "换行", accessibilityLabel: "换行", emphasized: true) { [weak self] in
-      self?.textDocumentProxy.insertText("\n")
+      self?.handleReturn()
     }
     row.addArrangedSubview(enter)
     return row
@@ -101,6 +133,68 @@ final class KeyboardViewController: UIInputViewController {
     row.distribution = .fillEqually
     row.spacing = 6
     return row
+  }
+
+  private func handleCharacter(_ character: String) {
+    render(session.handleCharacter(character))
+  }
+
+  private func handleBackspace() {
+    let snapshot = session.handleBackspace()
+    if !snapshot.isHandled {
+      textDocumentProxy.deleteBackward()
+    }
+    render(snapshot)
+  }
+
+  private func handleSpace() {
+    let snapshot = session.commitCandidate()
+    if !snapshot.isHandled {
+      textDocumentProxy.insertText(" ")
+    }
+    render(snapshot)
+  }
+
+  private func handleReturn() {
+    render(session.commitCandidate())
+    textDocumentProxy.insertText("\n")
+  }
+
+  private func switchToNextKeyboard() {
+    render(session.commitRaw())
+    advanceToNextInputMode()
+  }
+
+  private func render(_ snapshot: MetasequoiaInputSnapshot) {
+    if let commitText = snapshot.commitText {
+      textDocumentProxy.insertText(commitText)
+    }
+    updateCandidateStrip(preedit: snapshot.preedit, candidates: snapshot.candidates)
+  }
+
+  private func updateCandidateStrip(preedit: String, candidates: [String]) {
+    preeditLabel.text = preedit.isEmpty ? "水杉输入法" : preedit
+    for view in candidateStack.arrangedSubviews {
+      candidateStack.removeArrangedSubview(view)
+      view.removeFromSuperview()
+    }
+
+    for (index, candidate) in candidates.prefix(9).enumerated() {
+      var configuration = UIButton.Configuration.plain()
+      configuration.title = candidate
+      configuration.baseForegroundColor = .label
+      configuration.contentInsets = NSDirectionalEdgeInsets(
+        top: 3, leading: 8, bottom: 3, trailing: 8)
+      let button = UIButton(
+        configuration: configuration,
+        primaryAction: UIAction { [weak self] _ in
+          guard let self else { return }
+          self.render(self.session.selectCandidate(at: UInt(index)))
+        })
+      button.accessibilityLabel = "候选词 \(index + 1)：\(candidate)"
+      candidateStack.addArrangedSubview(button)
+    }
+    candidateScrollView.isHidden = candidates.isEmpty
   }
 
   private func makeSymbolKey(

--- a/platforms/ios/KeyboardExtension/Sources/MetasequoiaKeyboard-Bridging-Header.h
+++ b/platforms/ios/KeyboardExtension/Sources/MetasequoiaKeyboard-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "MetasequoiaInputSessionBridge.h"

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -2,17 +2,19 @@
 
 This directory contains the native iOS host app, custom keyboard extension, iOS-only shared UI, and their tests. `project.yml` is the reproducible XcodeGen source of truth; generated `.xcodeproj` files are build artifacts and are not committed.
 
-The iOS frontend will consume `MetasequoiaImeEngine` through `shared/apple-bridge`. It must not import AppKit, InputMethodKit, Sparkle, macOS registration helpers, or macOS installer code. The first functional keyboard will operate locally without Open Access; App Group and network-related capabilities require a later, explicit design and review.
+The iOS frontend consumes `MetasequoiaImeEngine` through the Objective-C++ adapter in `shared/apple-bridge`. It must not import AppKit, InputMethodKit, Sparkle, macOS registration helpers, or macOS installer code. The keyboard operates locally without Open Access; App Group and network-related capabilities require a later, explicit design and review.
 
 See [Apple platform architecture](../../docs/apple-platform-architecture.md) for ownership boundaries and the progressive pull-request sequence.
 
 Generate and build the current shell for the Simulator from the repository root:
 
 ```sh
-brew install xcodegen
+brew install boost fmt spdlog xcodegen
 mkdir -p build/ios
 xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
 xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaImeIOS -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/ios-derived CODE_SIGNING_ALLOWED=NO build
 ```
 
-The current keyboard shell inserts direct lowercase text and exposes Space, Return, Backspace, and the required next-keyboard control. Composition and candidates are intentionally deferred to the engine-bridge pull request.
+`BREW_PREFIX` defaults to `/opt/homebrew` in `project.yml`; override that build setting when dependencies are installed under another prefix.
+
+The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, and candidate selection through the shared engine. This bridge step intentionally does not package the production dictionary yet, so a build without dictionary assets still exposes engine-owned preedit and commits its raw spelling. Dictionary pruning and on-device candidate packaging belong to the next progressive pull request.

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -14,6 +14,60 @@ settings:
     IPHONEOS_DEPLOYMENT_TARGET: 15.0
 
 targets:
+  MetasequoiaAppleBridge:
+    type: library.static
+    platform: iOS
+    sources:
+      - path: shared/apple-bridge
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/common
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/core
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/english
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/japanese
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/providers
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/quanpin
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/schemes
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/shuangpin
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/user_dictionary
+        excludes:
+          - "*.h"
+      - path: vendor/MetasequoiaImeEngine/googlepinyinime-rev/src/share
+        excludes:
+          - "*.h"
+          - maintest.cpp
+    settings:
+      base:
+        BREW_PREFIX: /opt/homebrew
+        CLANG_CXX_LANGUAGE_STANDARD: c++17
+        GCC_PREPROCESSOR_DEFINITIONS:
+          - $(inherited)
+          - FMT_HEADER_ONLY=1
+          - SPDLOG_FMT_EXTERNAL
+        HEADER_SEARCH_PATHS:
+          - $(inherited)
+          - $(PROJECT_DIR)/../../shared/apple-bridge
+          - $(PROJECT_DIR)/../../vendor/MetasequoiaImeEngine
+          - $(PROJECT_DIR)/../../vendor/MetasequoiaImeEngine/utfcpp/source
+          - $(BREW_PREFIX)/include
+        SKIP_INSTALL: YES
+
   MetasequoiaImeIOS:
     type: application
     platform: iOS
@@ -41,6 +95,13 @@ targets:
         INFOPLIST_FILE: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Resources/Info.plist
         PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios.keyboard
         PRODUCT_NAME: MetasequoiaKeyboard
+        SWIFT_OBJC_BRIDGING_HEADER: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Sources/MetasequoiaKeyboard-Bridging-Header.h
+        HEADER_SEARCH_PATHS:
+          - $(inherited)
+          - $(PROJECT_DIR)/../../shared/apple-bridge
+    dependencies:
+      - target: MetasequoiaAppleBridge
+      - sdk: libsqlite3.tbd
 
 schemes:
   MetasequoiaImeIOS:

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -1,0 +1,77 @@
+#include "InputSessionAdapter.h"
+
+#include "user_dictionary/user_dictionary_journal.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+namespace {
+void Require(bool condition, const char *message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+int RunTest() {
+  const std::filesystem::path dataDirectory =
+      std::filesystem::temp_directory_path() /
+      ("metasequoia-apple-input-session-adapter-" +
+       std::to_string(std::chrono::high_resolution_clock::now()
+                          .time_since_epoch()
+                          .count()));
+  std::filesystem::create_directories(dataDirectory);
+  if (setenv("METASEQUOIA_IME_DATA_DIR", dataDirectory.c_str(), 1) != 0) {
+    throw std::runtime_error("Failed to set the adapter test data directory.");
+  }
+
+  {
+    metasequoia::apple::InputSessionAdapter adapter;
+    const auto first = adapter.handle_character('n');
+    Require(first.handled && first.preedit == "n",
+            "The first letter did not start an engine composition.");
+
+    const auto second = adapter.handle_character('i');
+    Require(second.handled && second.preedit == "ni",
+            "The second letter did not update the engine preedit.");
+
+    const auto backspace = adapter.handle_backspace();
+    Require(backspace.handled && backspace.preedit == "n",
+            "Backspace did not edit the engine composition.");
+
+    const auto committed = adapter.commit_candidate();
+    Require(committed.handled && committed.commit.has_value() &&
+                *committed.commit == "n" && committed.preedit.empty(),
+            "Candidate commit did not fall back to the raw composition.");
+
+    Require(adapter.handle_character('h').handled &&
+                adapter.handle_character('i').handled,
+            "The raw-commit fixture did not start a composition.");
+    const auto rawCommitted = adapter.commit_raw();
+    Require(rawCommitted.handled && rawCommitted.commit.has_value() &&
+                *rawCommitted.commit == "hi" && rawCommitted.preedit.empty(),
+            "Raw commit did not clear and return the engine composition.");
+
+    Require(!adapter.handle_backspace().handled,
+            "Idle Backspace was swallowed by the engine adapter.");
+    Require(!adapter.handle_character('N').handled,
+            "Unsupported uppercase input was swallowed by the adapter.");
+  }
+
+  user_dictionary::close_default_user_database();
+  std::filesystem::remove_all(dataDirectory);
+  return 0;
+}
+} // namespace
+
+int main() {
+  try {
+    return RunTest();
+  } catch (const std::exception &exception) {
+    std::fprintf(stderr, "%s\n", exception.what());
+    return 1;
+  }
+}

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -44,6 +44,17 @@ class ProjectConfigurationTests(unittest.TestCase):
 
         self.assertIn("mkdir -p build/ios", workflow)
 
+    def test_keyboard_routes_composition_through_the_shared_engine_bridge(self):
+        project = (IOS_ROOT / "project.yml").read_text()
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("MetasequoiaAppleBridge:", project)
+        self.assertIn("shared/apple-bridge", project)
+        self.assertIn("vendor/MetasequoiaImeEngine/core", project)
+        self.assertIn("MetasequoiaInputSessionBridge", controller)
+        self.assertIn("session.handleCharacter", controller)
+        self.assertIn("session.commitCandidate", controller)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -1,0 +1,59 @@
+#include "InputSessionAdapter.h"
+
+#include "core/input_session.h"
+
+#include <utility>
+
+namespace metasequoia::apple {
+class InputSessionAdapter::Impl {
+public:
+  InputSession session{SchemeType::Quanpin, true, true, true, false};
+};
+
+namespace {
+InputSnapshot MakeSnapshot(const InputSession &session, KeyResult result) {
+  InputSnapshot snapshot;
+  snapshot.handled = result.handled;
+  snapshot.commit = std::move(result.commit);
+  snapshot.preedit = session.preedit();
+  snapshot.candidates.reserve(session.candidates().size());
+  for (const auto &candidate : session.candidates()) {
+    snapshot.candidates.push_back(candidate.word);
+  }
+  return snapshot;
+}
+} // namespace
+
+InputSessionAdapter::InputSessionAdapter() : impl_(std::make_unique<Impl>()) {}
+
+InputSessionAdapter::~InputSessionAdapter() = default;
+
+InputSnapshot InputSessionAdapter::handle_character(char character) {
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_character(character));
+}
+
+InputSnapshot InputSessionAdapter::handle_backspace() {
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_command(Command::Backspace));
+}
+
+InputSnapshot InputSessionAdapter::commit_candidate() {
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_command(Command::CommitCandidate));
+}
+
+InputSnapshot InputSessionAdapter::commit_raw() {
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_command(Command::CommitRaw));
+}
+
+InputSnapshot InputSessionAdapter::cancel() {
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_command(Command::Cancel));
+}
+
+InputSnapshot InputSessionAdapter::select_candidate(std::size_t index) {
+  return MakeSnapshot(impl_->session, impl_->session.select_candidate(index));
+}
+} // namespace metasequoia::apple

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace metasequoia::apple {
+struct InputSnapshot {
+  bool handled = false;
+  std::optional<std::string> commit;
+  std::string preedit;
+  std::vector<std::string> candidates;
+};
+
+class InputSessionAdapter {
+public:
+  InputSessionAdapter();
+  ~InputSessionAdapter();
+
+  InputSessionAdapter(const InputSessionAdapter &) = delete;
+  InputSessionAdapter &operator=(const InputSessionAdapter &) = delete;
+
+  InputSnapshot handle_character(char character);
+  InputSnapshot handle_backspace();
+  InputSnapshot commit_candidate();
+  InputSnapshot commit_raw();
+  InputSnapshot cancel();
+  InputSnapshot select_candidate(std::size_t index);
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+} // namespace metasequoia::apple

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MetasequoiaInputSnapshot : NSObject
+
+@property(nonatomic, readonly, getter=isHandled) BOOL handled;
+@property(nonatomic, copy, readonly, nullable) NSString *commitText;
+@property(nonatomic, copy, readonly) NSString *preedit;
+@property(nonatomic, copy, readonly) NSArray<NSString *> *candidates;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+@interface MetasequoiaInputSessionBridge : NSObject
+
+- (MetasequoiaInputSnapshot *)handleCharacter:(NSString *)character;
+- (MetasequoiaInputSnapshot *)handleBackspace;
+- (MetasequoiaInputSnapshot *)commitCandidate;
+- (MetasequoiaInputSnapshot *)commitRaw;
+- (MetasequoiaInputSnapshot *)cancel;
+- (MetasequoiaInputSnapshot *)selectCandidateAtIndex:(NSUInteger)index;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -1,0 +1,128 @@
+#import "MetasequoiaInputSessionBridge.h"
+
+#include "InputSessionAdapter.h"
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace {
+NSString *StringFromUTF8(const std::string &value) {
+  NSString *string = [[NSString alloc] initWithBytes:value.data()
+                                              length:value.size()
+                                            encoding:NSUTF8StringEncoding];
+  return string == nil ? @"" : string;
+}
+
+void ConfigureDataDirectory() {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    NSURL *applicationSupport =
+        [fileManager URLForDirectory:NSApplicationSupportDirectory
+                            inDomain:NSUserDomainMask
+                   appropriateForURL:nil
+                              create:YES
+                               error:nil];
+    NSURL *dataDirectory =
+        [applicationSupport URLByAppendingPathComponent:@"metasequoiaime"
+                                            isDirectory:YES];
+    if (dataDirectory != nil && [fileManager createDirectoryAtURL:dataDirectory
+                                      withIntermediateDirectories:YES
+                                                       attributes:nil
+                                                            error:nil]) {
+      setenv("METASEQUOIA_IME_DATA_DIR", dataDirectory.fileSystemRepresentation,
+             1);
+    }
+  });
+}
+} // namespace
+
+@interface MetasequoiaInputSnapshot ()
+
+- (instancetype)initWithHandled:(BOOL)handled
+                     commitText:(nullable NSString *)commitText
+                        preedit:(NSString *)preedit
+                     candidates:(NSArray<NSString *> *)candidates;
+
+@end
+
+@implementation MetasequoiaInputSnapshot
+
+- (instancetype)initWithHandled:(BOOL)handled
+                     commitText:(nullable NSString *)commitText
+                        preedit:(NSString *)preedit
+                     candidates:(NSArray<NSString *> *)candidates {
+  self = [super init];
+  if (self != nil) {
+    _handled = handled;
+    _commitText = [commitText copy];
+    _preedit = [preedit copy];
+    _candidates = [candidates copy];
+  }
+  return self;
+}
+
+@end
+
+@implementation MetasequoiaInputSessionBridge {
+  std::unique_ptr<metasequoia::apple::InputSessionAdapter> _adapter;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self != nil) {
+    ConfigureDataDirectory();
+    _adapter = std::make_unique<metasequoia::apple::InputSessionAdapter>();
+  }
+  return self;
+}
+
+- (MetasequoiaInputSnapshot *)handleCharacter:(NSString *)character {
+  const char *utf8 = character.UTF8String;
+  if (utf8 == nullptr || utf8[0] == '\0' || utf8[1] != '\0') {
+    return [self snapshotFrom:_adapter->handle_character('\0')];
+  }
+  return [self snapshotFrom:_adapter->handle_character(utf8[0])];
+}
+
+- (MetasequoiaInputSnapshot *)handleBackspace {
+  return [self snapshotFrom:_adapter->handle_backspace()];
+}
+
+- (MetasequoiaInputSnapshot *)commitCandidate {
+  return [self snapshotFrom:_adapter->commit_candidate()];
+}
+
+- (MetasequoiaInputSnapshot *)commitRaw {
+  return [self snapshotFrom:_adapter->commit_raw()];
+}
+
+- (MetasequoiaInputSnapshot *)cancel {
+  return [self snapshotFrom:_adapter->cancel()];
+}
+
+- (MetasequoiaInputSnapshot *)selectCandidateAtIndex:(NSUInteger)index {
+  return [self
+      snapshotFrom:_adapter->select_candidate(static_cast<std::size_t>(index))];
+}
+
+- (MetasequoiaInputSnapshot *)snapshotFrom:
+    (metasequoia::apple::InputSnapshot)snapshot {
+  NSMutableArray<NSString *> *candidates =
+      [NSMutableArray arrayWithCapacity:snapshot.candidates.size()];
+  for (const auto &candidate : snapshot.candidates) {
+    [candidates addObject:StringFromUTF8(candidate)];
+  }
+
+  NSString *commitText =
+      snapshot.commit.has_value() ? StringFromUTF8(*snapshot.commit) : nil;
+  return [[MetasequoiaInputSnapshot alloc]
+      initWithHandled:snapshot.handled
+           commitText:commitText
+              preedit:StringFromUTF8(snapshot.preedit)
+           candidates:candidates];
+}
+
+@end


### PR DESCRIPTION
## Summary

- add a C++ Apple adapter around the shared MetasequoiaImeEngine InputSession
- expose it to Swift through a small Objective-C++ bridge
- route iOS preedit, backspace, candidate commit, raw commit, and selection through the engine
- build and test the bridge in CMake and the iOS Simulator CI job

This is stacked on #141. Production dictionary packaging is intentionally left for the next progressive PR.

## Verification

- 12/12 CTest suite passed
- 6/6 iOS configuration tests passed after the base CI fix
- generic iOS Simulator build passed for x86_64 and arm64
- Swift format lint and plist validation passed
- Orca Simulator verified ni preedit, Backspace to n, and Space committing n into the host field