### PR TITLE
test(ios): add native onboarding UI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,6 @@ jobs:
             -derivedDataPath build/ios-derived \
             CODE_SIGNING_ALLOWED=NO \
             build
+      - name: Test native iOS onboarding
+        timeout-minutes: 15
+        run: bash platforms/ios/scripts/run_ui_tests.sh

--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -35,6 +35,7 @@ struct OnboardingView: View {
         .background(
           MetasequoiaTheme.forest, in: RoundedRectangle(cornerRadius: 16, style: .continuous)
         )
+        .accessibilityIdentifier("openKeyboardSettingsButton")
         .accessibilityHint("打开水杉输入法的系统设置页面")
 
         VStack(alignment: .leading, spacing: 10) {

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -14,7 +14,10 @@ python3 platforms/ios/scripts/prepare_dictionary.py
 mkdir -p build/ios
 xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
 xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj -scheme MetasequoiaImeIOS -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build/ios-derived CODE_SIGNING_ALLOWED=NO build
+bash platforms/ios/scripts/run_ui_tests.sh
 ```
+
+The UI-test runner prefers an already booted iPhone Simulator, otherwise selects the newest available iPhone runtime, waits for its reported boot readiness, and runs the onboarding smoke test without fixed startup delays. Set `IOS_SIMULATOR_UDID` to target a specific device.
 
 `BREW_PREFIX` defaults to `/opt/homebrew` in `project.yml`; override that build setting when dependencies are installed under another prefix.
 

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+final class OnboardingUITests: XCTestCase {
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  func testOnboardingExposesEnablementPathAndTryoutField() {
+    let app = XCUIApplication()
+    app.launch()
+
+    XCTAssertTrue(app.staticTexts["水杉输入法"].waitForExistence(timeout: 10))
+    XCTAssertTrue(app.buttons["openKeyboardSettingsButton"].exists)
+
+    let tryoutField = app.textFields["keyboardTryoutField"]
+    XCTAssertTrue(tryoutField.exists)
+    tryoutField.tap()
+    tryoutField.typeText("test")
+    XCTAssertEqual(tryoutField.value as? String, "test")
+  }
+}

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -107,6 +107,18 @@ targets:
       - target: MetasequoiaAppleBridge
       - sdk: libsqlite3.tbd
 
+  MetasequoiaImeIOSUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - path: platforms/ios/UITests
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios.uitests
+    dependencies:
+      - target: MetasequoiaImeIOS
+
 schemes:
   MetasequoiaImeIOS:
     build:
@@ -115,3 +127,6 @@ schemes:
         MetasequoiaKeyboard: all
     run:
       config: Debug
+    test:
+      targets:
+        - MetasequoiaImeIOSUITests

--- a/platforms/ios/scripts/run_ui_tests.sh
+++ b/platforms/ios/scripts/run_ui_tests.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_path="${1:-build/ios/MetasequoiaImeIOS.xcodeproj}"
+derived_data_path="${2:-build/ios-ui-test-derived}"
+
+if [[ ! -d "${project_path}" ]]; then
+  echo "Generated Xcode project not found: ${project_path}" >&2
+  exit 1
+fi
+
+if [[ -n "${IOS_SIMULATOR_UDID:-}" ]]; then
+  test_device_id="${IOS_SIMULATOR_UDID}"
+else
+  test_device_id="$(xcrun simctl list devices available --json | python3 -c '
+import json
+import re
+import sys
+
+devices_by_runtime = json.load(sys.stdin)["devices"]
+
+def version_key(runtime):
+    return tuple(int(part) for part in re.findall(r"\d+", runtime))
+
+for runtime in sorted(devices_by_runtime, key=version_key, reverse=True):
+    if ".iOS-" not in runtime:
+        continue
+    devices = sorted(
+        devices_by_runtime[runtime],
+        key=lambda device: device.get("state") != "Booted",
+    )
+    for device in devices:
+        if device.get("isAvailable") and device["name"].startswith("iPhone"):
+            print(device["udid"])
+            raise SystemExit(0)
+
+raise SystemExit("No available iPhone Simulator runtime was found")
+')"
+fi
+
+# simctl bootstatus polls the real boot state; it avoids a timing guess before XCTest starts.
+xcrun simctl bootstatus "${test_device_id}" -b
+
+xcodebuild \
+  -project "${project_path}" \
+  -scheme MetasequoiaImeIOS \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,id=${test_device_id}" \
+  -derivedDataPath "${derived_data_path}" \
+  test

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -111,6 +111,19 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("isChineseMode ? \"中\" : \"英\"", controller)
         self.assertIn('languageModeButton.accessibilityIdentifier = "languageModeButton"', controller)
 
+    def test_project_and_ci_run_native_onboarding_ui_tests(self):
+        project = (IOS_ROOT / "project.yml").read_text()
+        workflow = (IOS_ROOT.parents[1] / ".github/workflows/ci.yml").read_text()
+        runner = (IOS_ROOT / "scripts/run_ui_tests.sh").read_text()
+
+        self.assertIn("MetasequoiaImeIOSUITests:", project)
+        self.assertIn("platforms/ios/UITests", project)
+        self.assertIn("GENERATE_INFOPLIST_FILE: YES", project)
+        self.assertIn("MetasequoiaImeIOSUITests", project.split("test:", 1)[1])
+        self.assertIn("platforms/ios/scripts/run_ui_tests.sh", workflow)
+        self.assertIn("simctl bootstatus", runner)
+        self.assertNotIn("sleep ", runner)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add an XCUITest target for the native iOS host app
- launch onboarding, verify the enablement entry and tryout field, and type into the host document
- add a Simulator runner that selects a booted/newest available iPhone and waits on real boot status
- run the smoke test in CI with a bounded step timeout

## Verification
- ProjectConfigurationTests: 13 passed
- DictionaryPackagingTests: 1 passed
- default Simulator selection path: 1 XCUITest passed twice
- full target graph built host, keyboard extension, shared Engine bridge, and UI test runner
- Orca Computer accessibility and pixel inspection passed
- bash syntax and git diff checks passed