### PR TITLE
feat(ios): share input scheme through app group

### DIFF
--- a/platforms/ios/App/Resources/MetasequoiaImeIOS.entitlements
+++ b/platforms/ios/App/Resources/MetasequoiaImeIOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.application-groups</key>
+  <array>
+    <string>group.com.houko.metasequoiaime.ios</string>
+  </array>
+</dict>
+</plist>

--- a/platforms/ios/KeyboardExtension/Resources/MetasequoiaKeyboard.entitlements
+++ b/platforms/ios/KeyboardExtension/Resources/MetasequoiaKeyboard.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.application-groups</key>
+  <array>
+    <string>group.com.houko.metasequoiaime.ios</string>
+  </array>
+</dict>
+</plist>

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -26,7 +26,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private var letterCaseState = LetterCaseState.lowercase
   private var isAutomaticShift = false
   private var lastShiftTapTime: TimeInterval?
-  private let schemePreferenceKey = "inputSchemeUsesShuangpin"
 
   var enableInputClicksWhenVisible: Bool { true }
 
@@ -43,7 +42,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    usesShuangpin = UserDefaults.standard.bool(forKey: schemePreferenceKey)
+    usesShuangpin = InputSchemePreference.usesShuangpin
     if usesShuangpin {
       _ = session.switch(toShuangpin: true)
     }
@@ -460,7 +459,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     playInputClick()
     usesShuangpin.toggle()
     let snapshot = session.switch(toShuangpin: usesShuangpin)
-    UserDefaults.standard.set(usesShuangpin, forKey: schemePreferenceKey)
+    InputSchemePreference.usesShuangpin = usesShuangpin
     updateSchemeButton()
     render(snapshot)
   }

--- a/platforms/ios/SharedUI/InputSchemePreference.swift
+++ b/platforms/ios/SharedUI/InputSchemePreference.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum InputSchemePreference {
+  static let appGroupIdentifier = "group.com.houko.metasequoiaime.ios"
+  private static let key = "inputSchemeUsesShuangpin"
+
+  static var usesShuangpin: Bool {
+    get {
+      guard let sharedDefaults = UserDefaults(suiteName: appGroupIdentifier) else {
+        return UserDefaults.standard.bool(forKey: key)
+      }
+      if sharedDefaults.object(forKey: key) == nil,
+        let legacyValue = UserDefaults.standard.object(forKey: key) as? Bool
+      {
+        sharedDefaults.set(legacyValue, forKey: key)
+      }
+      return sharedDefaults.bool(forKey: key)
+    }
+    set {
+      let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+      defaults.set(newValue, forKey: key)
+    }
+  }
+}

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -78,6 +78,7 @@ targets:
       base:
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: $(PROJECT_DIR)/../../platforms/ios/App/Resources/Info.plist
+        CODE_SIGN_ENTITLEMENTS: $(PROJECT_DIR)/../../platforms/ios/App/Resources/MetasequoiaImeIOS.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios
         PRODUCT_NAME: MetasequoiaIME
     dependencies:
@@ -97,6 +98,7 @@ targets:
       base:
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Resources/Info.plist
+        CODE_SIGN_ENTITLEMENTS: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Resources/MetasequoiaKeyboard.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios.keyboard
         PRODUCT_NAME: MetasequoiaKeyboard
         SWIFT_OBJC_BRIDGING_HEADER: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Sources/MetasequoiaKeyboard-Bridging-Header.h

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -9,6 +9,28 @@ IOS_ROOT = Path(__file__).resolve().parents[1]
 
 
 class ProjectConfigurationTests(unittest.TestCase):
+    def test_host_and_keyboard_share_the_input_scheme_through_an_app_group(self):
+        project = (IOS_ROOT / "project.yml").read_text()
+        shared_preference = (IOS_ROOT / "SharedUI/InputSchemePreference.swift").read_text()
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+        group_identifier = "group.com.houko.metasequoiaime.ios"
+
+        for relative_path in (
+            "App/Resources/MetasequoiaImeIOS.entitlements",
+            "KeyboardExtension/Resources/MetasequoiaKeyboard.entitlements",
+        ):
+            with (IOS_ROOT / relative_path).open("rb") as entitlement_file:
+                entitlements = plistlib.load(entitlement_file)
+            self.assertEqual(entitlements["com.apple.security.application-groups"], [group_identifier])
+            self.assertIn(relative_path, project)
+
+        self.assertIn(f'static let appGroupIdentifier = "{group_identifier}"', shared_preference)
+        self.assertIn('private static let key = "inputSchemeUsesShuangpin"', shared_preference)
+        self.assertIn("UserDefaults(suiteName: appGroupIdentifier)", shared_preference)
+        self.assertIn("UserDefaults.standard.object(forKey: key)", shared_preference)
+        self.assertIn("InputSchemePreference.usesShuangpin", controller)
+        self.assertNotIn("schemePreferenceKey", controller)
+
     def test_english_capitalization_policy(self):
         policy = IOS_ROOT / "KeyboardExtension/Sources/EnglishCapitalizationPolicy.swift"
         tests = IOS_ROOT / "tests/EnglishCapitalizationPolicyTests.swift"
@@ -230,8 +252,8 @@ class ProjectConfigurationTests(unittest.TestCase):
 
         self.assertIn("schemeButton", controller)
         self.assertIn("toggleScheme", controller)
-        self.assertIn("UserDefaults.standard.bool(forKey: schemePreferenceKey)", controller)
-        self.assertIn("UserDefaults.standard.set(usesShuangpin, forKey: schemePreferenceKey)", controller)
+        self.assertIn("usesShuangpin = InputSchemePreference.usesShuangpin", controller)
+        self.assertIn("InputSchemePreference.usesShuangpin = usesShuangpin", controller)
         self.assertIn("session.switch(toShuangpin: usesShuangpin)", controller)
         self.assertIn('usesShuangpin ? "小鹤" : "全拼"', controller)
         self.assertIn('schemeButton.accessibilityIdentifier = "schemeButton"', controller)


### PR DESCRIPTION
Summary:
- add matching App Group entitlements to the iOS host app and keyboard extension
- move the input-scheme preference into the shared App Group domain
- migrate the extension local preference on first read

Verification:
- ProjectConfigurationTests.py: 24 passed
- universal iOS Simulator build: arm64 and x86_64
- generated build settings use both entitlement files

Deployment note: register group.com.houko.metasequoiaime.ios for both App IDs before device or App Store signing.