### PR TITLE
feat(mac): add full-width input toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The target module boundaries and migration sequence are documented in [Apple pla
 
 The iOS work does not port the Windows TSF or WebView2 host. It reuses `MetasequoiaImeEngine` and supplies an iOS-specific UI and text-document adapter.
 
-The current release supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, composition commit on focus changes, and Shift+Space switching between Chinese and direct English input.
+The current release supports full-pinyin composition, live candidates from the official Metasequoia dictionary, candidate selection through the native candidate panel or number keys 1–9, Space to commit the leading candidate, Return to commit raw input, Backspace, Escape, composition commit on focus changes, Shift+Space switching between Chinese and direct English input, and an optional full-width mode toggled with Option+Shift+H. When full-width mode is enabled, idle ASCII letters, digits, punctuation, and spaces are converted to their Unicode full-width forms without changing pinyin composition.
 
 ## Requirements
 
@@ -44,7 +44,7 @@ The installer copies the signed bundle to `~/Library/Input Methods`, registers i
 
 ## Settings
 
-In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼、小鹤双拼 or 86 五笔, configure unique four-code Wubi candidates to commit automatically, preview and switch the native candidate window between a horizontal row and vertical list, show 5, 7, or 9 candidates per page, choose a small, standard, or large candidate font, select `- / =`, `[ / ]`, or Page Up / Page Down for candidate paging, enable full-pinyin autocorrection and auxiliary codes, switch Chinese punctuation conversion, and control whether selected candidates update learned word frequencies. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
+In System Settings > Keyboard > Text Input > Edit, select 水杉输入法 and choose its settings action to open the native 水杉输入法设置 panel. The panel lets you choose 全拼、小鹤双拼 or 86 五笔, configure unique four-code Wubi candidates to commit automatically, preview and switch the native candidate window between a horizontal row and vertical list, show 5, 7, or 9 candidates per page, choose a small, standard, or large candidate font, select `- / =`, `[ / ]`, or Page Up / Page Down for candidate paging, enable full-pinyin autocorrection and auxiliary codes, switch Chinese punctuation conversion, enable Option+Shift+H full-width input, and control whether selected candidates update learned word frequencies. These choices are saved for the current user and apply before the next key event when no composition is active; an active composition keeps its original settings until it is committed or cancelled. Additional input and candidate options will be added incrementally.
 
 The release ZIP also includes `Open Settings.command` as a direct fallback. After installation, open it to launch the same native panel without selecting 水杉 first; closing the panel exits only this standalone settings process and leaves the input method available.
 

--- a/platforms/macos/src/FullWidthInput.h
+++ b/platforms/macos/src/FullWidthInput.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
+
+namespace metasequoia::mac
+{
+inline bool IsFullWidthInputToggle(unsigned short keyCode, NSEventModifierFlags modifiers)
+{
+    const NSEventModifierFlags competingModifiers =
+        modifiers & (NSEventModifierFlagCommand | NSEventModifierFlagControl);
+    return keyCode == kVK_ANSI_H && (modifiers & NSEventModifierFlagOption) != 0 &&
+           (modifiers & NSEventModifierFlagShift) != 0 && competingModifiers == 0;
+}
+
+inline bool IsFullWidthConvertibleCharacter(unichar character)
+{
+    return character == ' ' || (character >= '!' && character <= '~');
+}
+
+inline unichar FullWidthCharacter(unichar character)
+{
+    return character == ' ' ? 0x3000 : static_cast<unichar>(character + 0xFEE0);
+}
+} // namespace metasequoia::mac

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -6,6 +6,7 @@
 #include "CandidatePanelStyle.h"
 #import "InputMenu.h"
 #include "InputModeRouting.h"
+#include "FullWidthInput.h"
 #include "InputSchemePreference.h"
 #include "WubiCommitPolicy.h"
 #import "PreferencesWindowController.h"
@@ -268,6 +269,12 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     {
         return NO;
     }
+    if (metasequoia::mac::IsFullWidthInputToggle(event.keyCode, inputModeModifiers))
+    {
+        [MetasequoiaPreferencesWindowController setFullWidthInputEnabled:
+            ![MetasequoiaPreferencesWindowController storedFullWidthInputEnabled]];
+        return YES;
+    }
     if (![self prepareSessionIfNeeded])
     {
         return NO;
@@ -438,6 +445,18 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     if (!result.handled)
     {
         [self commitLeadingCandidate:sender];
+        if (_session != nullptr && !_session->has_composition() &&
+            [MetasequoiaPreferencesWindowController storedFullWidthInputEnabled] && event.characters.length == 1)
+        {
+            const unichar character = [event.characters characterAtIndex:0];
+            if (metasequoia::mac::IsFullWidthConvertibleCharacter(character))
+            {
+                const unichar fullWidthCharacter = metasequoia::mac::FullWidthCharacter(character);
+                NSString *converted = [NSString stringWithCharacters:&fullWidthCharacter length:1];
+                [sender insertText:converted replacementRange:NSMakeRange(NSNotFound, NSNotFound)];
+                return YES;
+            }
+        }
         return NO;
     }
     [self applyResult:result client:sender];

--- a/platforms/macos/src/PreferencesWindowController.h
+++ b/platforms/macos/src/PreferencesWindowController.h
@@ -32,6 +32,8 @@ bool MetasequoiaShouldShowPreferences(int argc, const char *argv[]);
 + (void)setEnglishInputMode:(BOOL)enabled;
 + (BOOL)storedInputModeShortcutEnabled;
 + (void)setInputModeShortcutEnabled:(BOOL)enabled;
++ (BOOL)storedFullWidthInputEnabled;
++ (void)setFullWidthInputEnabled:(BOOL)enabled;
 + (BOOL)storedWubiAutoCommitUniqueEnabled;
 + (void)setWubiAutoCommitUniqueEnabled:(BOOL)enabled;
 - (void)showAndActivate;

--- a/platforms/macos/src/PreferencesWindowController.mm
+++ b/platforms/macos/src/PreferencesWindowController.mm
@@ -35,6 +35,7 @@ NSString * const kCandidatePageShortcutPreferenceKey = @"MetasequoiaImeCandidate
 NSString * const kCandidateLearningPreferenceKey = @"MetasequoiaImeCandidateLearning";
 NSString * const kEnglishInputModePreferenceKey = @"MetasequoiaImeEnglishInputMode";
 NSString * const kInputModeShortcutPreferenceKey = @"MetasequoiaImeInputModeShortcutEnabled";
+NSString * const kFullWidthInputPreferenceKey = @"MetasequoiaImeFullWidthInputEnabled";
 NSString * const kWubiAutoCommitUniquePreferenceKey = @"MetasequoiaImeWubiAutoCommitUnique";
 
 NSColor *MetasequoiaBrandColor()
@@ -345,6 +346,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     MetasequoiaCandidatePreviewView *_candidatePreview;
     NSButton *_candidateLearningButton;
     NSButton *_inputModeShortcutButton;
+    NSButton *_fullWidthInputButton;
     NSButton *_wubiAutoCommitButton;
     NSButton *_resetLearningButton;
     NSTextField *_statusLabel;
@@ -522,6 +524,19 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
 {
     [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kInputModeShortcutPreferenceKey];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaInputModeShortcutDidChangeNotification"
+                                                        object:@(enabled)];
+}
+
++ (BOOL)storedFullWidthInputEnabled
+{
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kFullWidthInputPreferenceKey];
+    return value == nil ? NO : [value boolValue];
+}
+
++ (void)setFullWidthInputEnabled:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kFullWidthInputPreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaFullWidthInputDidChangeNotification"
                                                         object:@(enabled)];
 }
 
@@ -712,6 +727,10 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                                                     target:self
                                                     action:@selector(inputModeShortcutChanged:)];
     _inputModeShortcutButton.accessibilityLabel = @"Shift+Space 切换中英文";
+    _fullWidthInputButton = [NSButton checkboxWithTitle:@"Option+Shift+H 切换全半角"
+                                                   target:self
+                                                   action:@selector(fullWidthInputChanged:)];
+    _fullWidthInputButton.accessibilityLabel = @"Option+Shift+H 切换全半角";
 
     _candidatePageShortcutButton = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
     [_candidatePageShortcutButton addItemsWithTitles:@[ @"- / =", @"[ / ]", @"Page Up / Page Down" ]];
@@ -721,7 +740,8 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
 
     NSBox *schemeCard = CardWithViews(schemeRows, 2.0);
     NSBox *behaviorCard =
-        CardWithViews(@[ _autocorrectButton, _chinesePunctuationButton, _inputModeShortcutButton ], 9.0);
+        CardWithViews(@[ _autocorrectButton, _chinesePunctuationButton, _inputModeShortcutButton,
+                         _fullWidthInputButton ], 9.0);
     NSBox *shortcutCard = CardWithViews(@[ PreferenceRow(@"上翻 / 下翻", _candidatePageShortcutButton) ], 0.0);
     schemeCard.accessibilityLabel = @"输入方式卡片";
     behaviorCard.accessibilityLabel = @"中英文状态切换卡片";
@@ -1050,6 +1070,9 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                                fontSize:[MetasequoiaPreferencesWindowController storedCandidateFontSize]];
     _candidateLearningButton.state = [MetasequoiaPreferencesWindowController storedCandidateLearningEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
     _inputModeShortcutButton.state = [MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
+    _fullWidthInputButton.state = [MetasequoiaPreferencesWindowController storedFullWidthInputEnabled]
+                                      ? NSControlStateValueOn
+                                      : NSControlStateValueOff;
     _wubiAutoCommitButton.state =
         [MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled] ? NSControlStateValueOn
                                                                                    : NSControlStateValueOff;
@@ -1193,6 +1216,12 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:button.state == NSControlStateValueOn];
 }
 
+- (void)fullWidthInputChanged:(id)sender
+{
+    NSButton *button = (NSButton *)sender;
+    [MetasequoiaPreferencesWindowController setFullWidthInputEnabled:button.state == NSControlStateValueOn];
+}
+
 - (void)wubiAutoCommitUniqueChanged:(id)sender
 {
     NSButton *button = (NSButton *)sender;
@@ -1259,6 +1288,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
              kCandidateLearningPreferenceKey,
              kInputModeShortcutPreferenceKey,
              kWubiAutoCommitUniquePreferenceKey,
+             kFullWidthInputPreferenceKey,
          ])
     {
         [defaults removeObjectForKey:key];
@@ -1287,6 +1317,8 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                                   object:@([MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled])];
     [notifications postNotificationName:@"MetasequoiaWubiAutoCommitUniqueDidChangeNotification"
                                   object:@([MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled])];
+    [notifications postNotificationName:@"MetasequoiaFullWidthInputDidChangeNotification"
+                                  object:@([MetasequoiaPreferencesWindowController storedFullWidthInputEnabled])];
     [self refreshControls];
 }
 

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -3,6 +3,7 @@
 #include "../src/CandidatePageSize.h"
 #include "../src/CandidateFontSize.h"
 #include "../src/InputModeRouting.h"
+#include "../src/FullWidthInput.h"
 #include "../src/InputSchemePreference.h"
 #include "../src/WubiCommitPolicy.h"
 
@@ -244,6 +245,16 @@ int main()
                 ClassifyControllerKey(kVK_ANSI_A, true, CandidatePageShortcut::MinusEqual, '-', false) ==
                     ControllerKeyAction::MoveCandidatePageUp,
             "Candidate paging followed a US physical key instead of the active keyboard layout.");
+    require(metasequoia::mac::IsFullWidthInputToggle(
+                kVK_ANSI_H, NSEventModifierFlagOption | NSEventModifierFlagShift),
+            "Option+Shift+H was not recognized as the full-width toggle.");
+    require(!metasequoia::mac::IsFullWidthInputToggle(
+                 kVK_ANSI_H, NSEventModifierFlagOption | NSEventModifierFlagShift | NSEventModifierFlagCommand),
+            "A competing Command modifier incorrectly triggered the full-width toggle.");
+    require(metasequoia::mac::IsFullWidthConvertibleCharacter('A') &&
+                metasequoia::mac::FullWidthCharacter('A') == 0xFF21 &&
+                metasequoia::mac::FullWidthCharacter(' ') == 0x3000,
+            "ASCII full-width conversion did not preserve the expected Unicode mapping.");
 
     const std::initializer_list<std::pair<unsigned short, ControllerKeyAction>> navigationKeys = {
         {kVK_LeftArrow, ControllerKeyAction::MoveCandidateLeft},

--- a/platforms/macos/tests/PreferencesWindowTests.mm
+++ b/platforms/macos/tests/PreferencesWindowTests.mm
@@ -149,6 +149,7 @@ int main()
         [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:NO];
         [MetasequoiaPreferencesWindowController setEnglishInputMode:YES];
         [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:NO];
+        [MetasequoiaPreferencesWindowController setFullWidthInputEnabled:NO];
         [MetasequoiaPreferencesWindowController setWubiAutoCommitUniqueEnabled:NO];
         [MetasequoiaPreferencesWindowController setStoredScheme:2];
         require([MetasequoiaPreferencesWindowController storedScheme] == 2,
@@ -171,6 +172,8 @@ int main()
                 "The English input-mode state was not stored.");
         require(![MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled],
                 "The disabled input-mode shortcut preference was not stored.");
+        require(![MetasequoiaPreferencesWindowController storedFullWidthInputEnabled],
+                "The disabled full-width input preference was not stored.");
         require(![MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled],
                 "The disabled Wubi auto-commit preference was not stored.");
 
@@ -248,8 +251,15 @@ int main()
         NSButton *quanpinSchemeButton = FindButtonWithTitle(controller.window.contentView, @"全拼输入");
         NSButton *shuangpinSchemeButton = FindButtonWithTitle(controller.window.contentView, @"小鹤双拼");
         NSButton *wubiSchemeButton = FindButtonWithTitle(controller.window.contentView, @"五笔输入（86 五笔）");
+        NSButton *fullWidthButton = FindButtonWithTitle(controller.window.contentView, @"Option+Shift+H 切换全半角");
         require(quanpinSchemeButton != nil && shuangpinSchemeButton != nil && wubiSchemeButton != nil,
                 "The keyboard-input page did not expose every supported input scheme.");
+        require(fullWidthButton != nil && fullWidthButton.state == NSControlStateValueOff,
+                "The keyboard-input page did not expose the full-width input toggle.");
+        fullWidthButton.state = NSControlStateValueOn;
+        require([NSApp sendAction:fullWidthButton.action to:fullWidthButton.target from:fullWidthButton] &&
+                    [MetasequoiaPreferencesWindowController storedFullWidthInputEnabled],
+                "The full-width input toggle did not persist its enabled state.");
         require(wubiSchemeButton.state == NSControlStateValueOn,
                 "The keyboard-input page did not reflect the stored Wubi scheme.");
         [shuangpinSchemeButton performClick:nil];
@@ -525,6 +535,7 @@ int main()
         [MetasequoiaPreferencesWindowController setCandidatePageShortcut:2];
         [MetasequoiaPreferencesWindowController setCandidateLearningEnabled:NO];
         [MetasequoiaPreferencesWindowController setInputModeShortcutEnabled:NO];
+        [MetasequoiaPreferencesWindowController setFullWidthInputEnabled:YES];
         [MetasequoiaPreferencesWindowController setEnglishInputMode:YES];
         [MetasequoiaPreferencesWindowController setWubiAutoCommitUniqueEnabled:YES];
         NSButton *restoreDefaultsButton = FindButtonWithTitle(controller.window.contentView, @"恢复默认设置");
@@ -540,6 +551,7 @@ int main()
                     [MetasequoiaPreferencesWindowController storedCandidatePageShortcut] == 0 &&
                     [MetasequoiaPreferencesWindowController storedCandidateLearningEnabled] &&
                     [MetasequoiaPreferencesWindowController storedInputModeShortcutEnabled] &&
+                    ![MetasequoiaPreferencesWindowController storedFullWidthInputEnabled] &&
                     ![MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled],
                 "Restoring defaults did not restore every visible setting.");
         NSArray<NSString *> *preferenceKeys = @[
@@ -553,6 +565,7 @@ int main()
             @"MetasequoiaImeCandidatePageShortcut",
             @"MetasequoiaImeCandidateLearning",
             @"MetasequoiaImeInputModeShortcutEnabled",
+            @"MetasequoiaImeFullWidthInputEnabled",
             @"MetasequoiaImeWubiAutoCommitUnique",
         ];
         for (NSString *key in preferenceKeys)


### PR DESCRIPTION
## Summary
- add a settings toggle and Option+Shift+H shortcut for full-width input
- convert idle ASCII characters to Unicode full-width forms without affecting pinyin composition
- cover preferences, routing, and restore-defaults behavior in tests and document the option

## Verification
- cmake --build build --parallel
- ctest --test-dir build -E ^release_package$ --output-on-failure (16/16 passed)