### PR TITLE
ci(release): validate macOS without waiting on iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      mac_only:
+        description: "Run only the macOS validation jobs"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -54,6 +60,7 @@ jobs:
 
   ios:
     name: iOS Simulator
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_only != true }}
     runs-on: macos-15
     steps:
       - name: Check out source

--- a/platforms/macos/scripts/promote-release-branch.sh
+++ b/platforms/macos/scripts/promote-release-branch.sh
@@ -151,7 +151,7 @@ if [[ "$head_changelog_tail" != "## [$head_version]"* || "$head_changelog_tail" 
     exit 1
 fi
 
-gh workflow run ci.yml --repo "$GH_REPO" --ref "$RELEASE_BRANCH"
+gh workflow run ci.yml --repo "$GH_REPO" --ref "$RELEASE_BRANCH" --field mac_only=true
 max_polls=${METASEQUOIA_RELEASE_CI_MAX_POLLS:-150}
 poll_interval=${METASEQUOIA_RELEASE_CI_POLL_INTERVAL:-2}
 run_id=""

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -193,7 +193,7 @@ case "$*" in
   "api repos/$GH_REPO/contents/CHANGELOG.md?ref=$FAKE_HEAD_SHA --jq .content")
     print -r -- "$FAKE_HEAD_CHANGELOG_MD"
     ;;
-  "workflow run ci.yml --repo $GH_REPO --ref $RELEASE_BRANCH")
+  "workflow run ci.yml --repo $GH_REPO --ref $RELEASE_BRANCH --field mac_only=true")
     ;;
   "run list --repo $GH_REPO --workflow ci.yml --branch $RELEASE_BRANCH --event workflow_dispatch --limit 20 --json databaseId,headSha --jq "*)
     print -r -- "9001"

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -149,6 +149,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("persist-credentials: false", workflow)
         self.assertIn("GH_REPO: ${{ github.repository }}", workflow)
         self.assertIn("gh workflow run ci.yml", merge_release_pr)
+        self.assertIn("--field mac_only=true", promote_release_branch)
         self.assertIn("gh run watch", merge_release_pr)
         self.assertIn("--match-head-commit", merge_release_pr)
         self.assertTrue(merge_release_pr.startswith("#!/usr/bin/env bash\n"))


### PR DESCRIPTION
## Summary
- add a mac_only workflow-dispatch input to skip iOS only for release validation
- keep iOS checks enabled for normal pushes and pull requests
- make release promotion dispatch macOS-only validation

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- python3 -m unittest platforms/macos/tests/ReleaseAutomationTests.py platforms/macos/tests/ReleaseConfigurationTests.py (38/38 passed)