### PR TITLE
feat(ios): add host input scheme settings

### DIFF
--- a/docs/apple-platform-architecture.md
+++ b/docs/apple-platform-architecture.md
@@ -72,7 +72,7 @@ MSIME-Apple/
 
 The iOS frontend is a custom keyboard extension. It inserts and removes text only through `textDocumentProxy`, and it must expose the system next-keyboard action when required. Secure text fields, phone-pad fields, and applications that reject third-party keyboards can replace or disable the extension; those are operating-system boundaries rather than engine failures.
 
-The first usable keyboard will run entirely on-device without Open Access. App Group configuration and `RequestsOpenAccess` will be introduced only in a later, explicit feature when shared settings or dictionaries require them. Network access is not part of the base architecture.
+The keyboard runs entirely on-device without Open Access. The host app and keyboard extension use a narrowly scoped App Group for shared settings, beginning with the input-scheme choice. `RequestsOpenAccess` remains disabled, and network access is not part of the base architecture.
 
 Extension memory and startup time are stricter than on macOS. The bridge therefore creates engine state lazily, avoids background services, and tears down platform objects with the extension lifecycle. Dictionary packaging and memory measurements must be verified on a real device before declaring the iOS frontend production-ready.
 

--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct OnboardingView: View {
   @State private var sampleText = ""
+  @State private var usesShuangpin = InputSchemePreference.usesShuangpin
 
   private let steps = [
     ("1", "打开键盘设置", "前往“设置 → 通用 → 键盘 → 键盘”。"),
@@ -37,6 +38,44 @@ struct OnboardingView: View {
         )
         .accessibilityIdentifier("openKeyboardSettingsButton")
         .accessibilityHint("打开水杉输入法的系统设置页面")
+
+        VStack(alignment: .leading, spacing: 16) {
+          HStack(spacing: 12) {
+            Image(systemName: "character.cursor.ibeam")
+              .font(.system(size: 17, weight: .semibold))
+              .foregroundStyle(MetasequoiaTheme.forest)
+              .frame(width: 38, height: 38)
+              .background(MetasequoiaTheme.mist, in: Circle())
+
+            VStack(alignment: .leading, spacing: 3) {
+              Text("输入方案")
+                .font(.headline)
+                .foregroundStyle(MetasequoiaTheme.ink)
+              Text("设置会同步到水杉键盘")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+          }
+
+          Picker("输入方案", selection: $usesShuangpin) {
+            Text("全拼").tag(false)
+            Text("小鹤双拼").tag(true)
+          }
+          .pickerStyle(.segmented)
+          .accessibilityIdentifier("inputSchemePicker")
+          .onChange(of: usesShuangpin) { newValue in
+            InputSchemePreference.usesShuangpin = newValue
+          }
+        }
+        .padding(18)
+        .background(.background, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay {
+          RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .stroke(MetasequoiaTheme.needle.opacity(0.12), lineWidth: 1)
+        }
+        .onAppear {
+          usesShuangpin = InputSchemePreference.usesShuangpin
+        }
 
         VStack(alignment: .leading, spacing: 10) {
           Text("启用后试一试")

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -20,6 +20,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private weak var enterButton: UIButton?
   private var backspaceRepeatTimer: Timer?
   private var didRepeatBackspace = false
+  private var hasComposition = false
   private var isChineseMode = true
   private var usesShuangpin = false
   private var showsSymbols = false
@@ -50,6 +51,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     installKeyboard()
     updateReturnKey()
     updateCandidateStrip(preedit: "", candidates: [])
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    synchronizeInputSchemePreference()
   }
 
   override func textWillChange(_ textInput: UITextInput?) {
@@ -261,6 +267,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private func handleCharacter(_ character: String) {
     playInputClick()
     if isChineseMode {
+      synchronizeInputSchemePreference()
       render(session.handleCharacter(character))
     } else {
       let output = letterCaseState == .lowercase ? character : character.uppercased()
@@ -464,6 +471,17 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     render(snapshot)
   }
 
+  private func synchronizeInputSchemePreference() {
+    guard !hasComposition else { return }
+    let sharedValue = InputSchemePreference.usesShuangpin
+    guard sharedValue != usesShuangpin else { return }
+
+    usesShuangpin = sharedValue
+    let snapshot = session.switch(toShuangpin: usesShuangpin)
+    updateSchemeButton()
+    render(snapshot)
+  }
+
   private func updateSchemeButton() {
     var configuration = UIButton.Configuration.plain()
     configuration.title = usesShuangpin ? "小鹤" : "全拼"
@@ -561,6 +579,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     if let commitText = snapshot.commitText {
       textDocumentProxy.insertText(commitText)
     }
+    hasComposition = !snapshot.preedit.isEmpty
     updateCandidateStrip(preedit: snapshot.preedit, candidates: snapshot.candidates)
   }
 

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the native iOS host app, custom keyboard extension, iOS-only shared UI, and their tests. `project.yml` is the reproducible XcodeGen source of truth; generated `.xcodeproj` files are build artifacts and are not committed.
 
-The iOS frontend consumes `MetasequoiaImeEngine` through the Objective-C++ adapter in `shared/apple-bridge`. It must not import AppKit, InputMethodKit, Sparkle, macOS registration helpers, or macOS installer code. The keyboard operates locally without Open Access; App Group and network-related capabilities require a later, explicit design and review.
+The iOS frontend consumes `MetasequoiaImeEngine` through the Objective-C++ adapter in `shared/apple-bridge`. It must not import AppKit, InputMethodKit, Sparkle, macOS registration helpers, or macOS installer code. The keyboard operates locally without Open Access or network access. The host app and keyboard extension share the selected full-pinyin or Xiaohe double-pinyin scheme through the `group.com.houko.metasequoiaime.ios` App Group.
 
 See [Apple platform architecture](../../docs/apple-platform-architecture.md) for ownership boundaries and the progressive pull-request sequence.
 
@@ -22,5 +22,7 @@ The UI-test runner prefers an already booted iPhone Simulator, otherwise selects
 `BREW_PREFIX` defaults to `/opt/homebrew` in `project.yml`; override that build setting when dependencies are installed under another prefix.
 
 The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, numbered candidate selection, and Chinese punctuation through the shared engine. Its candidate bar also provides a local `中` / `英` switch; entering English mode first commits the leading Engine candidate, then passes letters and symbols directly to the host app. The native `123` / `ABC` layer owns only key layout; it does not duplicate the engine's composition or punctuation policy.
+
+The host app exposes the same input-scheme setting as a native segmented control. A changed setting is picked up when the keyboard appears or before the next composition begins; an active composition keeps its original scheme until it is committed or cancelled.
 
 `prepare_dictionary.py` first builds the canonical database, then retains all single-syllable entries and common multi-syllable entries with weight 2000 or greater. The generated database and its SHA-256 sidecar are ignored build artifacts. At runtime the extension atomically installs a changed bundled database into its private writable Application Support directory, keeping dictionary access local without requesting Open Access.

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -13,6 +13,11 @@ final class OnboardingUITests: XCTestCase {
     XCTAssertTrue(app.staticTexts["水杉输入法"].waitForExistence(timeout: 10))
     XCTAssertTrue(app.buttons["openKeyboardSettingsButton"].exists)
 
+    let schemePicker = app.segmentedControls["inputSchemePicker"]
+    XCTAssertTrue(schemePicker.exists)
+    XCTAssertTrue(schemePicker.buttons["全拼"].exists)
+    XCTAssertTrue(schemePicker.buttons["小鹤双拼"].exists)
+
     let tryoutField = app.textFields["keyboardTryoutField"]
     XCTAssertTrue(tryoutField.exists)
     tryoutField.tap()

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -97,6 +97,25 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn('TextField("在这里试试水杉键盘"', onboarding)
         self.assertIn('.accessibilityIdentifier("keyboardTryoutField")', onboarding)
 
+    def test_host_app_exposes_the_shared_input_scheme_setting(self):
+        onboarding = (IOS_ROOT / "App/Sources/OnboardingView.swift").read_text()
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn(
+            "@State private var usesShuangpin = InputSchemePreference.usesShuangpin",
+            onboarding,
+        )
+        self.assertIn('Picker("输入方案", selection: $usesShuangpin)', onboarding)
+        self.assertIn('Text("全拼").tag(false)', onboarding)
+        self.assertIn('Text("小鹤双拼").tag(true)', onboarding)
+        self.assertIn('.accessibilityIdentifier("inputSchemePicker")', onboarding)
+        self.assertIn("InputSchemePreference.usesShuangpin = newValue", onboarding)
+        self.assertIn("private var hasComposition = false", controller)
+        self.assertIn("override func viewWillAppear", controller)
+        self.assertIn("synchronizeInputSchemePreference()", controller)
+        self.assertIn("guard !hasComposition else { return }", controller)
+        self.assertIn("hasComposition = !snapshot.preedit.isEmpty", controller)
+
     def test_ci_creates_the_generated_project_output_directory(self):
         workflow = (IOS_ROOT.parents[1] / ".github/workflows/ci.yml").read_text()
 


### PR DESCRIPTION
Summary:
- add a native full-pinyin and Xiaohe double-pinyin selector to the iOS host app
- synchronize reused keyboard-extension processes before a new composition without disrupting active input
- add configuration and native UI smoke coverage, and update architecture documentation

Verification:
- ProjectConfigurationTests.py: 25 passed
- universal iOS Simulator build: arm64 and x86_64
- UI smoke is committed; local execution was blocked before launch by a shared-host CoreSimulator service contention, so this PR does not claim a local UI-test pass