### PR TITLE
fix(ios): route apostrophe through composition

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -207,6 +207,14 @@ final class KeyboardViewController: UIInputViewController {
       return
     }
 
+    if symbol == "'" {
+      let separatorSnapshot = session.handleCharacter(symbol)
+      if separatorSnapshot.isHandled {
+        render(separatorSnapshot)
+        return
+      }
+    }
+
     let snapshot = session.handlePunctuation(symbol)
     if snapshot.isHandled {
       render(snapshot)

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -65,6 +65,17 @@ int RunTest() {
                 *punctuation.commit == "。",
             "The adapter did not expose engine-owned Chinese punctuation.");
 
+    Require(adapter.handle_character('x').handled &&
+                adapter.handle_character('i').handled,
+            "The apostrophe fixture did not start a composition.");
+    const auto apostrophe = adapter.handle_character('\'');
+    Require(apostrophe.handled && apostrophe.preedit == "xi'",
+            "An in-composition apostrophe did not reach the engine.");
+    Require(adapter.cancel().handled,
+            "The apostrophe fixture did not cancel its composition.");
+    Require(!adapter.handle_character('\'').handled,
+            "An idle apostrophe was swallowed by the engine adapter.");
+
     Require(adapter.handle_character('n').handled &&
                 adapter.handle_character('i').handled,
             "The candidate-key fixture did not start a composition.");

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -89,6 +89,15 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("configuration.background.cornerRadius", controller)
         self.assertIn('button.accessibilityLabel = "候选词 \\(number)：\\(candidate)"', controller)
 
+    def test_apostrophe_reaches_the_engine_before_punctuation_conversion(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        separator_route = 'if symbol == "\'" {'
+        punctuation_route = "let snapshot = session.handlePunctuation(symbol)"
+        self.assertIn(separator_route, controller)
+        self.assertIn("session.handleCharacter(symbol)", controller)
+        self.assertLess(controller.index(separator_route), controller.index(punctuation_route))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- send apostrophe to the shared Engine before Chinese punctuation conversion
- preserve an in-progress split-pinyin composition such as xi'an
- retain Engine-owned Chinese quote output when no composition is active

## Verification
- ProjectConfigurationTests: 11 passed
- apple_input_session_adapter CTest: 1 passed, including xi' and idle apostrophe cases
- compact dictionary generation and universal iOS Simulator build passed
- git diff --check passed