### PR TITLE
ci: cancel duplicate branch runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -12,6 +12,15 @@ MACOS_ROOT = PROJECT_ROOT / "platforms" / "macos"
 
 
 class ReleaseConfigurationTests(unittest.TestCase):
+    def test_ci_cancels_duplicate_runs_for_the_same_source_branch(self):
+        workflow = (PROJECT_ROOT / ".github/workflows/ci.yml").read_text()
+
+        self.assertIn(
+            "group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}",
+            workflow,
+        )
+        self.assertIn("cancel-in-progress: true", workflow)
+
     def test_current_repository_links_use_the_canonical_apple_repository(self):
         canonical_repository = "https://github.com/metasequoiaime/MSIME-Apple"
         current_metadata = "\n".join(


### PR DESCRIPTION
## Summary
- group CI runs by workflow and source branch across push, pull request, and manual dispatch events
- cancel superseded runs so release validation does not compete with duplicate jobs
- lock the concurrency contract with a release configuration test

## Verification
- `python3 platforms/macos/tests/ReleaseConfigurationTests.py` (8/8)
- `python3 platforms/macos/tests/ReleaseAutomationTests.py` (16/16)