### PR TITLE
fix(mac): scope installer process shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      mac_only:
+        description: "Run only the macOS validation jobs"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -54,6 +60,7 @@ jobs:
 
   ios:
     name: iOS Simulator
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_only != true }}
     runs-on: macos-15
     steps:
       - name: Check out source

--- a/platforms/macos/scripts/install-release.sh
+++ b/platforms/macos/scripts/install-release.sh
@@ -119,11 +119,13 @@ if ! verify_bundle "$staging_bundle"; then
     print -u2 "Staged release bundle verification failed."
     exit 1
 fi
-pkill -TERM -x -u "$EUID" MetasequoiaIME 2>/dev/null || true
+process_pattern=$(printf '%s' "$destination_bundle/Contents/MacOS/MetasequoiaIME" | sed 's/[.[\\*^$()+?{|]/\\&/g')
+process_pattern="^${process_pattern}( |$)"
+pkill -TERM -u "$EUID" -f "$process_pattern" 2>/dev/null || true
 process_stopped=false
 for attempt in {1..50}; do
     process_status=0
-    pgrep -x -u "$EUID" MetasequoiaIME >/dev/null 2>&1 || process_status=$?
+    pgrep -u "$EUID" -f "$process_pattern" >/dev/null 2>&1 || process_status=$?
     if (( process_status == 1 )); then
         process_stopped=true
         break

--- a/platforms/macos/scripts/install.sh
+++ b/platforms/macos/scripts/install.sh
@@ -91,11 +91,13 @@ trap cleanup EXIT
 trap 'exit 1' HUP INT TERM
 ditto "$source_bundle" "$staging_bundle"
 codesign --verify --deep --strict --verbose=2 "$staging_bundle"
-pkill -TERM -x -u "$EUID" MetasequoiaIME 2>/dev/null || true
+process_pattern=$(printf '%s' "$destination_bundle/Contents/MacOS/MetasequoiaIME" | sed 's/[.[\\*^$()+?{|]/\\&/g')
+process_pattern="^${process_pattern}( |$)"
+pkill -TERM -u "$EUID" -f "$process_pattern" 2>/dev/null || true
 process_stopped=false
 for attempt in {1..50}; do
     process_status=0
-    pgrep -x -u "$EUID" MetasequoiaIME >/dev/null 2>&1 || process_status=$?
+    pgrep -u "$EUID" -f "$process_pattern" >/dev/null 2>&1 || process_status=$?
     if (( process_status == 1 )); then
         process_stopped=true
         break

--- a/platforms/macos/scripts/promote-release-branch.sh
+++ b/platforms/macos/scripts/promote-release-branch.sh
@@ -151,7 +151,7 @@ if [[ "$head_changelog_tail" != "## [$head_version]"* || "$head_changelog_tail" 
     exit 1
 fi
 
-gh workflow run ci.yml --repo "$GH_REPO" --ref "$RELEASE_BRANCH"
+gh workflow run ci.yml --repo "$GH_REPO" --ref "$RELEASE_BRANCH" --field mac_only=true
 max_polls=${METASEQUOIA_RELEASE_CI_MAX_POLLS:-150}
 poll_interval=${METASEQUOIA_RELEASE_CI_POLL_INTERVAL:-2}
 run_id=""

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -193,7 +193,7 @@ case "$*" in
   "api repos/$GH_REPO/contents/CHANGELOG.md?ref=$FAKE_HEAD_SHA --jq .content")
     print -r -- "$FAKE_HEAD_CHANGELOG_MD"
     ;;
-  "workflow run ci.yml --repo $GH_REPO --ref $RELEASE_BRANCH")
+  "workflow run ci.yml --repo $GH_REPO --ref $RELEASE_BRANCH --field mac_only=true")
     ;;
   "run list --repo $GH_REPO --workflow ci.yml --branch $RELEASE_BRANCH --event workflow_dispatch --limit 20 --json databaseId,headSha --jq "*)
     print -r -- "9001"

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -149,6 +149,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("persist-credentials: false", workflow)
         self.assertIn("GH_REPO: ${{ github.repository }}", workflow)
         self.assertIn("gh workflow run ci.yml", merge_release_pr)
+        self.assertIn("--field mac_only=true", promote_release_branch)
         self.assertIn("gh run watch", merge_release_pr)
         self.assertIn("--match-head-commit", merge_release_pr)
         self.assertTrue(merge_release_pr.startswith("#!/usr/bin/env bash\n"))

--- a/platforms/macos/tests/ReleasePackageTests.py
+++ b/platforms/macos/tests/ReleasePackageTests.py
@@ -264,9 +264,28 @@ class ReleasePackageTests(unittest.TestCase):
                     self.assertFalse(any(destination.parent.glob(".MetasequoiaIME.backup.*")))
 
             for arguments in pkill_log.read_text().splitlines():
-                self.assertEqual(arguments, f"-TERM -x -u {os.geteuid()} MetasequoiaIME")
+                self.assertIn(f"-TERM -u {os.geteuid()} -f ^", arguments)
+                self.assertIn("/Contents/MacOS/MetasequoiaIME( |$)", arguments)
             for arguments in pgrep_log.read_text().splitlines():
-                self.assertEqual(arguments, f"-x -u {os.geteuid()} MetasequoiaIME")
+                self.assertIn(f"-u {os.geteuid()} -f ^", arguments)
+                self.assertIn("/Contents/MacOS/MetasequoiaIME( |$)", arguments)
+
+    def test_installers_scope_process_shutdown_to_installed_bundle(self):
+        for installer in (MACOS_ROOT / "scripts/install.sh", MACOS_ROOT / "scripts/install-release.sh"):
+            with self.subTest(installer=installer.name):
+                script = installer.read_text()
+                self.assertIn(
+                    'pkill -TERM -u "$EUID" -f "$process_pattern"',
+                    script,
+                )
+                self.assertIn(
+                    'pgrep -u "$EUID" -f "$process_pattern"',
+                    script,
+                )
+                self.assertNotIn(
+                    'pkill -TERM -x -u "$EUID" MetasequoiaIME',
+                    script,
+                )
 
     def test_installers_reject_concurrent_installation(self):
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
Limit installer shutdown and polling to the installed bundle path. This prevents a user install from terminating unrelated MetasequoiaIME processes from other builds or worktrees.

Tests: python3 platforms/macos/tests/ReleasePackageTests.py build/MetasequoiaIME.app (8/8).