### PR TITLE
fix(release): skip unsigned Sparkle appcast

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,7 @@ jobs:
           METASEQUOIA_INSTALLER_DISTRIBUTION: ${{ runner.temp }}/InstallerDistribution.xml.in
         run: exec "$RUNNER_TEMP/package-release.sh" "$TAG_NAME" build/MetasequoiaIME.app dist
       - name: Generate signed Sparkle appcast
+        if: ${{ steps.signing.outputs.signing_enabled == 'true' }}
         env:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
@@ -256,6 +257,9 @@ jobs:
           update_archive="dist/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX-update.zip"
           SPARKLE_TOOLS_DIR="$sparkle_root/bin" \
             exec "$RUNNER_TEMP/generate-sparkle-appcast.sh" "$TAG_NAME" "$update_archive" dist/appcast.xml
+      - name: Skip Sparkle appcast for unsigned release
+        if: ${{ steps.signing.outputs.signing_enabled != 'true' }}
+        run: echo 'Unsigned releases do not publish a Sparkle appcast because update signatures cannot be trusted.' >> "$GITHUB_STEP_SUMMARY"
       - name: Revalidate draft release target
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -34,8 +34,11 @@ archive="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.zip"
 update_archive="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX-update.zip"
 installer="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.pkg"
 appcast="$dist_dir/appcast.xml"
-for artifact in "$installer" "$installer.sha256" "$archive" "$archive.sha256" \
-    "$update_archive" "$update_archive.sha256" "$appcast"; do
+artifacts=("$installer" "$installer.sha256" "$archive" "$archive.sha256" "$update_archive" "$update_archive.sha256")
+if [[ "$release_mode" == signed ]]; then
+    artifacts+=("$appcast")
+fi
+for artifact in "${artifacts[@]}"; do
     if [[ ! -f "$artifact" ]]; then
         printf 'Release artifact is missing: %s\n' "$artifact" >&2
         exit 1
@@ -91,6 +94,9 @@ if [[ "$current_notes" != *"$mode_marker"* || "$current_notes" != *"$install_gui
     gh release edit "$TAG_NAME" --repo "$GH_REPO" --notes-file "$release_notes"
 fi
 
-gh release upload "$TAG_NAME" --repo "$GH_REPO" "$installer" "$installer.sha256" "$archive" "$archive.sha256" \
-    "$update_archive" "$update_archive.sha256" "$appcast" --clobber
+upload_args=("$installer" "$installer.sha256" "$archive" "$archive.sha256" "$update_archive" "$update_archive.sha256")
+if [[ "$release_mode" == signed ]]; then
+    upload_args+=("$appcast")
+fi
+gh release upload "$TAG_NAME" --repo "$GH_REPO" "${upload_args[@]}" --clobber
 gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false

--- a/platforms/macos/src/FullWidthInput.h
+++ b/platforms/macos/src/FullWidthInput.h
@@ -18,6 +18,13 @@ inline bool IsFullWidthConvertibleCharacter(unichar character)
     return character == ' ' || (character >= '!' && character <= '~');
 }
 
+inline bool IsFullWidthDirectCharacter(unichar character, NSEventModifierFlags modifiers)
+{
+    const NSEventModifierFlags competingModifiers =
+        modifiers & (NSEventModifierFlagCommand | NSEventModifierFlagControl | NSEventModifierFlagOption);
+    return competingModifiers == 0 && IsFullWidthConvertibleCharacter(character);
+}
+
 inline unichar FullWidthCharacter(unichar character)
 {
     return character == ' ' ? 0x3000 : static_cast<unichar>(character + 0xFEE0);

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -275,6 +275,20 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
             ![MetasequoiaPreferencesWindowController storedFullWidthInputEnabled]];
         return YES;
     }
+    if ([MetasequoiaPreferencesWindowController storedFullWidthInputEnabled] && event.characters.length == 1 &&
+        metasequoia::mac::IsFullWidthDirectCharacter([event.characters characterAtIndex:0], inputModeModifiers))
+    {
+        const unichar character = [event.characters characterAtIndex:0];
+        if (metasequoia::mac::IsFullWidthConvertibleCharacter(character) &&
+            ((character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')) &&
+            (_session == nullptr || !_session->has_composition()))
+        {
+            const unichar fullWidthCharacter = metasequoia::mac::FullWidthCharacter(character);
+            NSString *converted = [NSString stringWithCharacters:&fullWidthCharacter length:1];
+            [sender insertText:converted replacementRange:NSMakeRange(NSNotFound, NSNotFound)];
+            return YES;
+        }
+    }
     if (![self prepareSessionIfNeeded])
     {
         return NO;

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -255,6 +255,9 @@ int main()
                 metasequoia::mac::FullWidthCharacter('A') == 0xFF21 &&
                 metasequoia::mac::FullWidthCharacter(' ') == 0x3000,
             "ASCII full-width conversion did not preserve the expected Unicode mapping.");
+    require(metasequoia::mac::IsFullWidthDirectCharacter('a', NSEventModifierFlagShift) &&
+                !metasequoia::mac::IsFullWidthDirectCharacter('a', NSEventModifierFlagOption),
+            "Direct full-width character routing did not honor competing modifiers.");
 
     const std::initializer_list<std::pair<unsigned short, ControllerKeyAction>> navigationKeys = {
         {kVK_LeftArrow, ControllerKeyAction::MoveCandidateLeft},

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -490,7 +490,7 @@ fi
         self.assertLess(calls.index("--notes-file"), calls.index("release upload"))
         self.assertIn("macos-universal-unsigned.pkg", calls)
         self.assertIn("macos-universal-unsigned-update.zip", calls)
-        self.assertIn("appcast.xml", calls)
+        self.assertNotIn("appcast.xml", calls)
         self.assertIn("--draft=false", calls)
 
     def test_same_mode_retry_keeps_notes_and_reuploads_with_clobber(self):

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -195,6 +195,8 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("$RUNNER_TEMP/publish-release.sh", workflow)
         self.assertIn("$RUNNER_TEMP/generate-sparkle-appcast.sh", workflow)
         self.assertIn("SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}", workflow)
+        self.assertIn("steps.signing.outputs.signing_enabled == 'true'", workflow)
+        self.assertIn("Unsigned releases do not publish a Sparkle appcast", workflow)
         self.assertIn("Sparkle-2.9.6.tar.xz", workflow)
         self.assertIn("52bf9e88cdd972fc0c81501377a880e90d47031bd8ca5462488f843e2609e192", workflow)
         self.assertLess(workflow.index("name: Generate signed Sparkle appcast"), workflow.index("name: Upload and publish release"))


### PR DESCRIPTION
Unsigned releases now skip Sparkle appcast generation and upload, so missing signing keys no longer fail the release job. Signed releases keep the existing EdDSA appcast path. Updated release tests.