### PR TITLE
fix(ios): use system input mode menu

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -177,9 +177,9 @@ final class KeyboardViewController: UIInputViewController {
     layoutToggleButton = layoutToggle
     row.addArrangedSubview(layoutToggle)
 
-    let globe = makeSymbolKey(symbol: "globe", accessibilityLabel: "下一个键盘") { [weak self] in
-      self?.switchToNextKeyboard()
-    }
+    let globe = makeSymbolKey(symbol: "globe", accessibilityLabel: "选择下一个键盘")
+    globe.addTarget(
+      self, action: #selector(handleInputModeButton(_:event:)), for: .allTouchEvents)
     row.addArrangedSubview(globe)
 
     let delete = makeSymbolKey(symbol: "delete.left", accessibilityLabel: "删除") { [weak self] in
@@ -335,9 +335,11 @@ final class KeyboardViewController: UIInputViewController {
     textDocumentProxy.insertText("\n")
   }
 
-  private func switchToNextKeyboard() {
-    render(session.commitRaw())
-    advanceToNextInputMode()
+  @objc private func handleInputModeButton(_ sender: UIButton, event: UIEvent) {
+    if event.allTouches?.contains(where: { touch in touch.phase == .began }) == true {
+      render(session.commitRaw())
+    }
+    handleInputModeList(from: sender, with: event)
   }
 
   private func render(_ snapshot: MetasequoiaInputSnapshot) {
@@ -385,14 +387,17 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func makeSymbolKey(
-    symbol: String, accessibilityLabel: String, action: @escaping () -> Void
+    symbol: String, accessibilityLabel: String, action: (() -> Void)? = nil
   ) -> UIButton {
     var configuration = UIButton.Configuration.plain()
     configuration.image = UIImage(systemName: symbol)
     configuration.baseForegroundColor = .label
     configuration.background.backgroundColor = MetasequoiaTheme.keyBackground
     configuration.background.cornerRadius = 8
-    let button = UIButton(configuration: configuration, primaryAction: UIAction { _ in action() })
+    let button = UIButton(configuration: configuration)
+    if let action {
+      button.addAction(UIAction { _ in action() }, for: .primaryActionTriggered)
+    }
     button.accessibilityLabel = accessibilityLabel
     return button
   }

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -30,7 +30,7 @@ class ProjectConfigurationTests(unittest.TestCase):
 
         self.assertIn("textDocumentProxy.insertText", controller)
         self.assertIn("textDocumentProxy.deleteBackward", controller)
-        self.assertIn("advanceToNextInputMode()", controller)
+        self.assertIn("handleInputModeList(from:", controller)
         self.assertNotIn("URLSession", controller)
 
     def test_onboarding_exposes_a_regular_text_field_for_keyboard_tryout(self):
@@ -157,6 +157,16 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn('schemeButton.accessibilityIdentifier = "schemeButton"', controller)
         self.assertIn("switchToShuangpin", bridge_header)
         self.assertIn("switch_to_shuangpin", adapter_header)
+
+    def test_globe_key_uses_the_system_input_mode_list(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("#selector(handleInputModeButton(_:event:))", controller)
+        self.assertIn("for: .allTouchEvents", controller)
+        self.assertIn("touch.phase == .began", controller)
+        self.assertIn("render(session.commitRaw())", controller)
+        self.assertIn("handleInputModeList(from: sender, with: event)", controller)
+        self.assertNotIn("advanceToNextInputMode()", controller)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- route the globe key through the standard iOS input-mode list
- support tap, long-press, and drag selection via all touch events
- preserve the existing raw-composition commit before leaving the keyboard
- keep ordinary symbol buttons on explicit primary actions

## Verification
- project configuration tests (16/16)
- dictionary packaging test (1/1)
- universal iOS Simulator build (arm64 + x86_64)
- native onboarding XCUITest (1/1)
- API signature verified against the installed Xcode 26.5 UIKit SDK