### PR TITLE
feat(ios): add pinyin scheme switch

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -7,11 +7,14 @@ final class KeyboardViewController: UIInputViewController {
   private let candidateScrollView = UIScrollView()
   private let candidateStack = UIStackView()
   private let languageModeButton = UIButton()
+  private let schemeButton = UIButton()
   private var letterRowViews: [UIView] = []
   private var symbolRowViews: [UIView] = []
   private var layoutToggleButton: UIButton?
   private var isChineseMode = true
+  private var usesShuangpin = false
   private var showsSymbols = false
+  private let schemePreferenceKey = "inputSchemeUsesShuangpin"
 
   private let letterRows = [
     Array("qwertyuiop"),
@@ -26,6 +29,10 @@ final class KeyboardViewController: UIInputViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    usesShuangpin = UserDefaults.standard.bool(forKey: schemePreferenceKey)
+    if usesShuangpin {
+      _ = session.switch(toShuangpin: true)
+    }
     view.backgroundColor = MetasequoiaTheme.keyboardBackground
     installKeyboard()
     updateCandidateStrip(preedit: "", candidates: [])
@@ -81,6 +88,11 @@ final class KeyboardViewController: UIInputViewController {
       UIAction { [weak self] _ in self?.toggleInputMode() }, for: .primaryActionTriggered)
     languageModeButton.widthAnchor.constraint(equalToConstant: 36).isActive = true
 
+    updateSchemeButton()
+    schemeButton.addAction(
+      UIAction { [weak self] _ in self?.toggleScheme() }, for: .primaryActionTriggered)
+    schemeButton.widthAnchor.constraint(equalToConstant: 48).isActive = true
+
     candidateStack.axis = .horizontal
     candidateStack.spacing = 6
     candidateStack.translatesAutoresizingMaskIntoConstraints = false
@@ -88,7 +100,7 @@ final class KeyboardViewController: UIInputViewController {
     candidateScrollView.addSubview(candidateStack)
 
     let content = UIStackView(
-      arrangedSubviews: [languageModeButton, preeditLabel, candidateScrollView])
+      arrangedSubviews: [languageModeButton, schemeButton, preeditLabel, candidateScrollView])
     content.axis = .horizontal
     content.alignment = .center
     content.spacing = 12
@@ -265,6 +277,29 @@ final class KeyboardViewController: UIInputViewController {
     languageModeButton.accessibilityLabel =
       isChineseMode ? "切换到英文输入" : "切换到中文输入"
     languageModeButton.accessibilityValue = isChineseMode ? "中文输入" : "英文输入"
+  }
+
+  private func toggleScheme() {
+    usesShuangpin.toggle()
+    let snapshot = session.switch(toShuangpin: usesShuangpin)
+    UserDefaults.standard.set(usesShuangpin, forKey: schemePreferenceKey)
+    updateSchemeButton()
+    render(snapshot)
+  }
+
+  private func updateSchemeButton() {
+    var configuration = UIButton.Configuration.plain()
+    configuration.title = usesShuangpin ? "小鹤" : "全拼"
+    configuration.baseForegroundColor = MetasequoiaTheme.forestUIColor
+    configuration.contentInsets = NSDirectionalEdgeInsets(
+      top: 3, leading: 4, bottom: 3, trailing: 4)
+    configuration.background.strokeColor = MetasequoiaTheme.forestUIColor.withAlphaComponent(0.35)
+    configuration.background.strokeWidth = 1
+    configuration.background.cornerRadius = 8
+    schemeButton.configuration = configuration
+    schemeButton.accessibilityIdentifier = "schemeButton"
+    schemeButton.accessibilityLabel = usesShuangpin ? "切换到全拼" : "切换到小鹤双拼"
+    schemeButton.accessibilityValue = usesShuangpin ? "小鹤双拼" : "全拼"
   }
 
   private func toggleLayout() {

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -76,6 +76,31 @@ int RunTest() {
     Require(!adapter.handle_character('\'').handled,
             "An idle apostrophe was swallowed by the engine adapter.");
 
+    Require(!adapter.uses_shuangpin(),
+            "The adapter did not start in full-pinyin mode.");
+    Require(adapter.handle_character('n').handled &&
+                adapter.handle_character('i').handled,
+            "The scheme-switch fixture did not start a composition.");
+    const auto switchedToShuangpin = adapter.switch_to_shuangpin(true);
+    Require(switchedToShuangpin.handled &&
+                switchedToShuangpin.commit.has_value() &&
+                *switchedToShuangpin.commit == "ni" &&
+                switchedToShuangpin.preedit.empty(),
+            "Switching schemes did not commit and clear the composition.");
+    Require(adapter.uses_shuangpin(),
+            "The adapter did not retain double-pinyin mode.");
+    Require(adapter.handle_character('n').handled,
+            "The idempotent switch fixture did not start a composition.");
+    const auto unchangedShuangpin = adapter.switch_to_shuangpin(true);
+    Require(!unchangedShuangpin.handled && unchangedShuangpin.preedit == "n" &&
+                adapter.uses_shuangpin(),
+            "Selecting the active scheme changed the composition.");
+    Require(adapter.cancel().handled,
+            "The idempotent switch fixture did not cancel its composition.");
+    const auto switchedToQuanpin = adapter.switch_to_shuangpin(false);
+    Require(!switchedToQuanpin.handled && !adapter.uses_shuangpin(),
+            "The adapter did not switch an idle session back to full pinyin.");
+
     Require(adapter.handle_character('n').handled &&
                 adapter.handle_character('i').handled,
             "The candidate-key fixture did not start a composition.");

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -143,6 +143,21 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertNotIn("space.widthAnchor.constraint(greaterThanOrEqualToConstant: 110)", controller)
         self.assertNotIn("enter.widthAnchor.constraint(equalToConstant: 72)", controller)
 
+    def test_keyboard_exposes_a_persisted_full_and_double_pinyin_switch(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+        bridge_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.h").read_text()
+        adapter_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/InputSessionAdapter.h").read_text()
+
+        self.assertIn("schemeButton", controller)
+        self.assertIn("toggleScheme", controller)
+        self.assertIn("UserDefaults.standard.bool(forKey: schemePreferenceKey)", controller)
+        self.assertIn("UserDefaults.standard.set(usesShuangpin, forKey: schemePreferenceKey)", controller)
+        self.assertIn("session.switch(toShuangpin: usesShuangpin)", controller)
+        self.assertIn('usesShuangpin ? "小鹤" : "全拼"', controller)
+        self.assertIn('schemeButton.accessibilityIdentifier = "schemeButton"', controller)
+        self.assertIn("switchToShuangpin", bridge_header)
+        self.assertIn("switch_to_shuangpin", adapter_header)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -7,7 +7,10 @@
 namespace metasequoia::apple {
 class InputSessionAdapter::Impl {
 public:
-  InputSession session{SchemeType::Quanpin, true, true, true, false};
+  explicit Impl(SchemeType scheme = SchemeType::Quanpin)
+      : session{scheme, true, true, true, false} {}
+
+  InputSession session;
 };
 
 namespace {
@@ -65,5 +68,21 @@ InputSnapshot InputSessionAdapter::cancel() {
 
 InputSnapshot InputSessionAdapter::select_candidate(std::size_t index) {
   return MakeSnapshot(impl_->session, impl_->session.select_candidate(index));
+}
+
+InputSnapshot InputSessionAdapter::switch_to_shuangpin(bool uses_shuangpin) {
+  if (uses_shuangpin == this->uses_shuangpin()) {
+    return MakeSnapshot(impl_->session, {});
+  }
+  const auto result = impl_->session.handle_command(Command::CommitCandidate);
+  auto snapshot = MakeSnapshot(impl_->session, result);
+  const auto scheme =
+      uses_shuangpin ? SchemeType::Shuangpin : SchemeType::Quanpin;
+  impl_ = std::make_unique<Impl>(scheme);
+  return snapshot;
+}
+
+bool InputSessionAdapter::uses_shuangpin() const {
+  return impl_->session.scheme_type() == SchemeType::Shuangpin;
 }
 } // namespace metasequoia::apple

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -30,6 +30,8 @@ public:
   InputSnapshot commit_raw();
   InputSnapshot cancel();
   InputSnapshot select_candidate(std::size_t index);
+  InputSnapshot switch_to_shuangpin(bool uses_shuangpin);
+  bool uses_shuangpin() const;
 
 private:
   class Impl;

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (MetasequoiaInputSnapshot *)commitRaw;
 - (MetasequoiaInputSnapshot *)cancel;
 - (MetasequoiaInputSnapshot *)selectCandidateAtIndex:(NSUInteger)index;
+- (MetasequoiaInputSnapshot *)switchToShuangpin:(BOOL)usesShuangpin;
 
 @end
 

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -190,6 +190,10 @@ void ConfigureDataDirectory() {
       snapshotFrom:_adapter->select_candidate(static_cast<std::size_t>(index))];
 }
 
+- (MetasequoiaInputSnapshot *)switchToShuangpin:(BOOL)usesShuangpin {
+  return [self snapshotFrom:_adapter->switch_to_shuangpin(usesShuangpin)];
+}
+
 - (MetasequoiaInputSnapshot *)snapshotFrom:
     (metasequoia::apple::InputSnapshot)snapshot {
   NSMutableArray<NSString *> *candidates =


### PR DESCRIPTION
## Summary
- add an on-keyboard 全拼 / 小鹤 switch backed by the shared Engine
- commit active composition before changing schemes and make repeated selection idempotent
- persist the selection inside the keyboard extension without requesting Full Access
- expose the scheme transition through the Objective-C Apple bridge

## Verification
- project configuration tests (15/15)
- dictionary packaging test (1/1)
- Apple input-session adapter test (1/1)
- universal iOS Simulator build (arm64 + x86_64)
- native onboarding XCUITest (1/1)