### PR TITLE
chore(deps): use organization engine upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "vendor/MetasequoiaImeEngine"]
 	path = vendor/MetasequoiaImeEngine
-	url = https://github.com/houko/MetasequoiaImeEngine.git
-	branch = feat/macos-portability
+	url = https://github.com/metasequoiaime/MSIME-Engine.git
+	branch = master
 [submodule "vendor/MetasequoiaImeDict"]
 	path = vendor/MetasequoiaImeDict
 	url = https://github.com/metasequoiaime/MSIME-Dict.git

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -5,7 +5,7 @@ This application embeds MetasequoiaImeEngine, which is distributed under
 the GNU General Public License version 3. The complete license is provided
 in GPL-3.0.txt. Source code is available from:
 https://github.com/metasequoiaime/MSIME-Apple
-https://github.com/houko/MetasequoiaImeEngine
+https://github.com/metasequoiaime/MSIME-Engine
 
 The application also incorporates the following components:
 

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -372,9 +372,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "path"), "vendor/MetasequoiaImeEngine")
         self.assertEqual(
             submodule_value("vendor/MetasequoiaImeEngine", "url"),
-            "https://github.com/houko/MetasequoiaImeEngine.git",
+            "https://github.com/metasequoiaime/MSIME-Engine.git",
         )
-        self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "branch"), "feat/macos-portability")
+        self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "branch"), "master")
         self.assertEqual(submodule_value("vendor/MetasequoiaImeDict", "path"), "vendor/MetasequoiaImeDict")
         self.assertEqual(
             submodule_value("vendor/MetasequoiaImeDict", "url"),


### PR DESCRIPTION
## Summary

- point the Engine submodule at the canonical `metasequoiaime/MSIME-Engine` repository
- track the upstream `master` branch instead of a fork-only portability branch
- update the bundled source notice and configuration test

## Verify

- `python3 -m unittest platforms.macos.tests.ReleaseConfigurationTests`
- `git diff --check`
- confirmed `metasequoiaime/MSIME-Engine` exposes the tracked `master` branch
