### PR TITLE
fix(ios): handle missing input traits

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -345,7 +345,7 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     let mode: EnglishCapitalizationMode
-    switch textDocumentProxy.autocapitalizationType {
+    switch textDocumentProxy.autocapitalizationType ?? .sentences {
     case .none:
       mode = .none
     case .words:
@@ -419,7 +419,7 @@ final class KeyboardViewController: UIInputViewController {
 
   private func updateReturnKey() {
     let title: String
-    switch textDocumentProxy.returnKeyType {
+    switch textDocumentProxy.returnKeyType ?? .default {
     case .default:
       title = "换行"
     case .go:

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -156,12 +156,14 @@ class ProjectConfigurationTests(unittest.TestCase):
 
         self.assertIn("private weak var enterButton: UIButton?", controller)
         self.assertIn("override func textDidChange", controller)
-        self.assertIn("switch textDocumentProxy.returnKeyType", controller)
+        self.assertIn("switch textDocumentProxy.returnKeyType ?? .default", controller)
         self.assertIn("case .go:", controller)
         self.assertIn("case .google, .search, .yahoo:", controller)
         self.assertIn("case .send:", controller)
         self.assertIn("case .done:", controller)
         self.assertIn("enterButton?.accessibilityLabel = title", controller)
+
+        self.assertIn("switch textDocumentProxy.autocapitalizationType ?? .sentences", controller)
 
     def test_project_and_ci_run_native_onboarding_ui_tests(self):
         project = (IOS_ROOT / "project.yml").read_text()


### PR DESCRIPTION
## Summary
- treat a missing return-key trait as the system default
- treat a missing autocapitalization trait as sentence capitalization
- make both optional UIKit trait switches exhaustive on current SDKs

## Verification
- iOS project and policy tests: 21/21
- official UIKit SDK Swift probe with warnings promoted to errors