### PR TITLE
feat(ios): follow automatic capitalization traits

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/EnglishCapitalizationPolicy.swift
+++ b/platforms/ios/KeyboardExtension/Sources/EnglishCapitalizationPolicy.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum EnglishCapitalizationMode {
+  case none
+  case words
+  case sentences
+  case allCharacters
+}
+
+enum EnglishCapitalizationPolicy {
+  private static let apostrophes: Set<Character> = ["'", "’"]
+  private static let sentenceTerminators: Set<Character> = [".", "!", "?", "。", "！", "？"]
+  private static let closingCharacters: Set<Character> = ["'", "\"", "’", "”", ")", "]", "}"]
+
+  static func shouldShift(
+    for mode: EnglishCapitalizationMode,
+    contextBeforeInput: String?
+  ) -> Bool {
+    switch mode {
+    case .none:
+      return false
+    case .allCharacters:
+      return true
+    case .words:
+      guard let contextBeforeInput else { return false }
+      guard let lastCharacter = contextBeforeInput.last else { return true }
+      if apostrophes.contains(lastCharacter) {
+        return false
+      }
+      let continuesWord = lastCharacter.unicodeScalars.contains {
+        CharacterSet.alphanumerics.contains($0)
+      }
+      return !continuesWord
+    case .sentences:
+      guard let contextBeforeInput else { return false }
+      guard !contextBeforeInput.isEmpty else { return true }
+      for character in contextBeforeInput.reversed() {
+        if character == "\n" || character == "\r" {
+          return true
+        }
+        if character.isWhitespace || closingCharacters.contains(character) {
+          continue
+        }
+        return sentenceTerminators.contains(character)
+      }
+      return true
+    }
+  }
+}

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -22,6 +22,7 @@ final class KeyboardViewController: UIInputViewController {
   private var usesShuangpin = false
   private var showsSymbols = false
   private var letterCaseState = LetterCaseState.lowercase
+  private var isAutomaticShift = false
   private var lastShiftTapTime: TimeInterval?
   private let schemePreferenceKey = "inputSchemeUsesShuangpin"
 
@@ -56,6 +57,7 @@ final class KeyboardViewController: UIInputViewController {
   override func textDidChange(_ textInput: UITextInput?) {
     super.textDidChange(textInput)
     updateReturnKey()
+    updateAutomaticCapitalization()
   }
 
   private func installKeyboard() {
@@ -296,15 +298,17 @@ final class KeyboardViewController: UIInputViewController {
     let snapshot = isChineseMode ? session.commitCandidate() : session.cancel()
     isChineseMode.toggle()
     letterCaseState = .lowercase
+    isAutomaticShift = false
     lastShiftTapTime = nil
     updateLanguageModeButton()
-    updateLetterCaseControls()
+    updateAutomaticCapitalization()
     render(snapshot)
   }
 
   private func toggleLetterCase() {
     guard !isChineseMode else { return }
 
+    isAutomaticShift = false
     let now = ProcessInfo.processInfo.systemUptime
     if letterCaseState == .shifted,
       let lastShiftTapTime,
@@ -315,6 +319,39 @@ final class KeyboardViewController: UIInputViewController {
       letterCaseState = letterCaseState == .lowercase ? .shifted : .lowercase
     }
     self.lastShiftTapTime = now
+    updateLetterCaseControls()
+  }
+
+  private func updateAutomaticCapitalization() {
+    guard !isChineseMode else {
+      isAutomaticShift = false
+      updateLetterCaseControls()
+      return
+    }
+    guard letterCaseState != .capsLock else {
+      updateLetterCaseControls()
+      return
+    }
+
+    let mode: EnglishCapitalizationMode
+    switch textDocumentProxy.autocapitalizationType {
+    case .none:
+      mode = .none
+    case .words:
+      mode = .words
+    case .sentences:
+      mode = .sentences
+    case .allCharacters:
+      mode = .allCharacters
+    @unknown default:
+      mode = .sentences
+    }
+
+    isAutomaticShift = EnglishCapitalizationPolicy.shouldShift(
+      for: mode,
+      contextBeforeInput: textDocumentProxy.documentContextBeforeInput)
+    letterCaseState = isAutomaticShift ? .shifted : .lowercase
+    lastShiftTapTime = nil
     updateLetterCaseControls()
   }
 
@@ -343,7 +380,7 @@ final class KeyboardViewController: UIInputViewController {
       configuration.background.backgroundColor =
         MetasequoiaTheme.forestUIColor.withAlphaComponent(0.22)
       button.accessibilityLabel = "大写"
-      button.accessibilityValue = "下一字母"
+      button.accessibilityValue = isAutomaticShift ? "自动开启" : "下一字母"
     case .capsLock:
       configuration.image = UIImage(systemName: "capslock.fill")
       configuration.background.backgroundColor =

--- a/platforms/ios/tests/EnglishCapitalizationPolicyTests.swift
+++ b/platforms/ios/tests/EnglishCapitalizationPolicyTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+private func expect(
+  _ expected: Bool,
+  _ mode: EnglishCapitalizationMode,
+  _ context: String?,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  let actual = EnglishCapitalizationPolicy.shouldShift(
+    for: mode, contextBeforeInput: context)
+  precondition(
+    actual == expected,
+    "Expected \(expected) for \(mode) with context \(String(describing: context)), got \(actual)",
+    file: file,
+    line: line)
+}
+
+@main
+struct EnglishCapitalizationPolicyTests {
+  static func main() {
+    expect(false, .none, "")
+    expect(false, .sentences, nil)
+    expect(true, .allCharacters, nil)
+
+    expect(true, .words, "")
+    expect(true, .words, "hello ")
+    expect(false, .words, "hel")
+    expect(false, .words, "don't")
+    expect(false, .words, "don'")
+
+    expect(true, .sentences, "")
+    expect(false, .sentences, "Hello")
+    expect(true, .sentences, "Hello. ")
+    expect(true, .sentences, "Really!\n")
+    expect(true, .sentences, "Done.” ")
+  }
+}

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -1,4 +1,6 @@
 import plistlib
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -7,6 +9,18 @@ IOS_ROOT = Path(__file__).resolve().parents[1]
 
 
 class ProjectConfigurationTests(unittest.TestCase):
+    def test_english_capitalization_policy(self):
+        policy = IOS_ROOT / "KeyboardExtension/Sources/EnglishCapitalizationPolicy.swift"
+        tests = IOS_ROOT / "tests/EnglishCapitalizationPolicyTests.swift"
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            executable = Path(temporary_directory) / "EnglishCapitalizationPolicyTests"
+            subprocess.run(
+                ["swiftc", str(policy), str(tests), "-o", str(executable)],
+                check=True,
+            )
+            subprocess.run([str(executable)], check=True)
+
     def test_project_defines_distinct_host_and_keyboard_identifiers(self):
         project = (IOS_ROOT / "project.yml").read_text()
 


### PR DESCRIPTION
## Summary
- honor the host field’s autocapitalization trait in English mode
- derive word and sentence boundaries from the document context without requesting Open Access
- keep manual one-shot shift and caps lock authoritative, with an accessible automatic-shift state
- add executable Swift policy tests for privacy-denied context, words, sentences, quotes, newlines, and all-character fields

## Verification
- iOS project configuration and policy tests: 20/20
- dictionary packaging test: 1/1
- universal iOS Simulator host app and keyboard-extension build