### PR TITLE
feat(ios): add system input click feedback

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 @MainActor
-final class KeyboardViewController: UIInputViewController {
+final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedback {
   private enum LetterCaseState {
     case lowercase, shifted, capsLock
   }
@@ -27,6 +27,8 @@ final class KeyboardViewController: UIInputViewController {
   private var isAutomaticShift = false
   private var lastShiftTapTime: TimeInterval?
   private let schemePreferenceKey = "inputSchemeUsesShuangpin"
+
+  var enableInputClicksWhenVisible: Bool { true }
 
   private let letterRows = [
     Array("qwertyuiop"),
@@ -259,6 +261,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func handleCharacter(_ character: String) {
+    playInputClick()
     if isChineseMode {
       render(session.handleCharacter(character))
     } else {
@@ -273,6 +276,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func handleSymbol(_ symbol: String) {
+    playInputClick()
     if !isChineseMode {
       textDocumentProxy.insertText(symbol)
       return
@@ -306,6 +310,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func toggleInputMode() {
+    playInputClick()
     let snapshot = isChineseMode ? session.commitCandidate() : session.cancel()
     isChineseMode.toggle()
     letterCaseState = .lowercase
@@ -319,6 +324,7 @@ final class KeyboardViewController: UIInputViewController {
   private func toggleLetterCase() {
     guard !isChineseMode else { return }
 
+    playInputClick()
     isAutomaticShift = false
     let now = ProcessInfo.processInfo.systemUptime
     if letterCaseState == .shifted,
@@ -452,6 +458,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func toggleScheme() {
+    playInputClick()
     usesShuangpin.toggle()
     let snapshot = session.switch(toShuangpin: usesShuangpin)
     UserDefaults.standard.set(usesShuangpin, forKey: schemePreferenceKey)
@@ -475,6 +482,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func toggleLayout() {
+    playInputClick()
     showsSymbols.toggle()
     letterRowViews.forEach { $0.isHidden = showsSymbols }
     symbolRowViews.forEach { $0.isHidden = !showsSymbols }
@@ -487,6 +495,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func handleBackspace() {
+    playInputClick()
     let snapshot = session.handleBackspace()
     if !snapshot.isHandled {
       textDocumentProxy.deleteBackward()
@@ -529,6 +538,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func handleSpace() {
+    playInputClick()
     let snapshot = session.commitCandidate()
     if !snapshot.isHandled {
       textDocumentProxy.insertText(" ")
@@ -537,6 +547,7 @@ final class KeyboardViewController: UIInputViewController {
   }
 
   private func handleReturn() {
+    playInputClick()
     render(session.commitCandidate())
     textDocumentProxy.insertText("\n")
   }
@@ -585,6 +596,7 @@ final class KeyboardViewController: UIInputViewController {
       configuration: configuration,
       primaryAction: UIAction { [weak self] _ in
         guard let self else { return }
+        self.playInputClick()
         self.render(self.session.selectCandidate(at: UInt(number - 1)))
       })
     button.accessibilityLabel = "候选词 \(number)：\(candidate)"
@@ -631,5 +643,9 @@ final class KeyboardViewController: UIInputViewController {
     let button = UIButton(configuration: configuration, primaryAction: UIAction { _ in action() })
     button.accessibilityLabel = accessibilityLabel
     return button
+  }
+
+  private func playInputClick() {
+    UIDevice.current.playInputClick()
   }
 }

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -34,6 +34,15 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("timer.fireDate = Date(timeIntervalSinceNow: 0.4)", controller)
         self.assertIn("override func viewWillDisappear", controller)
 
+    def test_keyboard_uses_system_input_click_feedback(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("UIInputViewAudioFeedback", controller)
+        self.assertIn("var enableInputClicksWhenVisible: Bool { true }", controller)
+        self.assertIn("UIDevice.current.playInputClick()", controller)
+        self.assertIn("private func playInputClick()", controller)
+        self.assertGreaterEqual(controller.count("playInputClick()"), 9)
+
     def test_project_defines_distinct_host_and_keyboard_identifiers(self):
         project = (IOS_ROOT / "project.yml").read_text()
 


### PR DESCRIPTION
## Summary
- opt the custom keyboard into UIKit’s system input-click feedback
- play feedback for text, symbols, candidates, modes, space, return, and each repeated delete
- rely on the user’s system sound preference; no bundled audio or Open Access is used

## Verification
- iOS project and behavior-contract tests: 22/22
- official UIKit SDK type-check with warnings promoted to errors