### PR TITLE
fix(ios): adapt action row to narrow screens

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -162,33 +162,36 @@ final class KeyboardViewController: UIInputViewController {
     layoutToggle.titleLabel?.adjustsFontSizeToFitWidth = true
     layoutToggle.titleLabel?.minimumScaleFactor = 0.7
     layoutToggle.titleLabel?.lineBreakMode = .byClipping
-    layoutToggle.widthAnchor.constraint(equalToConstant: 56).isActive = true
     layoutToggleButton = layoutToggle
     row.addArrangedSubview(layoutToggle)
 
     let globe = makeSymbolKey(symbol: "globe", accessibilityLabel: "下一个键盘") { [weak self] in
       self?.switchToNextKeyboard()
     }
-    globe.widthAnchor.constraint(equalToConstant: 50).isActive = true
     row.addArrangedSubview(globe)
 
     let delete = makeSymbolKey(symbol: "delete.left", accessibilityLabel: "删除") { [weak self] in
       self?.handleBackspace()
     }
-    delete.widthAnchor.constraint(equalToConstant: 50).isActive = true
     row.addArrangedSubview(delete)
 
     let space = makeKey(title: "空格", accessibilityLabel: "空格") { [weak self] in
       self?.handleSpace()
     }
-    space.widthAnchor.constraint(greaterThanOrEqualToConstant: 110).isActive = true
     row.addArrangedSubview(space)
 
     let enter = makeKey(title: "换行", accessibilityLabel: "换行", emphasized: true) { [weak self] in
       self?.handleReturn()
     }
-    enter.widthAnchor.constraint(equalToConstant: 72).isActive = true
     row.addArrangedSubview(enter)
+
+    NSLayoutConstraint.activate([
+      layoutToggle.widthAnchor.constraint(equalTo: globe.widthAnchor, multiplier: 1.1),
+      delete.widthAnchor.constraint(equalTo: globe.widthAnchor),
+      space.widthAnchor.constraint(equalTo: globe.widthAnchor, multiplier: 1.8),
+      enter.widthAnchor.constraint(equalTo: globe.widthAnchor, multiplier: 1.35),
+      globe.widthAnchor.constraint(greaterThanOrEqualToConstant: 44),
+    ])
     return row
   }
 

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -124,6 +124,25 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("simctl bootstatus", runner)
         self.assertNotIn("sleep ", runner)
 
+    def test_keyboard_action_row_adapts_to_narrow_screens(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn(
+            "space.widthAnchor.constraint(equalTo: globe.widthAnchor, multiplier: 1.8)",
+            controller,
+        )
+        self.assertIn(
+            "globe.widthAnchor.constraint(greaterThanOrEqualToConstant: 44)",
+            controller,
+        )
+        self.assertIn(
+            "enter.widthAnchor.constraint(equalTo: globe.widthAnchor, multiplier: 1.35)",
+            controller,
+        )
+        self.assertNotIn("layoutToggle.widthAnchor.constraint(equalToConstant: 56)", controller)
+        self.assertNotIn("space.widthAnchor.constraint(greaterThanOrEqualToConstant: 110)", controller)
+        self.assertNotIn("enter.widthAnchor.constraint(equalToConstant: 72)", controller)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- replace fixed bottom action-key widths with proportional constraints
- retain a 44pt minimum touch target on compact screens
- add a regression test preventing fixed-width constraints from returning

## Verification
- `python3 platforms/ios/tests/ProjectConfigurationTests.py` (14/14)
- `python3 platforms/ios/tests/DictionaryPackagingTests.py` (1/1)
- universal iOS Simulator build (arm64 + x86_64)
- native onboarding XCUITest (1/1)
- Orca Computer host-app visual inspection