### PR TITLE
feat(ios): bundle privacy manifests

### DIFF
--- a/platforms/ios/SharedResources/PrivacyInfo.xcprivacy
+++ b/platforms/ios/SharedResources/PrivacyInfo.xcprivacy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+        <string>1C8F.1</string>
+      </array>
+    </dict>
+  </array>
+  <key>NSPrivacyCollectedDataTypes</key>
+  <array/>
+  <key>NSPrivacyTracking</key>
+  <false/>
+</dict>
+</plist>

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -74,6 +74,8 @@ targets:
     sources:
       - path: platforms/ios/App/Sources
       - path: platforms/ios/SharedUI
+      - path: platforms/ios/SharedResources/PrivacyInfo.xcprivacy
+        buildPhase: resources
     settings:
       base:
         GENERATE_INFOPLIST_FILE: NO
@@ -90,6 +92,8 @@ targets:
     sources:
       - path: platforms/ios/KeyboardExtension/Sources
       - path: platforms/ios/SharedUI
+      - path: platforms/ios/SharedResources/PrivacyInfo.xcprivacy
+        buildPhase: resources
       - path: platforms/ios/KeyboardExtension/Resources/msime.db
         buildPhase: resources
       - path: platforms/ios/KeyboardExtension/Resources/msime.db.sha256

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -9,6 +9,29 @@ IOS_ROOT = Path(__file__).resolve().parents[1]
 
 
 class ProjectConfigurationTests(unittest.TestCase):
+    def test_host_and_keyboard_bundle_the_required_reason_privacy_manifest(self):
+        project = (IOS_ROOT / "project.yml").read_text()
+        manifest_path = IOS_ROOT / "SharedResources/PrivacyInfo.xcprivacy"
+
+        with manifest_path.open("rb") as manifest_file:
+            manifest = plistlib.load(manifest_file)
+
+        self.assertFalse(manifest["NSPrivacyTracking"])
+        self.assertEqual(manifest["NSPrivacyCollectedDataTypes"], [])
+        self.assertEqual(
+            manifest["NSPrivacyAccessedAPITypes"],
+            [
+                {
+                    "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+                    "NSPrivacyAccessedAPITypeReasons": ["CA92.1", "1C8F.1"],
+                }
+            ],
+        )
+        self.assertEqual(
+            project.count("platforms/ios/SharedResources/PrivacyInfo.xcprivacy"),
+            2,
+        )
+
     def test_host_and_keyboard_share_the_input_scheme_through_an_app_group(self):
         project = (IOS_ROOT / "project.yml").read_text()
         shared_preference = (IOS_ROOT / "SharedUI/InputSchemePreference.swift").read_text()


### PR DESCRIPTION
Summary:
- add one audited iOS privacy manifest to both executable bundles
- declare only the private and App Group UserDefaults required reasons
- declare no tracking and no collected data

Verification:
- plist lint passed
- ProjectConfigurationTests.py: 26 passed
- universal iOS Simulator build passed
- built host app and keyboard extension each contain a byte-identical PrivacyInfo.xcprivacy