### PR TITLE
fix(ci): ignore non-pinyin dictionary indexes

### DIFF
--- a/platforms/ios/scripts/create_compact_dictionary.py
+++ b/platforms/ios/scripts/create_compact_dictionary.py
@@ -40,6 +40,7 @@ def compact_dictionary(source_path, output_path, minimum_weight):
         ).fetchall()
         if not tables:
             raise ValueError("The source dictionary has no pinyin tables")
+        included_tables = {table_name for table_name, _ in tables}
 
         source_uri = source_path.resolve().as_uri().replace("'", "''")
         output.execute(f"ATTACH DATABASE '{source_uri}?mode=ro' AS source")
@@ -63,11 +64,12 @@ def compact_dictionary(source_path, output_path, minimum_weight):
             ).fetchone()[0]
 
         indexes = source.execute(
-            "SELECT sql FROM sqlite_master "
+            "SELECT tbl_name, sql FROM sqlite_master "
             "WHERE type='index' AND sql IS NOT NULL ORDER BY name"
         ).fetchall()
-        for (schema,) in indexes:
-            output.execute(schema)
+        for table_name, schema in indexes:
+            if table_name in included_tables:
+                output.execute(schema)
         output.commit()
 
         integrity = output.execute("PRAGMA integrity_check").fetchone()[0]

--- a/platforms/ios/tests/DictionaryPackagingTests.py
+++ b/platforms/ios/tests/DictionaryPackagingTests.py
@@ -31,6 +31,10 @@ class DictionaryPackagingTests(unittest.TestCase):
                     CREATE INDEX idx_key_2_n ON tbl_2_n(key);
                     INSERT INTO tbl_2_n VALUES ('ni''hao', 'nh', '你好', 332885);
                     INSERT INTO tbl_2_n VALUES ('ni''hao', 'nh', '拟好', 1999);
+
+                    CREATE TABLE wubi86 (key TEXT, value TEXT, weight INTEGER DEFAULT 0);
+                    CREATE INDEX idx_wubi86_key_weight ON wubi86(key, weight DESC);
+                    INSERT INTO wubi86 VALUES ('aaaa', '工', 1000);
                     """
                 )
 
@@ -67,6 +71,11 @@ class DictionaryPackagingTests(unittest.TestCase):
                         "SELECT name FROM sqlite_master WHERE type='index' ORDER BY name"
                     ).fetchall(),
                     [("idx_jp_1_n",), ("idx_key_1_n",), ("idx_key_2_n",)],
+                )
+                self.assertIsNone(
+                    database.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='wubi86'"
+                    ).fetchone()
                 )
 
             self.assertEqual(digest.read_text().strip(), hashlib.sha256(output.read_bytes()).hexdigest())


### PR DESCRIPTION
## Summary
- copy indexes only for tables included in the compact iOS pinyin dictionary
- keep macOS Wubi tables and indexes out of the iOS-only compact artifact
- add a regression fixture containing the real `wubi86` table/index shape

## Root cause
The compact dictionary intentionally copies only `tbl_*` pinyin tables, but copied every source index. Once the macOS build added `idx_wubi86_key_weight`, SQLite tried to create that index without the `wubi86` table.

## Verification
- `python3 -m unittest platforms/ios/tests/DictionaryPackagingTests.py`
- `python3 -m unittest discover -s platforms/ios/tests -p '*Tests.py'` (27/27)
- `python3 platforms/ios/scripts/prepare_dictionary.py` with the full dictionary (212,882 compact rows)