### PR TITLE
fix(release): use canonical Apple repository URLs

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 Metasequoia IME for macOS processes keystrokes, pre-edit text, and candidates locally on the user's Mac. The application does not send typed text, candidates, learned words, preferences, diagnostics, analytics, or crash reports over the network. It does not include cloud synchronization.
 
-The app contacts GitHub's public Releases API at most once per day to discover new stable versions, and when the user manually requests an update check. The request does not include typed text, preferences, or dictionary data. GitHub may receive the IP address and standard network request metadata. Opening an available update uses the corresponding fixed page under `github.com/houko/MetasequoiaImeApple`.
+The app contacts GitHub's public Releases API at most once per day to discover new stable versions, and when the user manually requests an update check. The request does not include typed text, preferences, or dictionary data. GitHub may receive the IP address and standard network request metadata. Opening an available update uses the corresponding fixed page under `github.com/metasequoiaime/MSIME-Apple`.
 
 The input method stores its settings in the current user's macOS preferences. When candidate learning is enabled, learned word-frequency changes are stored locally under `~/Library/Application Support/metasequoiaime/`. The bundled dictionary is copied to the same directory so it can be upgraded safely. These files are available only through the permissions of the local macOS account; users should protect that account and its backups as they would other personal data.
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The current release supports full-pinyin composition, live candidates from the o
 ## Build
 
 ```sh
-git clone --recursive https://github.com/houko/MetasequoiaImeApple.git
-cd MetasequoiaImeApple
+git clone --recursive https://github.com/metasequoiaime/MSIME-Apple.git
+cd MSIME-Apple
 brew install cmake boost fmt spdlog
 ./platforms/macos/scripts/build.sh
 ```

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -4,7 +4,7 @@ Metasequoia IME for macOS — Third-Party Notices
 This application embeds MetasequoiaImeEngine, which is distributed under
 the GNU General Public License version 3. The complete license is provided
 in GPL-3.0.txt. Source code is available from:
-https://github.com/houko/MetasequoiaImeApple
+https://github.com/metasequoiaime/MSIME-Apple
 https://github.com/houko/MetasequoiaImeEngine
 
 The application also incorporates the following components:

--- a/docs/apple-platform-architecture.md
+++ b/docs/apple-platform-architecture.md
@@ -4,7 +4,7 @@
 
 Metasequoia IME uses one composition engine across macOS and iOS, with a separate native frontend for each platform. The shared layer owns input-method behavior; platform layers own operating-system integration and presentation.
 
-This repository is named `MetasequoiaImeApple` because it contains Apple-platform adapters and applications. The reusable engine remains in the independent `MetasequoiaImeEngine` repository so Windows, Apple, and future frontends do not depend on an Apple application project.
+This repository is named `MSIME-Apple` because it contains Apple-platform adapters and applications. The reusable engine remains in the independent `MetasequoiaImeEngine` repository so Windows, Apple, and future frontends do not depend on an Apple application project.
 
 ## Ownership boundaries
 
@@ -37,7 +37,7 @@ macOS settings  iOS host app/settings
 The migration will converge on this layout:
 
 ```text
-MetasequoiaImeApple/
+MSIME-Apple/
 ├── platforms/
 │   ├── macos/
 │   │   ├── src/

--- a/platforms/macos/resources/Info.plist
+++ b/platforms/macos/resources/Info.plist
@@ -72,7 +72,7 @@
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>SUFeedURL</key>
-    <string>https://github.com/houko/MetasequoiaImeApple/releases/latest/download/appcast.xml</string>
+    <string>https://github.com/metasequoiaime/MSIME-Apple/releases/latest/download/appcast.xml</string>
     <key>SUEnableAutomaticChecks</key>
     <true/>
     <key>SUPublicEDKey</key>

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -60,7 +60,7 @@ fi
             environment.update(
                 {
                     "PATH": f"{temporary}:{environment['PATH']}",
-                    "GH_REPO": "houko/MetasequoiaImeApple",
+                    "GH_REPO": "metasequoiaime/MSIME-Apple",
                     "RELEASE_PR": json.dumps(release_pr),
                     "GITHUB_OUTPUT": str(output),
                     "FAKE_GH_LOG": str(log),
@@ -216,7 +216,7 @@ fi
             environment.update(
                 {
                     "PATH": f"{fake_bin}:{environment['PATH']}",
-                    "GH_REPO": "houko/MetasequoiaImeApple",
+                    "GH_REPO": "metasequoiaime/MSIME-Apple",
                     "TAG_NAME": "v1.2.3",
                     "ASSET_SUFFIX": asset_suffix,
                     "SIGNING_ENABLED": signing_enabled,
@@ -344,7 +344,7 @@ while (($#)); do
     shift
 done
 cat > "$output" <<'XML'
-<?xml version="1.0"?><rss><channel><item><enclosure url="https://github.com/houko/MetasequoiaImeApple/releases/download/v1.2.3/MetasequoiaIME-v1.2.3-macos-universal-unsigned-update.zip" sparkle:edSignature="test-signature" /></item></channel></rss>
+<?xml version="1.0"?><rss><channel><item><enclosure url="https://github.com/metasequoiaime/MSIME-Apple/releases/download/v1.2.3/MetasequoiaIME-v1.2.3-macos-universal-unsigned-update.zip" sparkle:edSignature="test-signature" /></item></channel></rss>
 XML
 """
             )
@@ -368,7 +368,7 @@ fi
                     "SPARKLE_TOOLS_DIR": str(tools),
                     "SPARKLE_ED_PRIVATE_KEY": private_key,
                     "FAKE_SPARKLE_LOG": str(log),
-                    "GH_REPO": "houko/MetasequoiaImeApple",
+                    "GH_REPO": "metasequoiaime/MSIME-Apple",
                 }
             )
             result = subprocess.run(

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -12,6 +12,30 @@ MACOS_ROOT = PROJECT_ROOT / "platforms" / "macos"
 
 
 class ReleaseConfigurationTests(unittest.TestCase):
+    def test_current_repository_links_use_the_canonical_apple_repository(self):
+        canonical_repository = "https://github.com/metasequoiaime/MSIME-Apple"
+        current_metadata = "\n".join(
+            path.read_text()
+            for path in (
+                PROJECT_ROOT / "README.md",
+                PROJECT_ROOT / "PRIVACY.md",
+                PROJECT_ROOT / "THIRD_PARTY_NOTICES.txt",
+                PROJECT_ROOT / "docs/apple-platform-architecture.md",
+                MACOS_ROOT / "resources/Info.plist",
+                MACOS_ROOT / "tests/ReleaseAutomationTests.py",
+            )
+        )
+
+        self.assertNotIn("github.com/houko/MetasequoiaImeApple", current_metadata)
+        self.assertNotIn("github.com/houko/MetasequoiaImeMac", current_metadata)
+        self.assertIn(canonical_repository, current_metadata)
+        with (MACOS_ROOT / "resources/Info.plist").open("rb") as info_file:
+            info = plistlib.load(info_file)
+        self.assertEqual(
+            info["SUFeedURL"],
+            f"{canonical_repository}/releases/latest/download/appcast.xml",
+        )
+
     def test_input_source_uses_a_dedicated_menu_icon(self):
         with (MACOS_ROOT / "resources/Info.plist").open("rb") as info_file:
             info = plistlib.load(info_file)


### PR DESCRIPTION
## Summary
- point the Sparkle feed directly at the renamed canonical repository
- update clone instructions, privacy disclosure, source notice, and architecture docs
- update release automation fixtures and add a regression test for stale repository URLs
- preserve historical CHANGELOG links and stable product identities

## Verification
- release configuration tests (7/7)
- release automation tests (16/16)
- `plutil -lint platforms/macos/resources/Info.plist`
- targeted stale-URL scan