### PR TITLE
fix(release): document pkg auto-enable behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The dictionary build generates `vendor/MetasequoiaImeDict/out/msime.db` from the
 ./platforms/macos/scripts/install.sh
 ```
 
-Then enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit. The installer copies the signed bundle to `~/Library/Input Methods` and registers that exact bundle with macOS; it does not require administrator privileges.
+The installer copies the signed bundle to `~/Library/Input Methods`, registers it, and enables 水杉输入法 automatically for the current user; it does not require administrator privileges. If macOS blocks an ad-hoc build, approve it in Privacy & Security and enable it from System Settings > Keyboard > Text Input > Edit.
 
 ## Settings
 
@@ -93,7 +93,7 @@ When all of the following repository secrets are configured, release builds are 
 - `MACOS_DEVELOPER_ID_APPLICATION`
 - `MACOS_DEVELOPER_ID_INSTALLER`
 
-Local development builds remain ad-hoc signed. After installation, enable 水杉输入法 in System Settings > Keyboard > Text Input > Edit.
+Local development builds remain ad-hoc signed. After installation, the script registers and enables 水杉输入法 automatically; if macOS blocks the bundle, approve it in Privacy & Security and then enable it in System Settings > Keyboard > Text Input > Edit.
 
 The ZIP provides the same current-user destination through `Install.command` and is the recommended option when 水杉 should be available immediately without logging out or administrator privileges. The installer always verifies the bundle's code signature before replacing an existing installation, then registers and enables that exact bundle with macOS so it appears in the input menu without logging out. If registration or enablement fails, the verified app remains installed and the installer directs you to enable it manually in System Settings. Signed releases must also pass Gatekeeper; clearly marked unsigned builds instead require typing `I UNDERSTAND` and may need explicit approval in System Settings > Privacy & Security.
 

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -85,7 +85,7 @@ if [[ "$current_notes" != *"$mode_marker"* || "$current_notes" != *"$install_gui
             printf '%s\n\n' "$install_guidance_marker"
             printf '%s\n' '### Install on macOS'
             printf '%s\n' '- **Recommended: ZIP.** Verify its `.sha256`, extract it, then run `Install.command`. It installs for the current user, registers and enables the exact input source, and does not automatically log out or restart the Mac.'
-            printf '%s\n' '- **Compatibility option: PKG.** The native Installer copies the same app but cannot reliably enable the current GUI user’s input source. After installation, enable 水杉 in System Settings > Keyboard > Text Input. The package does not force a logout or restart; macOS may still require a later logout before a newly copied input method appears.'
+            printf '%s\n' '- **PKG option.** The native Installer copies the same app and attempts to register and enable 水杉 for the logged-in GUI user. If no GUI user is logged in or macOS blocks the app, enable it later in System Settings > Keyboard > Text Input > Edit. The package does not force a logout or restart; macOS may still require a later logout before a newly copied input method appears.'
         fi
     } > "$release_notes"
     gh release edit "$TAG_NAME" --repo "$GH_REPO" --notes-file "$release_notes"

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -484,7 +484,8 @@ fi
         self.assertIn("Recommended: ZIP", notes)
         self.assertIn("Install.command", notes)
         self.assertIn("does not automatically log out or restart", notes)
-        self.assertIn("Compatibility option: PKG", notes)
+        self.assertIn("PKG option", notes)
+        self.assertIn("attempts to register and enable 水杉", notes)
         self.assertIn("System Settings", notes)
         self.assertLess(calls.index("--notes-file"), calls.index("release upload"))
         self.assertIn("macos-universal-unsigned.pkg", calls)
@@ -533,7 +534,8 @@ fi
         self.assertIn("metasequoia-release-mode:signed", notes)
         self.assertNotIn("WARNING", notes)
         self.assertIn("Recommended: ZIP", notes)
-        self.assertIn("Compatibility option: PKG", notes)
+        self.assertIn("PKG option", notes)
+        self.assertIn("attempts to register and enable 水杉", notes)
         self.assertIn("macos-universal.pkg", calls)
 
     def test_corrupt_artifact_is_rejected_before_release_metadata_or_assets_change(self):

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -324,6 +324,8 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("The installer always verifies the bundle's code signature", readme)
         self.assertIn("appears in the input menu without logging out", readme)
         self.assertIn("Both paths install the current-user bundle", readme)
+        self.assertIn("enables 水杉输入法 automatically for the current user", readme)
+        self.assertIn("script registers and enables 水杉输入法 automatically", readme)
         self.assertIn("unsigned builds instead require typing `I UNDERSTAND`", readme)
         self.assertNotIn("verifies both the code signature and Gatekeeper acceptance", readme)
         self.assertIn("./MetasequoiaIME-vX.Y.Z/Uninstall.command", readme)


### PR DESCRIPTION
## Summary

- update generated release notes to describe the PKG postinstall auto-enable path
- document the headless and Privacy & Security fallback
- keep signed and unsigned publication tests aligned with actual behavior

## Verification

- ReleaseAutomationTests.py: 30/30