### PR TITLE
fix(mac): support non-default package build dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,10 @@ if(METASEQUOIA_IME_BUILD_INPUT_METHOD)
         target_link_libraries(MetasequoiaPreferencesWindowTests PRIVATE MetasequoiaIme::Engine MetasequoiaSparkle ${APPKIT_FRAMEWORK} ${INPUT_METHOD_KIT_FRAMEWORK})
         set_target_properties(MetasequoiaPreferencesWindowTests PROPERTIES BUILD_RPATH "${METASEQUOIA_SPARKLE_ROOT}")
         add_test(NAME preferences_window COMMAND MetasequoiaPreferencesWindowTests)
-        add_test(NAME release_package COMMAND ${Python3_EXECUTABLE} ${METASEQUOIA_MACOS_ROOT}/tests/ReleasePackageTests.py $<TARGET_BUNDLE_DIR:MetasequoiaIME>)
+        add_test(NAME release_package COMMAND ${CMAKE_COMMAND} -E env
+            "METASEQUOIA_DEVELOPMENT_BUNDLE=$<TARGET_BUNDLE_DIR:MetasequoiaIME>"
+            ${Python3_EXECUTABLE} ${METASEQUOIA_MACOS_ROOT}/tests/ReleasePackageTests.py
+            $<TARGET_BUNDLE_DIR:MetasequoiaIME>)
         set_tests_properties(release_package PROPERTIES TIMEOUT 240)
     endif()
 endif()

--- a/platforms/macos/scripts/install.sh
+++ b/platforms/macos/scripts/install.sh
@@ -12,7 +12,8 @@ if [[ "$home_directory" == / ]]; then
 fi
 
 project_root=${0:A:h:h:h:h}
-source_bundle="$project_root/build/MetasequoiaIME.app"
+source_bundle=${METASEQUOIA_DEVELOPMENT_BUNDLE:-"$project_root/build/MetasequoiaIME.app"}
+source_bundle=${source_bundle:A}
 destination_root="$home_directory/Library/Input Methods"
 destination_bundle="$destination_root/MetasequoiaIME.app"
 

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -202,6 +202,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("recommended option when 水杉 should be available immediately", readme)
         self.assertNotIn("installs the input method system-wide", readme)
         self.assertIn("InputMethodServerPreferencesWindowControllerClass", info_plist)
+        self.assertIn("METASEQUOIA_DEVELOPMENT_BUNDLE=$<TARGET_BUNDLE_DIR:MetasequoiaIME>", cmake)
         self.assertIn("@METASEQUOIA_IME_DICTIONARY_SHA256@", info_plist)
         self.assertIn("<key>SUPublicEDKey</key>", info_plist)
         self.assertIn("rSAufajnup+T+d+I4LTs4EAhe5M8bwHemWDKao3CB/E=", info_plist)


### PR DESCRIPTION
## Summary

- let the development installer consume the exact input-method bundle built by CMake
- keep the existing default build path for manual development installs
- lock the CTest configuration to the target bundle directory

## Verification

- configured and built from a deliberately non-default `build-alt` directory
- `GIT_DIR=/dev/null ctest --test-dir build-alt -R "^release_package$" --output-on-failure` (1/1)
- `GIT_DIR=/dev/null ctest --test-dir build-alt -E "^release_package$" --output-on-failure` (16/16)
- `GIT_DIR=/dev/null python3 -m unittest platforms/macos/tests/ReleaseConfigurationTests.py` (8/8)
- confirmed no default `build` path or symlink existed