### PR TITLE
ci(ios): stabilize simulator UI tests

### DIFF
--- a/platforms/ios/scripts/run_ui_tests.sh
+++ b/platforms/ios/scripts/run_ui_tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 project_path="${1:-build/ios/MetasequoiaImeIOS.xcodeproj}"
-derived_data_path="${2:-build/ios-ui-test-derived}"
+derived_data_path="${2:-build/ios-derived}"
 
 if [[ ! -d "${project_path}" ]]; then
   echo "Generated Xcode project not found: ${project_path}" >&2
@@ -38,7 +38,10 @@ raise SystemExit("No available iPhone Simulator runtime was found")
 ')"
 fi
 
-# simctl bootstatus polls the real boot state; it avoids a timing guess before XCTest starts.
+# A stale booted runner can accept status requests while its app installation service is wedged.
+# Restarting the selected device is bounded by bootstatus and preserves its installed data.
+xcrun simctl shutdown "${test_device_id}" >/dev/null 2>&1 || true
+xcrun simctl boot "${test_device_id}"
 xcrun simctl bootstatus "${test_device_id}" -b
 
 xcodebuild \

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -161,6 +161,9 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("MetasequoiaImeIOSUITests", project.split("test:", 1)[1])
         self.assertIn("platforms/ios/scripts/run_ui_tests.sh", workflow)
         self.assertIn("simctl bootstatus", runner)
+        self.assertIn('derived_data_path="${2:-build/ios-derived}"', runner)
+        self.assertIn('xcrun simctl shutdown "${test_device_id}"', runner)
+        self.assertIn('xcrun simctl boot "${test_device_id}"', runner)
         self.assertNotIn("sleep ", runner)
 
     def test_ui_tests_are_main_actor_isolated_for_swift_6(self):


### PR DESCRIPTION
## Summary
- reuse the preceding iOS build’s DerivedData instead of recompiling the full C++ engine for UI tests
- restart the selected Simulator before XCTest to recover stale app-installation services
- continue waiting on `simctl bootstatus` rather than using fixed sleeps
- lock both reliability contracts in project configuration tests

## Root cause evidence
- stale booted Simulator hung on both XCTest install and direct `simctl install`
- the same app installed in 14 seconds after a controlled Simulator restart

## Verification
- iOS configuration tests: 20/20
- shell syntax validation
- native onboarding XCUITest: 1/1 in 21.9 seconds after the restart, with no second Engine compilation