### PR TITLE
feat(ios): package compact pinyin dictionary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,11 @@ jobs:
       - name: Install project generator
         run: brew install boost fmt spdlog xcodegen
       - name: Validate keyboard configuration
-        run: python3 platforms/ios/tests/ProjectConfigurationTests.py
+        run: |
+          python3 platforms/ios/tests/ProjectConfigurationTests.py
+          python3 platforms/ios/tests/DictionaryPackagingTests.py
+      - name: Package iOS dictionary
+        run: python3 platforms/ios/scripts/prepare_dictionary.py
       - name: Generate Xcode project
         run: |
           mkdir -p build/ios

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build*/
 /.DS_Store
+/platforms/ios/KeyboardExtension/Resources/msime.db
+/platforms/ios/KeyboardExtension/Resources/msime.db.sha256

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -10,6 +10,7 @@ Generate and build the current shell for the Simulator from the repository root:
 
 ```sh
 brew install boost fmt spdlog xcodegen
+python3 platforms/ios/scripts/prepare_dictionary.py
 mkdir -p build/ios
 xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
 xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaImeIOS -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/ios-derived CODE_SIGNING_ALLOWED=NO build
@@ -17,4 +18,4 @@ xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaIme
 
 `BREW_PREFIX` defaults to `/opt/homebrew` in `project.yml`; override that build setting when dependencies are installed under another prefix.
 
-The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, and candidate selection through the shared engine. This bridge step intentionally does not package the production dictionary yet, so a build without dictionary assets still exposes engine-owned preedit and commits its raw spelling. Dictionary pruning and on-device candidate packaging belong to the next progressive pull request.
+The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, and candidate selection through the shared engine. `prepare_dictionary.py` first builds the canonical database, then retains all single-syllable entries and common multi-syllable entries with weight 2000 or greater. The generated database and its SHA-256 sidecar are ignored build artifacts. At runtime the extension atomically installs a changed bundled database into its private writable Application Support directory, keeping dictionary access local without requesting Open Access.

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -89,6 +89,10 @@ targets:
     sources:
       - path: platforms/ios/KeyboardExtension/Sources
       - path: platforms/ios/SharedUI
+      - path: platforms/ios/KeyboardExtension/Resources/msime.db
+        buildPhase: resources
+      - path: platforms/ios/KeyboardExtension/Resources/msime.db.sha256
+        buildPhase: resources
     settings:
       base:
         GENERATE_INFOPLIST_FILE: NO

--- a/platforms/ios/scripts/create_compact_dictionary.py
+++ b/platforms/ios/scripts/create_compact_dictionary.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Create a read-only mobile dictionary from the canonical full database."""
+
+import argparse
+import hashlib
+import re
+import sqlite3
+from pathlib import Path
+
+
+TABLE_NAME = re.compile(r"tbl_(?:[1-7]|others)_[a-z]\Z")
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--minimum-weight", type=int, default=2000)
+    return parser.parse_args()
+
+
+def compact_dictionary(source_path, output_path, minimum_weight):
+    if not source_path.is_file():
+        raise FileNotFoundError(f"Dictionary not found: {source_path}")
+    if minimum_weight < 0:
+        raise ValueError("minimum weight must not be negative")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    temporary_path.unlink(missing_ok=True)
+
+    source = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True)
+    output = sqlite3.connect(temporary_path)
+    try:
+        output.execute("PRAGMA journal_mode=OFF")
+        output.execute("PRAGMA synchronous=OFF")
+        tables = source.execute(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type='table' AND name LIKE 'tbl_%' ORDER BY name"
+        ).fetchall()
+        if not tables:
+            raise ValueError("The source dictionary has no pinyin tables")
+
+        source_uri = source_path.resolve().as_uri().replace("'", "''")
+        output.execute(f"ATTACH DATABASE '{source_uri}?mode=ro' AS source")
+        kept_rows = 0
+        for table_name, schema in tables:
+            if TABLE_NAME.fullmatch(table_name) is None:
+                raise ValueError(f"Unexpected pinyin table name: {table_name}")
+            output.execute(schema)
+            if table_name.startswith("tbl_1_"):
+                output.execute(
+                    f'INSERT INTO "{table_name}" SELECT * FROM source."{table_name}"'
+                )
+            else:
+                output.execute(
+                    f'INSERT INTO "{table_name}" SELECT * FROM source."{table_name}" '
+                    "WHERE weight >= ?",
+                    (minimum_weight,),
+                )
+            kept_rows += output.execute(
+                f'SELECT count(*) FROM "{table_name}"'
+            ).fetchone()[0]
+
+        indexes = source.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type='index' AND sql IS NOT NULL ORDER BY name"
+        ).fetchall()
+        for (schema,) in indexes:
+            output.execute(schema)
+        output.commit()
+
+        integrity = output.execute("PRAGMA integrity_check").fetchone()[0]
+        if integrity != "ok":
+            raise ValueError(f"Compact dictionary integrity check failed: {integrity}")
+        candidate = output.execute(
+            "SELECT value FROM tbl_1_n WHERE key='ni' ORDER BY weight DESC LIMIT 1"
+        ).fetchone()
+        if candidate is None or candidate[0] != "你":
+            raise ValueError("Compact dictionary failed the ni -> 你 smoke check")
+    except Exception:
+        output.close()
+        source.close()
+        temporary_path.unlink(missing_ok=True)
+        raise
+    else:
+        output.close()
+        source.close()
+
+    temporary_path.replace(output_path)
+    digest = hashlib.sha256(output_path.read_bytes()).hexdigest()
+    output_path.with_suffix(output_path.suffix + ".sha256").write_text(
+        digest + "\n", encoding="ascii"
+    )
+    return kept_rows
+
+
+def main():
+    arguments = parse_arguments()
+    kept_rows = compact_dictionary(
+        arguments.source, arguments.output, arguments.minimum_weight
+    )
+    print(
+        f"Generated {arguments.output} ({arguments.output.stat().st_size} bytes, "
+        f"{kept_rows} rows)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/platforms/ios/scripts/prepare_dictionary.py
+++ b/platforms/ios/scripts/prepare_dictionary.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Build the canonical dictionary and package its compact iOS variant."""
+
+import subprocess
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+FULL_DICTIONARY = REPOSITORY_ROOT / "vendor/MetasequoiaImeDict/out/msime.db"
+IOS_DICTIONARY = (
+    REPOSITORY_ROOT / "platforms/ios/KeyboardExtension/Resources/msime.db"
+)
+
+
+def main():
+    subprocess.run(
+        ["python3", "platforms/macos/scripts/build_dictionary.py"],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "python3",
+            "platforms/ios/scripts/create_compact_dictionary.py",
+            str(FULL_DICTIONARY),
+            str(IOS_DICTIONARY),
+        ],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/platforms/ios/tests/DictionaryPackagingTests.py
+++ b/platforms/ios/tests/DictionaryPackagingTests.py
@@ -1,0 +1,76 @@
+import hashlib
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+IOS_ROOT = Path(__file__).resolve().parents[1]
+PACKAGER = IOS_ROOT / "scripts/create_compact_dictionary.py"
+
+
+class DictionaryPackagingTests(unittest.TestCase):
+    def test_compact_dictionary_preserves_schema_and_common_candidates(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "source.db"
+            output = root / "msime.db"
+            digest = root / "msime.db.sha256"
+
+            with sqlite3.connect(source) as database:
+                database.executescript(
+                    """
+                    CREATE TABLE tbl_1_n (key TEXT, jp TEXT, value TEXT, weight INTEGER DEFAULT 0);
+                    CREATE INDEX idx_key_1_n ON tbl_1_n(key);
+                    CREATE INDEX idx_jp_1_n ON tbl_1_n(jp);
+                    INSERT INTO tbl_1_n VALUES ('ni', 'n', '你', 1422192);
+                    INSERT INTO tbl_1_n VALUES ('ni', 'n', '倪', 100);
+
+                    CREATE TABLE tbl_2_n (key TEXT, jp TEXT, value TEXT, weight INTEGER DEFAULT 0);
+                    CREATE INDEX idx_key_2_n ON tbl_2_n(key);
+                    INSERT INTO tbl_2_n VALUES ('ni''hao', 'nh', '你好', 332885);
+                    INSERT INTO tbl_2_n VALUES ('ni''hao', 'nh', '拟好', 1999);
+                    """
+                )
+
+            subprocess.run(
+                [
+                    "python3",
+                    str(PACKAGER),
+                    str(source),
+                    str(output),
+                    "--minimum-weight",
+                    "2000",
+                ],
+                check=True,
+            )
+
+            with sqlite3.connect(output) as database:
+                self.assertEqual(
+                    database.execute(
+                        "SELECT value FROM tbl_1_n WHERE key='ni' ORDER BY weight DESC"
+                    ).fetchall(),
+                    [("你",), ("倪",)],
+                )
+                self.assertEqual(
+                    database.execute(
+                        "SELECT value FROM tbl_2_n ORDER BY weight DESC"
+                    ).fetchall(),
+                    [("你好",)],
+                )
+                self.assertEqual(
+                    database.execute("PRAGMA integrity_check").fetchone()[0], "ok"
+                )
+                self.assertEqual(
+                    database.execute(
+                        "SELECT name FROM sqlite_master WHERE type='index' ORDER BY name"
+                    ).fetchall(),
+                    [("idx_jp_1_n",), ("idx_key_1_n",), ("idx_key_2_n",)],
+                )
+
+            self.assertEqual(digest.read_text().strip(), hashlib.sha256(output.read_bytes()).hexdigest())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -55,6 +55,21 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("session.handleCharacter", controller)
         self.assertIn("session.commitCandidate", controller)
 
+    def test_keyboard_packages_the_compact_dictionary(self):
+        project = (IOS_ROOT / "project.yml").read_text()
+        workflow = (IOS_ROOT.parents[1] / ".github/workflows/ci.yml").read_text()
+
+        self.assertIn("platforms/ios/KeyboardExtension/Resources/msime.db", project)
+        self.assertIn("platforms/ios/KeyboardExtension/Resources/msime.db.sha256", project)
+        self.assertIn("python3 platforms/ios/scripts/prepare_dictionary.py", workflow)
+
+    def test_bridge_installs_the_bundled_dictionary_before_engine_startup(self):
+        bridge = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.mm").read_text()
+
+        self.assertIn('URLForResource:@"msime" withExtension:@"db"', bridge)
+        self.assertIn('URLForResource:@"msime.db" withExtension:@"sha256"', bridge)
+        self.assertIn('setenv("METASEQUOIA_IME_DATA_DIR"', bridge)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -15,6 +15,71 @@ NSString *StringFromUTF8(const std::string &value) {
   return string == nil ? @"" : string;
 }
 
+BOOL InstallBundledDictionary(NSFileManager *fileManager,
+                              NSURL *dataDirectory) {
+  NSBundle *bundle = [NSBundle bundleForClass:MetasequoiaInputSessionBridge.class];
+  NSURL *bundledDictionary = [bundle URLForResource:@"msime" withExtension:@"db"];
+  NSURL *bundledDigest =
+      [bundle URLForResource:@"msime.db" withExtension:@"sha256"];
+  if (bundledDictionary == nil || bundledDigest == nil) {
+    return NO;
+  }
+
+  NSString *expectedDigest =
+      [NSString stringWithContentsOfURL:bundledDigest
+                               encoding:NSASCIIStringEncoding
+                                  error:nil];
+  expectedDigest = [expectedDigest
+      stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+  NSURL *installedDictionary =
+      [dataDirectory URLByAppendingPathComponent:@"msime.db"];
+  NSURL *installedDigest =
+      [dataDirectory URLByAppendingPathComponent:@"msime.db.sha256"];
+  NSString *currentDigest =
+      [NSString stringWithContentsOfURL:installedDigest
+                               encoding:NSASCIIStringEncoding
+                                  error:nil];
+  currentDigest = [currentDigest
+      stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+  if (expectedDigest.length > 0 &&
+      [expectedDigest isEqualToString:currentDigest] &&
+      [fileManager fileExistsAtPath:installedDictionary.path]) {
+    return YES;
+  }
+
+  NSURL *stagingDictionary =
+      [dataDirectory URLByAppendingPathComponent:@"msime.db.installing"];
+  [fileManager removeItemAtURL:stagingDictionary error:nil];
+  if (![fileManager copyItemAtURL:bundledDictionary
+                            toURL:stagingDictionary
+                            error:nil]) {
+    return NO;
+  }
+
+  BOOL installed = NO;
+  if ([fileManager fileExistsAtPath:installedDictionary.path]) {
+    installed = [fileManager replaceItemAtURL:installedDictionary
+                                withItemAtURL:stagingDictionary
+                               backupItemName:nil
+                                      options:0
+                             resultingItemURL:nil
+                                        error:nil];
+  } else {
+    installed = [fileManager moveItemAtURL:stagingDictionary
+                                      toURL:installedDictionary
+                                      error:nil];
+  }
+  if (!installed) {
+    [fileManager removeItemAtURL:stagingDictionary error:nil];
+    return NO;
+  }
+
+  return [expectedDigest writeToURL:installedDigest
+                         atomically:YES
+                           encoding:NSASCIIStringEncoding
+                              error:nil];
+}
+
 void ConfigureDataDirectory() {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
@@ -32,6 +97,7 @@ void ConfigureDataDirectory() {
                                       withIntermediateDirectories:YES
                                                        attributes:nil
                                                             error:nil]) {
+      InstallBundledDictionary(fileManager, dataDirectory);
       setenv("METASEQUOIA_IME_DATA_DIR", dataDirectory.fileSystemRepresentation,
              1);
     }


### PR DESCRIPTION
Packages a deterministic 15 MiB compact dictionary in the keyboard extension, installs changed assets atomically into its private writable sandbox before Engine startup, and validates generation in CI. Verified with Python tests, an arm64/x86_64 Simulator build, bundle and sandbox integrity checks, and Orca Computer: typing ni showed 你 first and selecting it committed 你. Stacked on #142.