### PR TITLE
fix(ios): isolate UI tests on main actor

### DIFF
--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -5,6 +5,7 @@ final class OnboardingUITests: XCTestCase {
     continueAfterFailure = false
   }
 
+  @MainActor
   func testOnboardingExposesEnablementPathAndTryoutField() {
     let app = XCUIApplication()
     app.launch()

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -124,6 +124,14 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("simctl bootstatus", runner)
         self.assertNotIn("sleep ", runner)
 
+    def test_ui_tests_are_main_actor_isolated_for_swift_6(self):
+        ui_tests = (IOS_ROOT / "UITests/OnboardingUITests.swift").read_text()
+
+        self.assertIn(
+            "@MainActor\n  func testOnboardingExposesEnablementPathAndTryoutField()",
+            ui_tests,
+        )
+
     def test_keyboard_action_row_adapts_to_narrow_screens(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 


### PR DESCRIPTION
## Summary

- isolate the onboarding UI test on the main actor for Swift 6/Xcode 16
- add a regression assertion so XCUI calls cannot silently lose actor isolation

## Verification

- ProjectConfigurationTests.py: 17/17
- DictionaryPackagingTests.py: 1/1
- universal iOS Simulator build
- native onboarding XCUITest: 1/1
