### PR TITLE
chore: follow the default branch rename to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "vendor/MetasequoiaImeEngine"]
 	path = vendor/MetasequoiaImeEngine
 	url = https://github.com/metasequoiaime/MSIME-Engine.git
-	branch = master
+	branch = main
 [submodule "vendor/MetasequoiaImeDict"]
 	path = vendor/MetasequoiaImeDict
 	url = https://github.com/metasequoiaime/MSIME-Dict.git
 [submodule "vendor/MetasequoiaImeHelpCode"]
 	path = vendor/MetasequoiaImeHelpCode
 	url = https://github.com/metasequoiaime/MetasequoiaImeHelpCode.git
-	branch = master
+	branch = main

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -457,7 +457,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
             submodule_value("vendor/MetasequoiaImeEngine", "url"),
             "https://github.com/metasequoiaime/MSIME-Engine.git",
         )
-        self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "branch"), "master")
+        self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "branch"), "main")
         self.assertEqual(submodule_value("vendor/MetasequoiaImeDict", "path"), "vendor/MetasequoiaImeDict")
         self.assertEqual(
             submodule_value("vendor/MetasequoiaImeDict", "url"),


### PR DESCRIPTION
组织内 17 个仓库的默认分支已从 `master` 统一改名为 `main`，本 PR 跟进本仓库里因此失配的引用。

GitHub 在改名时会自动重定向网页链接并把在途 PR 指向新的默认分支，但不会更新仓库内容里的分支引用。

## 改了什么

- `.gitmodules`：`vendor/MetasequoiaImeEngine` 和 `vendor/MetasequoiaImeHelpCode` 的 `branch` 从 `master` 改为 `main`。改名后 `master` 分支已不存在，这两个 pin 会让 `git submodule update --remote` 找不到分支。
- `platforms/macos/tests/ReleaseConfigurationTests.py`：`test_dependabot_tracks_actions_and_expected_submodule_branches` 里把 engine 子模块的期望分支同步为 `main`。

第二处是这个仓库的测试主动抓出来的：只改 `.gitmodules` 后 CI 报 `AssertionError: 'main' != 'master'`。期望值写死在测试里是有意的，所以跟着数据一起更新，而不是放宽断言。

## 验证

macOS 15 arm64、macOS 15 x86_64、iOS Simulator 三个 job 均通过。
