### PR TITLE
feat(mac): add updates and feedback settings page

### DIFF
--- a/platforms/macos/src/PreferencesWindowController.mm
+++ b/platforms/macos/src/PreferencesWindowController.mm
@@ -348,9 +348,12 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     NSButton *_wubiAutoCommitButton;
     NSButton *_resetLearningButton;
     NSTextField *_statusLabel;
-    NSButton *_updateButton;
+    NSTextField *_versionLabel;
+    NSTextField *_automaticUpdateLabel;
+    NSButton *_updatePageButton;
     NSArray<NSView *> *_preferencePages;
     NSArray<NSButton *> *_navigationButtons;
+    MetasequoiaUpdateController *_updateController;
     BOOL _standaloneLaunch;
 }
 
@@ -549,6 +552,11 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
 
 - (instancetype)init
 {
+    return [self initWithUpdateController:[MetasequoiaUpdateController sharedController]];
+}
+
+- (instancetype)initWithUpdateController:(MetasequoiaUpdateController *)updateController
+{
     NSRect frame = NSMakeRect(0.0, 0.0, kWindowWidth, kWindowHeight);
     NSWindow *window = [[NSWindow alloc] initWithContentRect:frame
                                                    styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable)
@@ -567,6 +575,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
         return nil;
     }
     window.delegate = self;
+    _updateController = updateController;
 
     NSView *contentView = [[NSView alloc] initWithFrame:frame];
     window.contentView = contentView;
@@ -596,8 +605,9 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     brandDescription.alignment = NSTextAlignmentCenter;
     brandDescription.translatesAutoresizingMaskIntoConstraints = NO;
 
-    NSArray<NSString *> *navigationTitles = @[ @"键盘输入", @"外观", @"词库与数据" ];
-    NSArray<NSString *> *navigationSymbols = @[ @"keyboard", @"paintpalette", @"books.vertical" ];
+    NSArray<NSString *> *navigationTitles = @[ @"键盘输入", @"外观", @"词库与数据", @"更新与反馈" ];
+    NSArray<NSString *> *navigationSymbols =
+        @[ @"keyboard", @"paintpalette", @"books.vertical", @"exclamationmark.bubble" ];
     NSMutableArray<NSButton *> *navigationButtons = [NSMutableArray arrayWithCapacity:navigationTitles.count];
     for (NSInteger index = 0; index < static_cast<NSInteger>(navigationTitles.count); ++index)
     {
@@ -617,8 +627,13 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
         button.bordered = NO;
         button.contentTintColor = [NSColor whiteColor];
         button.imagePosition = NSImageLeading;
-        button.image = [NSImage imageWithSystemSymbolName:navigationSymbols[index]
-                                 accessibilityDescription:navigationTitles[index]];
+        NSImage *navigationImage = [NSImage imageWithSystemSymbolName:navigationSymbols[index]
+                                             accessibilityDescription:navigationTitles[index]];
+        navigationImage = [navigationImage imageWithSymbolConfiguration:
+                                                [NSImageSymbolConfiguration
+                                                    configurationWithHierarchicalColor:[NSColor whiteColor]]];
+        [navigationImage setTemplate:NO];
+        button.image = navigationImage;
         button.accessibilityLabel = navigationTitles[index];
         button.wantsLayer = YES;
         button.layer.cornerRadius = 8.0;
@@ -800,18 +815,71 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                            SectionLabel(@"数据与隐私"), resetCard ]);
     dataPage.accessibilityLabel = @"词库与数据设置页";
 
-    _preferencePages = @[ generalPage, appearancePage, dataPage, wubiPage ];
+    _versionLabel = [NSTextField labelWithString:@"开发构建"];
+    _versionLabel.textColor = [NSColor secondaryLabelColor];
+    _versionLabel.alignment = NSTextAlignmentRight;
+    _versionLabel.accessibilityLabel = @"当前版本";
+
+    _automaticUpdateLabel = [NSTextField labelWithString:@"检查自动更新状态…"];
+    _automaticUpdateLabel.textColor = [NSColor secondaryLabelColor];
+    _automaticUpdateLabel.alignment = NSTextAlignmentRight;
+    _automaticUpdateLabel.accessibilityLabel = @"自动更新状态";
+
+    _updatePageButton = [NSButton buttonWithTitle:@"检查更新…"
+                                           target:self
+                                           action:@selector(checkForUpdates:)];
+    _updatePageButton.bezelStyle = NSBezelStyleRounded;
+    _updatePageButton.accessibilityLabel = @"立即检查更新";
+
+    NSButton *feedbackButton = [NSButton buttonWithTitle:@"提交反馈…"
+                                                    target:self
+                                                    action:@selector(openFeedback:)];
+    feedbackButton.bezelStyle = NSBezelStyleInline;
+    feedbackButton.accessibilityLabel = @"提交反馈";
+    feedbackButton.contentTintColor = [NSColor linkColor];
+    feedbackButton.attributedTitle =
+        [[NSAttributedString alloc] initWithString:feedbackButton.title
+                                        attributes:@{
+                                            NSFontAttributeName :
+                                                [NSFont systemFontOfSize:13.0 weight:NSFontWeightMedium],
+                                            NSForegroundColorAttributeName : [NSColor linkColor],
+                                        }];
+
+    NSButton *productWebsiteButton = [NSButton buttonWithTitle:@"访问 msime.app"
+                                                        target:self
+                                                        action:@selector(openWebsite:)];
+    productWebsiteButton.bezelStyle = NSBezelStyleInline;
+    productWebsiteButton.accessibilityLabel = @"访问水杉官网";
+    productWebsiteButton.contentTintColor = [NSColor linkColor];
+    productWebsiteButton.attributedTitle =
+        [[NSAttributedString alloc] initWithString:productWebsiteButton.title
+                                        attributes:@{
+                                            NSFontAttributeName :
+                                                [NSFont systemFontOfSize:13.0 weight:NSFontWeightMedium],
+                                            NSForegroundColorAttributeName : [NSColor linkColor],
+                                        }];
+
+    NSBox *updateCard = CardWithViews(@[
+        PreferenceRow(@"当前版本", _versionLabel),
+        PreferenceRow(@"自动更新", _automaticUpdateLabel),
+        PreferenceRow(@"立即检查", _updatePageButton),
+    ], 4.0);
+    updateCard.accessibilityLabel = @"软件更新卡片";
+    NSBox *feedbackCard = CardWithViews(@[
+        PreferenceRow(@"问题反馈与功能建议", feedbackButton),
+        PreferenceRow(@"产品主页与使用帮助", productWebsiteButton),
+    ], 4.0);
+    feedbackCard.accessibilityLabel = @"反馈与帮助卡片";
+    NSView *updatesPage =
+        PreferencesPage(@"更新与反馈", @"保持水杉输入法为最新版本，并告诉我们哪里还可以做得更好。",
+                        @[ SectionLabel(@"软件更新"), updateCard, SectionLabel(@"反馈与帮助"), feedbackCard ]);
+    updatesPage.accessibilityLabel = @"更新与反馈设置页";
+
+    _preferencePages = @[ generalPage, appearancePage, dataPage, updatesPage, wubiPage ];
 
     NSButton *restoreButton = [NSButton buttonWithTitle:@"恢复默认设置" target:self action:@selector(restoreDefaults:)];
     restoreButton.bezelStyle = NSBezelStyleRounded;
     restoreButton.translatesAutoresizingMaskIntoConstraints = NO;
-
-    _updateButton = [NSButton buttonWithTitle:@"检查更新…"
-                                        target:self
-                                        action:@selector(checkForUpdates:)];
-    _updateButton.bezelStyle = NSBezelStyleInline;
-    _updateButton.accessibilityLabel = @"软件更新";
-    _updateButton.translatesAutoresizingMaskIntoConstraints = NO;
 
     NSButton *closeButton = [NSButton buttonWithTitle:@"关闭" target:self action:@selector(close:)];
     closeButton.bezelStyle = NSBezelStyleRounded;
@@ -838,7 +906,6 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
         ]];
     }
     [settingsPanel addSubview:restoreButton];
-    [settingsPanel addSubview:_updateButton];
     [settingsPanel addSubview:closeButton];
 
     [NSLayoutConstraint activateConstraints:@[
@@ -874,32 +941,32 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
         [pageContainer.bottomAnchor constraintEqualToAnchor:restoreButton.topAnchor constant:-16.0],
         [restoreButton.leadingAnchor constraintEqualToAnchor:settingsPanel.leadingAnchor constant:30.0],
         [restoreButton.bottomAnchor constraintEqualToAnchor:settingsPanel.bottomAnchor constant:-20.0],
-        [_updateButton.centerXAnchor constraintEqualToAnchor:settingsPanel.centerXAnchor],
-        [_updateButton.centerYAnchor constraintEqualToAnchor:restoreButton.centerYAnchor],
         [closeButton.trailingAnchor constraintEqualToAnchor:settingsPanel.trailingAnchor constant:-30.0],
         [closeButton.centerYAnchor constraintEqualToAnchor:restoreButton.centerYAnchor],
         [closeButton.widthAnchor constraintGreaterThanOrEqualToConstant:80.0],
     ]];
     [self selectPreferencesPage:_navigationButtons.firstObject];
-    [self refreshUpdateButton];
+    [self refreshUpdateControls];
     return self;
 }
 
-- (void)refreshUpdateButton
+- (void)refreshUpdateControls
 {
     NSString *version = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    _updateButton.title = version.length == 0 ? @"检查更新…" : [NSString stringWithFormat:@"检查更新（v%@）…", version];
-    _updateButton.toolTip = @"通过 msime.app 检查水杉输入法的最新正式版本";
-    _updateButton.accessibilityHelp = version.length == 0
-                                          ? @"通过 msime.app 检查最新正式版本"
-                                          : [NSString stringWithFormat:@"当前版本 v%@，通过 msime.app 检查最新正式版本", version];
-    _updateButton.contentTintColor = nil;
-    _updateButton.enabled = YES;
+    _versionLabel.stringValue = version.length == 0 ? @"开发构建" : [NSString stringWithFormat:@"v%@", version];
+    _automaticUpdateLabel.stringValue = _updateController.automaticallyChecksForUpdates
+                                            ? @"已开启自动检查"
+                                            : @"自动检查已关闭";
+    _updatePageButton.toolTip = @"通过 msime.app 检查水杉输入法的最新正式版本";
+    _updatePageButton.accessibilityHelp = version.length == 0
+                                              ? @"通过 msime.app 检查最新正式版本"
+                                              : [NSString stringWithFormat:@"当前版本 v%@，通过 msime.app 检查最新正式版本", version];
+    _updatePageButton.enabled = YES;
 }
 
 - (void)checkForUpdates:(id)sender
 {
-    [[MetasequoiaUpdateController sharedController] checkForUpdates:sender];
+    [_updateController checkForUpdates:sender];
 }
 
 - (void)selectPreferencesPage:(id)sender
@@ -932,7 +999,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
 {
     (void)sender;
     [self refreshControls];
-    [self showPreferencesPageAtIndex:3 sidebarIndex:0];
+    [self showPreferencesPageAtIndex:4 sidebarIndex:0];
 }
 
 - (void)backToKeyboardInput:(id)sender
@@ -948,6 +1015,16 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     if (website != nil)
     {
         [[NSWorkspace sharedWorkspace] openURL:website];
+    }
+}
+
+- (void)openFeedback:(id)sender
+{
+    (void)sender;
+    NSURL *feedback = [NSURL URLWithString:@"https://github.com/metasequoiaime/MSIME-Apple/issues/new"];
+    if (feedback != nil)
+    {
+        [[NSWorkspace sharedWorkspace] openURL:feedback];
     }
 }
 
@@ -998,7 +1075,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
 {
     [self refreshControls];
     [self refreshDictionaryStatus];
-    [self refreshUpdateButton];
+    [self refreshUpdateControls];
     if (_standaloneLaunch)
     {
         _resetLearningButton.enabled = NO;

--- a/platforms/macos/src/UpdateController.h
+++ b/platforms/macos/src/UpdateController.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MetasequoiaUpdateDriver <NSObject>
 @property(nonatomic, readonly) BOOL canCheckForUpdates;
+@property(nonatomic, readonly) BOOL automaticallyChecksForUpdates;
 - (void)checkForUpdates:(nullable id)sender;
 @end
 
@@ -16,6 +17,7 @@ typedef void (^MetasequoiaUpdateActivationHandler)(void);
 - (instancetype)initWithDriver:(id<MetasequoiaUpdateDriver>)driver
              activationHandler:(MetasequoiaUpdateActivationHandler)activationHandler;
 @property(nonatomic, readonly) BOOL canCheckForUpdates;
+@property(nonatomic, readonly) BOOL automaticallyChecksForUpdates;
 - (void)checkForUpdates:(nullable id)sender;
 @end
 

--- a/platforms/macos/src/UpdateController.mm
+++ b/platforms/macos/src/UpdateController.mm
@@ -25,6 +25,11 @@
     return self.updaterController.updater.canCheckForUpdates;
 }
 
+- (BOOL)automaticallyChecksForUpdates
+{
+    return self.updaterController.updater.automaticallyChecksForUpdates;
+}
+
 - (void)checkForUpdates:(id)sender
 {
     [self.updaterController checkForUpdates:sender];
@@ -70,6 +75,11 @@
 - (BOOL)canCheckForUpdates
 {
     return self.driver.canCheckForUpdates;
+}
+
+- (BOOL)automaticallyChecksForUpdates
+{
+    return self.driver.automaticallyChecksForUpdates;
 }
 
 - (void)checkForUpdates:(id)sender

--- a/platforms/macos/tests/PreferencesWindowTests.mm
+++ b/platforms/macos/tests/PreferencesWindowTests.mm
@@ -8,9 +8,24 @@
 #include <stdexcept>
 
 @interface MetasequoiaPreferencesWindowController (Testing)
+- (instancetype)initWithUpdateController:(MetasequoiaUpdateController *)updateController;
 - (void)refreshControls;
+- (void)refreshUpdateControls;
 - (void)selectPreferencesPage:(id)sender;
 - (void)openWebsite:(id)sender;
+- (void)openFeedback:(id)sender;
+@end
+
+@interface PreferencesFakeUpdateDriver : NSObject <MetasequoiaUpdateDriver>
+@property(nonatomic) BOOL canCheckForUpdates;
+@property(nonatomic) BOOL automaticallyChecksForUpdates;
+@end
+
+@implementation PreferencesFakeUpdateDriver
+- (void)checkForUpdates:(id)sender
+{
+    (void)sender;
+}
 @end
 
 namespace
@@ -97,6 +112,20 @@ NSButton *FindButtonWithTitle(NSView *view, NSString *title)
     }
     return nil;
 }
+
+NSInteger CountButtonsWithAction(NSView *view, SEL action)
+{
+    NSInteger count = 0;
+    if ([view isKindOfClass:[NSButton class]] && ((NSButton *)view).action == action)
+    {
+        ++count;
+    }
+    for (NSView *subview in view.subviews)
+    {
+        count += CountButtonsWithAction(subview, action);
+    }
+    return count;
+}
 } // namespace
 
 int main()
@@ -145,31 +174,43 @@ int main()
         require(![MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled],
                 "The disabled Wubi auto-commit preference was not stored.");
 
+        PreferencesFakeUpdateDriver *updateDriver = [[PreferencesFakeUpdateDriver alloc] init];
+        updateDriver.canCheckForUpdates = YES;
+        updateDriver.automaticallyChecksForUpdates = YES;
+        MetasequoiaUpdateController *updateController =
+            [[MetasequoiaUpdateController alloc] initWithDriver:updateDriver activationHandler:^{}];
         MetasequoiaPreferencesWindowController *controller =
-            [[MetasequoiaPreferencesWindowController alloc] init];
+            [[MetasequoiaPreferencesWindowController alloc] initWithUpdateController:updateController];
         [controller refreshControls];
         NSButton *generalNavigationButton = FindButtonWithTitle(controller.window.contentView, @"键盘输入");
         NSButton *appearanceNavigationButton = FindButtonWithTitle(controller.window.contentView, @"外观");
         NSButton *dataNavigationButton = FindButtonWithTitle(controller.window.contentView, @"词库与数据");
-        require(generalNavigationButton != nil && appearanceNavigationButton != nil && dataNavigationButton != nil,
+        NSButton *updatesNavigationButton = FindButtonWithTitle(controller.window.contentView, @"更新与反馈");
+        require(generalNavigationButton != nil && appearanceNavigationButton != nil && dataNavigationButton != nil &&
+                    updatesNavigationButton != nil,
                 "The settings window did not expose all sidebar destinations.");
         NSColor *generalTitleColor = [generalNavigationButton.attributedTitle attribute:NSForegroundColorAttributeName
                                                                                 atIndex:0
                                                                          effectiveRange:nil];
         require([generalTitleColor isEqual:[NSColor whiteColor]],
                 "The settings sidebar did not render navigation titles in white.");
+        require([generalNavigationButton.contentTintColor isEqual:[NSColor whiteColor]] &&
+                    ![generalNavigationButton.image isTemplate],
+                "The settings sidebar did not render navigation symbols in white.");
         require(generalNavigationButton.state == NSControlStateValueOn &&
                     appearanceNavigationButton.state == NSControlStateValueOff &&
                     dataNavigationButton.state == NSControlStateValueOff &&
+                    updatesNavigationButton.state == NSControlStateValueOff &&
                     [generalNavigationButton.accessibilityValue integerValue] == 1 &&
                     [appearanceNavigationButton.accessibilityValue integerValue] == 0,
                 "The settings sidebar did not mark the initial page as selected.");
         NSView *generalPage = FindViewWithAccessibilityLabel(controller.window.contentView, @"键盘输入设置页");
         NSView *appearancePage = FindViewWithAccessibilityLabel(controller.window.contentView, @"外观设置页");
         NSView *dataPage = FindViewWithAccessibilityLabel(controller.window.contentView, @"词库与数据设置页");
-        require(generalPage != nil && appearancePage != nil && dataPage != nil,
+        NSView *updatesPage = FindViewWithAccessibilityLabel(controller.window.contentView, @"更新与反馈设置页");
+        require(generalPage != nil && appearancePage != nil && dataPage != nil && updatesPage != nil,
                 "The settings window did not create all functional pages.");
-        require(!generalPage.hidden && appearancePage.hidden && dataPage.hidden,
+        require(!generalPage.hidden && appearancePage.hidden && dataPage.hidden && updatesPage.hidden,
                 "The settings window did not open on the keyboard-input page.");
         [appearanceNavigationButton performClick:nil];
         require(generalPage.hidden && !appearancePage.hidden && dataPage.hidden &&
@@ -180,6 +221,10 @@ int main()
         require(generalPage.hidden && appearancePage.hidden && !dataPage.hidden &&
                     dataNavigationButton.state == NSControlStateValueOn,
                 "The data sidebar item did not reveal and select the data page.");
+        [updatesNavigationButton performClick:nil];
+        require(generalPage.hidden && appearancePage.hidden && dataPage.hidden && !updatesPage.hidden &&
+                    updatesNavigationButton.state == NSControlStateValueOn,
+                "The updates sidebar item did not reveal and select the updates page.");
         [generalNavigationButton performClick:nil];
 
         NSView *candidatePageShortcutView =
@@ -254,14 +299,22 @@ int main()
         NSView *candidatePageShortcutCard =
             FindViewWithAccessibilityLabel(controller.window.contentView, @"候选翻页快捷键卡片");
         NSView *learningCard = FindViewWithAccessibilityLabel(controller.window.contentView, @"候选与学习卡片");
+        NSView *softwareUpdateCard =
+            FindViewWithAccessibilityLabel(controller.window.contentView, @"软件更新卡片");
+        NSView *feedbackCard = FindViewWithAccessibilityLabel(controller.window.contentView, @"反馈与帮助卡片");
         require(schemeCard.frame.size.width == behaviorCard.frame.size.width &&
                     schemeCard.frame.size.width == candidatePageShortcutCard.frame.size.width &&
-                    schemeCard.frame.size.width == learningCard.frame.size.width,
+                    schemeCard.frame.size.width == learningCard.frame.size.width &&
+                    schemeCard.frame.size.width == softwareUpdateCard.frame.size.width &&
+                    schemeCard.frame.size.width == feedbackCard.frame.size.width,
                 "The settings cards did not consistently fill the content width.");
         NSRect candidatePageShortcutCardRect =
             [generalPage convertRect:candidatePageShortcutCard.bounds fromView:candidatePageShortcutCard];
         require(NSMaxY(candidatePageShortcutCardRect) <= NSMaxY(generalPage.bounds),
                 "The candidate page shortcut card overflowed the keyboard-input page.");
+        NSRect feedbackCardRect = [updatesPage convertRect:feedbackCard.bounds fromView:feedbackCard];
+        require(NSMaxY(feedbackCardRect) <= NSMaxY(updatesPage.bounds),
+                "The feedback card overflowed the updates page.");
 
         NSView *view = FindViewWithAccessibilityLabel(controller.window.contentView, @"候选排列");
         require([view isKindOfClass:[NSPopUpButton class]],
@@ -348,16 +401,39 @@ int main()
         require([resetLearningView isKindOfClass:[NSButton class]],
                 "The settings window did not expose the learned-data reset button.");
         NSButton *resetLearningButton = (NSButton *)resetLearningView;
-        NSView *updateView = FindViewWithAccessibilityLabel(controller.window.contentView, @"软件更新");
-        require([updateView isKindOfClass:[NSButton class]],
-                "The settings window did not expose the software-update control.");
-        require([((NSButton *)updateView).title containsString:@"检查更新"],
-                "The software-update control did not show the installed-version state.");
-        require([((NSButton *)updateView).accessibilityHelp containsString:@"msime.app"],
-                "The software-update control did not expose its current state to assistive technology.");
-        require(((NSButton *)updateView).action == @selector(checkForUpdates:) &&
-                    ((NSButton *)updateView).target == controller,
-                "The software-update control did not invoke the in-place Sparkle updater.");
+        NSView *versionView = FindViewWithAccessibilityLabel(controller.window.contentView, @"当前版本");
+        require([versionView isKindOfClass:[NSTextField class]] &&
+                    ((NSTextField *)versionView).stringValue.length > 0,
+                "The updates page did not expose the installed version.");
+        NSView *automaticUpdatesView =
+            FindViewWithAccessibilityLabel(controller.window.contentView, @"自动更新状态");
+        require([automaticUpdatesView isKindOfClass:[NSTextField class]] &&
+                    [((NSTextField *)automaticUpdatesView).stringValue isEqualToString:@"已开启自动检查"],
+                "The updates page did not show the enabled automatic-check state.");
+        updateDriver.automaticallyChecksForUpdates = NO;
+        [controller refreshUpdateControls];
+        require([((NSTextField *)automaticUpdatesView).stringValue isEqualToString:@"自动检查已关闭"],
+                "The updates page did not refresh the disabled automatic-check state.");
+        NSView *checkNowView = FindViewWithAccessibilityLabel(controller.window.contentView, @"立即检查更新");
+        require([checkNowView isKindOfClass:[NSButton class]] &&
+                    [((NSButton *)checkNowView).title containsString:@"检查更新"] &&
+                    [((NSButton *)checkNowView).accessibilityHelp containsString:@"msime.app"] &&
+                    ((NSButton *)checkNowView).action == @selector(checkForUpdates:) &&
+                    ((NSButton *)checkNowView).target == controller,
+                "The updates page did not expose an in-place update action.");
+        require(CountButtonsWithAction(controller.window.contentView, @selector(checkForUpdates:)) == 1,
+                "The settings window exposed duplicate software-update actions.");
+        NSView *feedbackView = FindViewWithAccessibilityLabel(controller.window.contentView, @"提交反馈");
+        require([feedbackView isKindOfClass:[NSButton class]] &&
+                    ((NSButton *)feedbackView).action == @selector(openFeedback:) &&
+                    ((NSButton *)feedbackView).target == controller,
+                "The updates page did not expose a feedback action.");
+        NSColor *feedbackTitleColor = [((NSButton *)feedbackView).attributedTitle
+            attribute:NSForegroundColorAttributeName
+              atIndex:0
+       effectiveRange:nil];
+        require([feedbackTitleColor isEqual:[NSColor linkColor]],
+                "The updates-page actions did not remain visually distinct from disabled controls.");
 
         __block bool resetStartedAfterCancel = false;
         id cancelObserver = [[NSNotificationCenter defaultCenter]
@@ -500,7 +576,7 @@ int main()
                         standaloneCloseObserved = true;
                     }];
         MetasequoiaPreferencesWindowController *standaloneController =
-            [[MetasequoiaPreferencesWindowController alloc] init];
+            [[MetasequoiaPreferencesWindowController alloc] initWithUpdateController:updateController];
         [standaloneController showAndActivateForStandaloneLaunch];
         NSView *standaloneResetView = FindViewWithAccessibilityLabel(standaloneController.window.contentView,
                                                                      @"清除学习数据");

--- a/platforms/macos/tests/UpdateControllerTests.mm
+++ b/platforms/macos/tests/UpdateControllerTests.mm
@@ -17,6 +17,7 @@ void require(bool condition, const char *message)
 
 @interface FakeUpdateDriver : NSObject <MetasequoiaUpdateDriver>
 @property(nonatomic) BOOL canCheckForUpdates;
+@property(nonatomic) BOOL automaticallyChecksForUpdates;
 @property(nonatomic) BOOL checked;
 @end
 
@@ -35,6 +36,7 @@ int main()
         __block BOOL activated = NO;
         FakeUpdateDriver *driver = [[FakeUpdateDriver alloc] init];
         driver.canCheckForUpdates = YES;
+        driver.automaticallyChecksForUpdates = YES;
         MetasequoiaUpdateController *controller =
             [[MetasequoiaUpdateController alloc] initWithDriver:driver
                                              activationHandler:^{
@@ -42,12 +44,17 @@ int main()
                                              }];
 
         require(controller.canCheckForUpdates, "The controller did not expose the Sparkle driver's readiness.");
+        require(controller.automaticallyChecksForUpdates,
+                "The controller did not expose Sparkle's automatic-check state.");
         [controller checkForUpdates:nil];
         require(activated, "A manual update check did not activate the accessory application UI.");
         require(driver.checked, "A manual update check was not forwarded to Sparkle.");
 
         driver.canCheckForUpdates = NO;
         require(!controller.canCheckForUpdates, "The controller cached an obsolete readiness state.");
+        driver.automaticallyChecksForUpdates = NO;
+        require(!controller.automaticallyChecksForUpdates,
+                "The controller cached an obsolete automatic-check state.");
     }
     return 0;
 }


### PR DESCRIPTION
## Summary

- add a dedicated 更新与反馈 destination to the macOS settings sidebar
- show the current version and the real Sparkle automatic-check state
- provide one in-place update action, feedback link, and msime.app help link
- keep sidebar symbols and secondary actions readable in the settings palette

## Verification

- cmake --build build --parallel
- GIT_DIR=/dev/null ctest --test-dir build -E ^release_package$ --output-on-failure (16/16)
- GIT_DIR=/dev/null ctest --test-dir build -R ^release_package$ --output-on-failure (1/1)
- GIT_DIR=/dev/null python3 -m unittest platforms/macos/tests/ReleaseConfigurationTests.py (8/8)
- independent UI review: no blocker or important findings