### PR TITLE
feat(ios): number candidate chips

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -270,21 +270,32 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     for (index, candidate) in candidates.prefix(9).enumerated() {
-      var configuration = UIButton.Configuration.plain()
-      configuration.title = candidate
-      configuration.baseForegroundColor = .label
-      configuration.contentInsets = NSDirectionalEdgeInsets(
-        top: 3, leading: 8, bottom: 3, trailing: 8)
-      let button = UIButton(
-        configuration: configuration,
-        primaryAction: UIAction { [weak self] _ in
-          guard let self else { return }
-          self.render(self.session.selectCandidate(at: UInt(index)))
-        })
-      button.accessibilityLabel = "候选词 \(index + 1)：\(candidate)"
-      candidateStack.addArrangedSubview(button)
+      candidateStack.addArrangedSubview(
+        makeCandidateButton(candidate: candidate, number: index + 1))
     }
     candidateScrollView.isHidden = candidates.isEmpty
+  }
+
+  private func makeCandidateButton(candidate: String, number: Int) -> UIButton {
+    var configuration = UIButton.Configuration.plain()
+    configuration.title = "\(number)  \(candidate)"
+    configuration.baseForegroundColor = .label
+    configuration.contentInsets = NSDirectionalEdgeInsets(
+      top: 4, leading: 9, bottom: 4, trailing: 9)
+    configuration.background.backgroundColor = MetasequoiaTheme.keyBackground
+    configuration.background.strokeColor = MetasequoiaTheme.forestUIColor.withAlphaComponent(0.22)
+    configuration.background.strokeWidth = 1
+    configuration.background.cornerRadius = 9
+
+    let button = UIButton(
+      configuration: configuration,
+      primaryAction: UIAction { [weak self] _ in
+        guard let self else { return }
+        self.render(self.session.selectCandidate(at: UInt(number - 1)))
+      })
+    button.accessibilityLabel = "候选词 \(number)：\(candidate)"
+    button.accessibilityIdentifier = "candidate-\(number)"
+    return button
   }
 
   private func makeSymbolKey(

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -81,6 +81,14 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("handleCandidateKey", bridge_header)
         self.assertIn("handlePunctuation", bridge_header)
 
+    def test_candidate_surface_exposes_numbered_native_chips(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("makeCandidateButton(candidate: candidate, number: index + 1)", controller)
+        self.assertIn('configuration.title = "\\(number)  \\(candidate)"', controller)
+        self.assertIn("configuration.background.cornerRadius", controller)
+        self.assertIn('button.accessibilityLabel = "候选词 \\(number)：\\(candidate)"', controller)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- show candidate selection numbers directly on native UIKit chips
- add bordered chip styling and stable accessibility identifiers
- keep candidate selection owned by the shared Engine session

## Verification
- python3 platforms/ios/tests/ProjectConfigurationTests.py (10 passed)
- python3 platforms/ios/tests/DictionaryPackagingTests.py (1 passed)
- universal iOS Simulator build (arm64 + x86_64)
- host onboarding pixel inspection; Simulator window automation was unavailable because the macOS accessibility frame was 0x0
- previous merged keyboard batch verified ni → 你 selection with Orca Computer