### PR TITLE
fix(mac): route letters through full-width mode

### DIFF
--- a/platforms/macos/src/FullWidthInput.h
+++ b/platforms/macos/src/FullWidthInput.h
@@ -18,6 +18,13 @@ inline bool IsFullWidthConvertibleCharacter(unichar character)
     return character == ' ' || (character >= '!' && character <= '~');
 }
 
+inline bool IsFullWidthDirectCharacter(unichar character, NSEventModifierFlags modifiers)
+{
+    const NSEventModifierFlags competingModifiers =
+        modifiers & (NSEventModifierFlagCommand | NSEventModifierFlagControl | NSEventModifierFlagOption);
+    return competingModifiers == 0 && IsFullWidthConvertibleCharacter(character);
+}
+
 inline unichar FullWidthCharacter(unichar character)
 {
     return character == ' ' ? 0x3000 : static_cast<unichar>(character + 0xFEE0);

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -275,6 +275,20 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
             ![MetasequoiaPreferencesWindowController storedFullWidthInputEnabled]];
         return YES;
     }
+    if ([MetasequoiaPreferencesWindowController storedFullWidthInputEnabled] && event.characters.length == 1 &&
+        metasequoia::mac::IsFullWidthDirectCharacter([event.characters characterAtIndex:0], inputModeModifiers))
+    {
+        const unichar character = [event.characters characterAtIndex:0];
+        if (metasequoia::mac::IsFullWidthConvertibleCharacter(character) &&
+            ((character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')) &&
+            (_session == nullptr || !_session->has_composition()))
+        {
+            const unichar fullWidthCharacter = metasequoia::mac::FullWidthCharacter(character);
+            NSString *converted = [NSString stringWithCharacters:&fullWidthCharacter length:1];
+            [sender insertText:converted replacementRange:NSMakeRange(NSNotFound, NSNotFound)];
+            return YES;
+        }
+    }
     if (![self prepareSessionIfNeeded])
     {
         return NO;

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -255,6 +255,9 @@ int main()
                 metasequoia::mac::FullWidthCharacter('A') == 0xFF21 &&
                 metasequoia::mac::FullWidthCharacter(' ') == 0x3000,
             "ASCII full-width conversion did not preserve the expected Unicode mapping.");
+    require(metasequoia::mac::IsFullWidthDirectCharacter('a', NSEventModifierFlagShift) &&
+                !metasequoia::mac::IsFullWidthDirectCharacter('a', NSEventModifierFlagOption),
+            "Direct full-width character routing did not honor competing modifiers.");
 
     const std::initializer_list<std::pair<unsigned short, ControllerKeyAction>> navigationKeys = {
         {kVK_LeftArrow, ControllerKeyAction::MoveCandidateLeft},


### PR DESCRIPTION
Fix full-width input for ASCII letters by routing idle letter events before pinyin handling. Add modifier-aware routing coverage.