### PR TITLE
fix(ios): respect the system keyboard height

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -81,7 +81,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       root.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -5),
       root.topAnchor.constraint(equalTo: view.topAnchor, constant: 7),
       root.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -7),
-      view.heightAnchor.constraint(greaterThanOrEqualToConstant: 270),
     ])
 
     root.addArrangedSubview(makeCandidateStrip())

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -217,6 +217,12 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertNotIn("space.widthAnchor.constraint(greaterThanOrEqualToConstant: 110)", controller)
         self.assertNotIn("enter.widthAnchor.constraint(equalToConstant: 72)", controller)
 
+    def test_keyboard_respects_the_height_assigned_by_the_system(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("root.bottomAnchor.constraint(equalTo: view.bottomAnchor", controller)
+        self.assertNotIn("view.heightAnchor.constraint", controller)
+
     def test_keyboard_exposes_a_persisted_full_and_double_pinyin_switch(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
         bridge_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.h").read_text()


### PR DESCRIPTION
## Summary
- remove the hard 270-point minimum from the keyboard extension root view
- keep the native stack pinned to the bounds assigned by iOS
- avoid constraint conflicts and host-content loss on landscape phones and compact iPad layouts

## Verification
- iOS project and behavior-contract tests: 23/23
- change only removes the conflicting height constraint from the previously verified Swift 6 keyboard build