### PR TITLE
chore: move the engine submodule onto the engine main line

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,5 +7,5 @@
 	url = https://github.com/metasequoiaime/MSIME-Dict.git
 [submodule "vendor/MetasequoiaImeHelpCode"]
 	path = vendor/MetasequoiaImeHelpCode
-	url = https://github.com/metasequoiaime/MetasequoiaImeHelpCode.git
+	url = https://github.com/metasequoiaime/MSIME-HelpCode.git
 	branch = main

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -21,6 +21,9 @@ final class OnboardingUITests: XCTestCase {
     let tryoutField = app.textFields["keyboardTryoutField"]
     XCTAssertTrue(tryoutField.exists)
     tryoutField.tap()
+    // Tapping only requests first responder. Typing before the field actually holds keyboard focus fails with "Neither element nor any descendant has keyboard focus", so wait for the focus rather than assuming the transition already landed.
+    let focused = expectation(for: NSPredicate(format: "hasKeyboardFocus == true"), evaluatedWith: tryoutField)
+    wait(for: [focused], timeout: 10)
     tryoutField.typeText("test")
     XCTAssertEqual(tryoutField.value as? String, "test")
   }

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -33,6 +33,9 @@ targets:
       - path: vendor/MetasequoiaImeEngine/japanese
         excludes:
           - "*.h"
+      - path: vendor/MetasequoiaImeEngine/local_modes
+        excludes:
+          - "*.h"
       - path: vendor/MetasequoiaImeEngine/providers
         excludes:
           - "*.h"

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -312,6 +312,27 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("handleInputModeList(from: sender, with: event)", controller)
         self.assertNotIn("advanceToNextInputMode()", controller)
 
+    def test_bridge_compiles_every_engine_source_directory(self):
+        # macOS pulls the engine in with add_subdirectory, so it tracks new engine directories on its own. This target enumerates them by hand, so a directory added upstream silently drops out of the static library and only surfaces as undefined symbols at link time — which is how local_modes broke the keyboard extension.
+        engine_root = IOS_ROOT.parents[1] / "vendor/MetasequoiaImeEngine"
+        if not (engine_root / "core").is_dir():
+            self.skipTest("engine submodule is not checked out")
+
+        project = (IOS_ROOT / "project.yml").read_text()
+        not_built = {"tests"}
+        missing = []
+        for directory in sorted(engine_root.iterdir()):
+            if not directory.is_dir() or directory.name.startswith("."):
+                continue
+            if directory.name in not_built:
+                continue
+            if not any(directory.glob("*.cpp")):
+                continue
+            if f"vendor/MetasequoiaImeEngine/{directory.name}" not in project:
+                missing.append(directory.name)
+
+        self.assertEqual(missing, [], f"engine directories missing from the bridge target: {missing}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -580,7 +580,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         )
         self.assertEqual(
             submodule_value("vendor/MetasequoiaImeHelpCode", "url"),
-            "https://github.com/metasequoiaime/MetasequoiaImeHelpCode.git",
+            "https://github.com/metasequoiaime/MSIME-HelpCode.git",
         )
 
     def test_macos_bundle_packages_helpcode_assets(self):


### PR DESCRIPTION
## What

- Move the engine submodule from `d0883249` to `8cc306c`.
- Point the helpcode submodule at `MSIME-HelpCode`.

## Why the engine pin had to move

`d0883249` is not an ancestor of the engine's `main`. It sits on the cross-platform feature line that branched off `a197746` and was never merged; the same work later landed on `main` as a squash, so the pin has been tracking a dead branch.

The diff from `d0883249` to engine `main` is +5162 / -144. The deletions are rewritten implementations (`InputSession::handle_character`, the shuangpin data-root snapshot), not dropped functionality, so `main` is a content superset. Moving the pin also picks up:

- the local mode queries (`local_modes/`: date-time, emoji, jianpin, kaomoji, quick phrase, unicode)
- the online candidate API
- the shuangpin data-root fix and the test sources `imetest` already referenced

## Helpcode URL

`MetasequoiaImeHelpCode` only resolved through GitHub's rename redirect. The submodule path is unchanged, so nothing moves on disk.

## Note for existing clones

```
git submodule sync --recursive
git submodule update --init --recursive
```

## Verification

Built the engine at `8cc306c` standalone on macOS (AppleClang 21, Homebrew boost/fmt/spdlog/sqlite): configure and build clean, 11/11 ctest tests passed. The Apple frontend build itself is left to CI on this PR.
