### PR TITLE
feat(ios): add Chinese English mode switch

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -6,9 +6,11 @@ final class KeyboardViewController: UIInputViewController {
   private let preeditLabel = UILabel()
   private let candidateScrollView = UIScrollView()
   private let candidateStack = UIStackView()
+  private let languageModeButton = UIButton()
   private var letterRowViews: [UIView] = []
   private var symbolRowViews: [UIView] = []
   private var layoutToggleButton: UIButton?
+  private var isChineseMode = true
   private var showsSymbols = false
 
   private let letterRows = [
@@ -74,13 +76,19 @@ final class KeyboardViewController: UIInputViewController {
     preeditLabel.adjustsFontForContentSizeCategory = true
     preeditLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
+    updateLanguageModeButton()
+    languageModeButton.addAction(
+      UIAction { [weak self] _ in self?.toggleInputMode() }, for: .primaryActionTriggered)
+    languageModeButton.widthAnchor.constraint(equalToConstant: 36).isActive = true
+
     candidateStack.axis = .horizontal
     candidateStack.spacing = 6
     candidateStack.translatesAutoresizingMaskIntoConstraints = false
     candidateScrollView.showsHorizontalScrollIndicator = false
     candidateScrollView.addSubview(candidateStack)
 
-    let content = UIStackView(arrangedSubviews: [preeditLabel, candidateScrollView])
+    let content = UIStackView(
+      arrangedSubviews: [languageModeButton, preeditLabel, candidateScrollView])
     content.axis = .horizontal
     content.alignment = .center
     content.spacing = 12
@@ -194,10 +202,19 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func handleCharacter(_ character: String) {
-    render(session.handleCharacter(character))
+    if isChineseMode {
+      render(session.handleCharacter(character))
+    } else {
+      textDocumentProxy.insertText(character)
+    }
   }
 
   private func handleSymbol(_ symbol: String) {
+    if !isChineseMode {
+      textDocumentProxy.insertText(symbol)
+      return
+    }
+
     if symbol.count == 1, symbol >= "1", symbol <= "9" {
       let snapshot = session.handleCandidateKey(symbol)
       if !snapshot.isHandled && snapshot.preedit.isEmpty {
@@ -223,6 +240,28 @@ final class KeyboardViewController: UIInputViewController {
 
     render(session.commitRaw())
     textDocumentProxy.insertText(symbol)
+  }
+
+  private func toggleInputMode() {
+    let snapshot = isChineseMode ? session.commitCandidate() : session.cancel()
+    isChineseMode.toggle()
+    updateLanguageModeButton()
+    render(snapshot)
+  }
+
+  private func updateLanguageModeButton() {
+    var configuration = UIButton.Configuration.filled()
+    configuration.title = isChineseMode ? "中" : "英"
+    configuration.baseForegroundColor = .white
+    configuration.baseBackgroundColor = MetasequoiaTheme.forestUIColor
+    configuration.contentInsets = NSDirectionalEdgeInsets(
+      top: 3, leading: 5, bottom: 3, trailing: 5)
+    configuration.background.cornerRadius = 8
+    languageModeButton.configuration = configuration
+    languageModeButton.accessibilityIdentifier = "languageModeButton"
+    languageModeButton.accessibilityLabel =
+      isChineseMode ? "切换到英文输入" : "切换到中文输入"
+    languageModeButton.accessibilityValue = isChineseMode ? "中文输入" : "英文输入"
   }
 
   private func toggleLayout() {
@@ -271,7 +310,8 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func updateCandidateStrip(preedit: String, candidates: [String]) {
-    preeditLabel.text = preedit.isEmpty ? "水杉输入法" : preedit
+    preeditLabel.text =
+      preedit.isEmpty ? (isChineseMode ? "水杉输入法" : "英文输入") : preedit
     for view in candidateStack.arrangedSubviews {
       candidateStack.removeArrangedSubview(view)
       view.removeFromSuperview()

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -18,6 +18,6 @@ xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaIme
 
 `BREW_PREFIX` defaults to `/opt/homebrew` in `project.yml`; override that build setting when dependencies are installed under another prefix.
 
-The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, numbered candidate selection, and Chinese punctuation through the shared engine. The native `123` / `ABC` layer owns only key layout; it does not duplicate the engine's composition or punctuation policy.
+The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, numbered candidate selection, and Chinese punctuation through the shared engine. Its candidate bar also provides a local `中` / `英` switch; entering English mode first commits the leading Engine candidate, then passes letters and symbols directly to the host app. The native `123` / `ABC` layer owns only key layout; it does not duplicate the engine's composition or punctuation policy.
 
 `prepare_dictionary.py` first builds the canonical database, then retains all single-syllable entries and common multi-syllable entries with weight 2000 or greater. The generated database and its SHA-256 sidecar are ignored build artifacts. At runtime the extension atomically installs a changed bundled database into its private writable Application Support directory, keeping dictionary access local without requesting Open Access.

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -98,6 +98,19 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("session.handleCharacter(symbol)", controller)
         self.assertLess(controller.index(separator_route), controller.index(punctuation_route))
 
+    def test_keyboard_exposes_a_local_chinese_english_mode_switch(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("private var isChineseMode = true", controller)
+        self.assertIn("languageModeButton", controller)
+        self.assertIn("toggleInputMode", controller)
+        self.assertIn("render(session.handleCharacter(character))", controller)
+        self.assertIn("textDocumentProxy.insertText(character)", controller)
+        self.assertIn("if !isChineseMode {\n      textDocumentProxy.insertText(symbol)", controller)
+        self.assertIn("isChineseMode ? session.commitCandidate() : session.cancel()", controller)
+        self.assertIn("isChineseMode ? \"中\" : \"英\"", controller)
+        self.assertIn('languageModeButton.accessibilityIdentifier = "languageModeButton"', controller)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add an accessible 中/英 mode control to the native candidate bar
- commit the leading Engine candidate before switching to English, matching macOS behavior
- pass English letters and symbols directly to the host while keeping Chinese input Engine-owned
- keep mode state local to the extension session without Open Access or App Groups

## Verification
- ProjectConfigurationTests: 12 passed
- DictionaryPackagingTests: 1 passed
- compact dictionary generation passed
- universal iOS Simulator build (arm64 + x86_64) passed
- git diff --check passed