### PR TITLE
feat(ios): add number and symbol keyboard

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -6,11 +6,20 @@ final class KeyboardViewController: UIInputViewController {
   private let preeditLabel = UILabel()
   private let candidateScrollView = UIScrollView()
   private let candidateStack = UIStackView()
+  private var letterRowViews: [UIView] = []
+  private var symbolRowViews: [UIView] = []
+  private var layoutToggleButton: UIButton?
+  private var showsSymbols = false
 
   private let letterRows = [
     Array("qwertyuiop"),
     Array("asdfghjkl"),
     Array("zxcvbnm"),
+  ]
+  private let symbolRows = [
+    Array("1234567890").map(String.init),
+    [",", ".", "?", "!", ";", ":", "'", "\""],
+    ["(", ")", "[", "]", "<", ">", "\\", "-"],
   ]
 
   override func viewDidLoad() {
@@ -42,7 +51,15 @@ final class KeyboardViewController: UIInputViewController {
 
     root.addArrangedSubview(makeCandidateStrip())
     for row in letterRows {
-      root.addArrangedSubview(makeLetterRow(row))
+      let rowView = makeLetterRow(row)
+      letterRowViews.append(rowView)
+      root.addArrangedSubview(rowView)
+    }
+    for row in symbolRows {
+      let rowView = makeSymbolRow(row)
+      rowView.isHidden = true
+      symbolRowViews.append(rowView)
+      root.addArrangedSubview(rowView)
     }
     root.addArrangedSubview(makeActionRow())
   }
@@ -102,26 +119,67 @@ final class KeyboardViewController: UIInputViewController {
     return row
   }
 
-  private func makeActionRow() -> UIStackView {
+  private func makeSymbolRow(_ symbols: [String]) -> UIStackView {
     let row = makeRow()
-    row.addArrangedSubview(
-      makeSymbolKey(symbol: "globe", accessibilityLabel: "下一个键盘") { [weak self] in
-        self?.switchToNextKeyboard()
-      })
-    row.addArrangedSubview(
-      makeSymbolKey(symbol: "delete.left", accessibilityLabel: "删除") { [weak self] in
-        self?.handleBackspace()
-      })
+    for symbol in symbols {
+      row.addArrangedSubview(
+        makeKey(title: symbol, accessibilityLabel: "符号 \(symbol)") { [weak self] in
+          self?.handleSymbol(symbol)
+        })
+    }
+    return row
+  }
+
+  private func makeActionRow() -> UIStackView {
+    let row = UIStackView()
+    row.axis = .horizontal
+    row.alignment = .fill
+    row.distribution = .fill
+    row.spacing = 6
+
+    let layoutToggle = makeKey(title: "123", accessibilityLabel: "切换到数字和符号") {
+      [weak self] in self?.toggleLayout()
+    }
+    if var configuration = layoutToggle.configuration {
+      configuration.contentInsets = NSDirectionalEdgeInsets(
+        top: 0, leading: 4, bottom: 0, trailing: 4)
+      configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
+        attributes in
+        var attributes = attributes
+        attributes.font = .systemFont(ofSize: 17, weight: .medium)
+        return attributes
+      }
+      layoutToggle.configuration = configuration
+    }
+    layoutToggle.titleLabel?.adjustsFontSizeToFitWidth = true
+    layoutToggle.titleLabel?.minimumScaleFactor = 0.7
+    layoutToggle.titleLabel?.lineBreakMode = .byClipping
+    layoutToggle.widthAnchor.constraint(equalToConstant: 56).isActive = true
+    layoutToggleButton = layoutToggle
+    row.addArrangedSubview(layoutToggle)
+
+    let globe = makeSymbolKey(symbol: "globe", accessibilityLabel: "下一个键盘") { [weak self] in
+      self?.switchToNextKeyboard()
+    }
+    globe.widthAnchor.constraint(equalToConstant: 50).isActive = true
+    row.addArrangedSubview(globe)
+
+    let delete = makeSymbolKey(symbol: "delete.left", accessibilityLabel: "删除") { [weak self] in
+      self?.handleBackspace()
+    }
+    delete.widthAnchor.constraint(equalToConstant: 50).isActive = true
+    row.addArrangedSubview(delete)
 
     let space = makeKey(title: "空格", accessibilityLabel: "空格") { [weak self] in
       self?.handleSpace()
     }
-    space.widthAnchor.constraint(greaterThanOrEqualToConstant: 120).isActive = true
+    space.widthAnchor.constraint(greaterThanOrEqualToConstant: 110).isActive = true
     row.addArrangedSubview(space)
 
     let enter = makeKey(title: "换行", accessibilityLabel: "换行", emphasized: true) { [weak self] in
       self?.handleReturn()
     }
+    enter.widthAnchor.constraint(equalToConstant: 72).isActive = true
     row.addArrangedSubview(enter)
     return row
   }
@@ -137,6 +195,38 @@ final class KeyboardViewController: UIInputViewController {
 
   private func handleCharacter(_ character: String) {
     render(session.handleCharacter(character))
+  }
+
+  private func handleSymbol(_ symbol: String) {
+    if symbol.count == 1, symbol >= "1", symbol <= "9" {
+      let snapshot = session.handleCandidateKey(symbol)
+      if !snapshot.isHandled && snapshot.preedit.isEmpty {
+        textDocumentProxy.insertText(symbol)
+      }
+      render(snapshot)
+      return
+    }
+
+    let snapshot = session.handlePunctuation(symbol)
+    if snapshot.isHandled {
+      render(snapshot)
+      return
+    }
+
+    render(session.commitRaw())
+    textDocumentProxy.insertText(symbol)
+  }
+
+  private func toggleLayout() {
+    showsSymbols.toggle()
+    letterRowViews.forEach { $0.isHidden = showsSymbols }
+    symbolRowViews.forEach { $0.isHidden = !showsSymbols }
+    if var configuration = layoutToggleButton?.configuration {
+      configuration.title = showsSymbols ? "ABC" : "123"
+      layoutToggleButton?.configuration = configuration
+    }
+    layoutToggleButton?.accessibilityLabel =
+      showsSymbols ? "切换到字母" : "切换到数字和符号"
   }
 
   private func handleBackspace() {

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -18,4 +18,6 @@ xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaIme
 
 `BREW_PREFIX` defaults to `/opt/homebrew` in `project.yml`; override that build setting when dependencies are installed under another prefix.
 
-The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, and candidate selection through the shared engine. `prepare_dictionary.py` first builds the canonical database, then retains all single-syllable entries and common multi-syllable entries with weight 2000 or greater. The generated database and its SHA-256 sidecar are ignored build artifacts. At runtime the extension atomically installs a changed bundled database into its private writable Application Support directory, keeping dictionary access local without requesting Open Access.
+The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, numbered candidate selection, and Chinese punctuation through the shared engine. The native `123` / `ABC` layer owns only key layout; it does not duplicate the engine's composition or punctuation policy.
+
+`prepare_dictionary.py` first builds the canonical database, then retains all single-syllable entries and common multi-syllable entries with weight 2000 or greater. The generated database and its SHA-256 sidecar are ignored build artifacts. At runtime the extension atomically installs a changed bundled database into its private writable Application Support directory, keeping dictionary access local without requesting Open Access.

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -59,6 +59,25 @@ int RunTest() {
             "Idle Backspace was swallowed by the engine adapter.");
     Require(!adapter.handle_character('N').handled,
             "Unsupported uppercase input was swallowed by the adapter.");
+
+    const auto punctuation = adapter.handle_punctuation('.');
+    Require(punctuation.handled && punctuation.commit.has_value() &&
+                *punctuation.commit == "。",
+            "The adapter did not expose engine-owned Chinese punctuation.");
+
+    Require(adapter.handle_character('n').handled &&
+                adapter.handle_character('i').handled,
+            "The candidate-key fixture did not start a composition.");
+    const auto unavailableCandidate = adapter.handle_candidate_key('1');
+    Require(!unavailableCandidate.handled &&
+                unavailableCandidate.preedit == "ni",
+            "An unavailable numbered candidate was swallowed.");
+    const auto composedPunctuation = adapter.handle_punctuation(',');
+    Require(composedPunctuation.handled &&
+                composedPunctuation.commit.has_value() &&
+                *composedPunctuation.commit == "ni，" &&
+                composedPunctuation.preedit.empty(),
+            "Punctuation did not atomically commit the raw composition.");
   }
 
   user_dictionary::close_default_user_database();

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -70,6 +70,17 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn('URLForResource:@"msime.db" withExtension:@"sha256"', bridge)
         self.assertIn('setenv("METASEQUOIA_IME_DATA_DIR"', bridge)
 
+    def test_keyboard_exposes_engine_owned_number_and_punctuation_routing(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+        bridge_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.h").read_text()
+
+        self.assertIn("symbolRows", controller)
+        self.assertIn("toggleLayout", controller)
+        self.assertIn("session.handleCandidateKey", controller)
+        self.assertIn("session.handlePunctuation", controller)
+        self.assertIn("handleCandidateKey", bridge_header)
+        self.assertIn("handlePunctuation", bridge_header)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -33,6 +33,16 @@ InputSnapshot InputSessionAdapter::handle_character(char character) {
                       impl_->session.handle_character(character));
 }
 
+InputSnapshot InputSessionAdapter::handle_candidate_key(char character) {
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_candidate_key(character));
+}
+
+InputSnapshot InputSessionAdapter::handle_punctuation(char character) {
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_punctuation(character));
+}
+
 InputSnapshot InputSessionAdapter::handle_backspace() {
   return MakeSnapshot(impl_->session,
                       impl_->session.handle_command(Command::Backspace));

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -23,6 +23,8 @@ public:
   InputSessionAdapter &operator=(const InputSessionAdapter &) = delete;
 
   InputSnapshot handle_character(char character);
+  InputSnapshot handle_candidate_key(char character);
+  InputSnapshot handle_punctuation(char character);
   InputSnapshot handle_backspace();
   InputSnapshot commit_candidate();
   InputSnapshot commit_raw();

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MetasequoiaInputSessionBridge : NSObject
 
 - (MetasequoiaInputSnapshot *)handleCharacter:(NSString *)character;
+- (MetasequoiaInputSnapshot *)handleCandidateKey:(NSString *)character;
+- (MetasequoiaInputSnapshot *)handlePunctuation:(NSString *)character;
 - (MetasequoiaInputSnapshot *)handleBackspace;
 - (MetasequoiaInputSnapshot *)commitCandidate;
 - (MetasequoiaInputSnapshot *)commitRaw;

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -153,6 +153,22 @@ void ConfigureDataDirectory() {
   return [self snapshotFrom:_adapter->handle_character(utf8[0])];
 }
 
+- (MetasequoiaInputSnapshot *)handleCandidateKey:(NSString *)character {
+  const char *utf8 = character.UTF8String;
+  if (utf8 == nullptr || utf8[0] == '\0' || utf8[1] != '\0') {
+    return [self snapshotFrom:_adapter->handle_candidate_key('\0')];
+  }
+  return [self snapshotFrom:_adapter->handle_candidate_key(utf8[0])];
+}
+
+- (MetasequoiaInputSnapshot *)handlePunctuation:(NSString *)character {
+  const char *utf8 = character.UTF8String;
+  if (utf8 == nullptr || utf8[0] == '\0' || utf8[1] != '\0') {
+    return [self snapshotFrom:_adapter->handle_punctuation('\0')];
+  }
+  return [self snapshotFrom:_adapter->handle_punctuation(utf8[0])];
+}
+
 - (MetasequoiaInputSnapshot *)handleBackspace {
   return [self snapshotFrom:_adapter->handle_backspace()];
 }


### PR DESCRIPTION
## Summary

- add a native UIKit 123 / ABC number and symbol layer
- route 1–9 candidate selection through the shared Engine
- route Chinese punctuation and paired quote policy through the shared Engine
- keep layout state in UIKit while composition and candidate state remain Engine-owned
- document the frontend and Engine ownership boundary

## Verification

- ProjectConfigurationTests.py: 9 passed
- DictionaryPackagingTests.py: 1 passed
- Apple input session adapter: 1 passed
- universal iOS Simulator build: passed
- Orca Computer pixel verification on iPhone 17 Pro simulator; caught and fixed the initial wrapping of the 123 label