### PR TITLE
fix(deps): use canonical dictionary repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = feat/macos-portability
 [submodule "vendor/MetasequoiaImeDict"]
 	path = vendor/MetasequoiaImeDict
-	url = https://github.com/metasequoiaime/MetasequoiaImeDict.git
+	url = https://github.com/metasequoiaime/MSIME-Dict.git

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -335,6 +335,11 @@ class ReleaseConfigurationTests(unittest.TestCase):
             "https://github.com/houko/MetasequoiaImeEngine.git",
         )
         self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "branch"), "feat/macos-portability")
+        self.assertEqual(submodule_value("vendor/MetasequoiaImeDict", "path"), "vendor/MetasequoiaImeDict")
+        self.assertEqual(
+            submodule_value("vendor/MetasequoiaImeDict", "url"),
+            "https://github.com/metasequoiaime/MSIME-Dict.git",
+        )
 
     def test_release_scripts_have_valid_zsh_syntax(self):
         for relative_path in (


### PR DESCRIPTION
## Summary
- point the top-level dictionary submodule directly at `metasequoiaime/MSIME-Dict`
- keep the pinned dictionary commit unchanged
- add a regression assertion for the canonical dictionary path and URL

## Verification
- release configuration tests (7/7)
- release automation tests (16/16)
- clean recursive submodule checkout from the network, including nested CustomDict and Engine dependencies