### PR TITLE
fix(release): stop referencing secrets from a step condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,8 +240,20 @@ jobs:
           METASEQUOIA_RELEASE_UNINSTALL_SCRIPT: ${{ runner.temp }}/uninstall.sh
           METASEQUOIA_INSTALLER_DISTRIBUTION: ${{ runner.temp }}/InstallerDistribution.xml.in
         run: exec "$RUNNER_TEMP/package-release.sh" "$TAG_NAME" build/MetasequoiaIME.app dist
+      - name: Detect the Sparkle update key
+        id: sparkle
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          # The secrets context is not available in a step-level if:, so decide here and let the following steps read the output.
+          if [[ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]]; then
+            printf 'appcast_enabled=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'appcast_enabled=false\n' >> "$GITHUB_OUTPUT"
+          fi
       - name: Generate signed Sparkle appcast
-        if: ${{ secrets.SPARKLE_ED_PRIVATE_KEY != '' }}
+        if: ${{ steps.sparkle.outputs.appcast_enabled == 'true' }}
         env:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
@@ -263,7 +275,7 @@ jobs:
           SPARKLE_TOOLS_DIR="$sparkle_root/bin" \
             exec "$RUNNER_TEMP/generate-sparkle-appcast.sh" "$TAG_NAME" "$update_archive" dist/appcast.xml
       - name: Skip Sparkle appcast without an update key
-        if: ${{ secrets.SPARKLE_ED_PRIVATE_KEY == '' }}
+        if: ${{ steps.sparkle.outputs.appcast_enabled != 'true' }}
         run: echo 'No SPARKLE_ED_PRIVATE_KEY is configured, so this release ships without an appcast and automatic updates stay paused.' >> "$GITHUB_STEP_SUMMARY"
       - name: Revalidate draft release target
         env:

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -341,8 +341,15 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("$RUNNER_TEMP/generate-sparkle-appcast.sh", workflow)
         self.assertIn("SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}", workflow)
         self.assertIn("steps.signing.outputs.signing_enabled == 'true'", workflow)
-        self.assertIn("secrets.SPARKLE_ED_PRIVATE_KEY != ''", workflow)
+        self.assertIn("steps.sparkle.outputs.appcast_enabled == 'true'", workflow)
         self.assertNotIn("name: Generate signed Sparkle appcast\n        if: ${{ steps.signing.outputs.signing_enabled", workflow)
+
+        # The secrets context is rejected in a step-level if:, and the workflow then fails to parse and schedules no jobs at all. Release only runs on push to main, so no pull request check can catch it.
+        for workflow_path in sorted((PROJECT_ROOT / ".github/workflows").glob("*.yml")):
+            for number, line in enumerate(workflow_path.read_text().splitlines(), start=1):
+                stripped = line.strip()
+                if stripped.startswith("if:") and "secrets." in stripped:
+                    self.fail(f"{workflow_path.name}:{number} uses the secrets context in a step condition: {stripped}")
         self.assertIn("Unsigned release: skipping Developer ID signature verification before packaging.", workflow)
         self.assertIn("Unsigned release: skipping source bundle Developer ID signature verification.", release_packager)
         self.assertIn("Sparkle-2.9.6.tar.xz", workflow)


### PR DESCRIPTION
#223 gated the appcast steps on `if: ${{ secrets.SPARKLE_ED_PRIVATE_KEY != '' }}`. The `secrets` context is not available in a step-level `if:`, so `release.yml` stopped parsing.

Both runs since that merge scheduled **zero jobs** and failed immediately, and the workflow now appears in the run list as `.github/workflows/release.yml` instead of `Release` — the signature of a file that fails validation. Nothing on the pull request could have caught it: `Release` only triggers on push to `main`, so it never runs against a PR.

`actionlint` reproduces it exactly:

```
release.yml:244:17: context "secrets" is not allowed here. available contexts are
"env", "github", "inputs", "job", "matrix", "needs", "runner", "steps", "strategy", "vars"
```

Decide once in a step that reads the secret through `env`, publish the answer as an output, and condition the appcast steps on that output. `actionlint` is clean on the result.

Also adds a check over `.github/workflows/*.yml` that fails on any step condition referencing the `secrets` context, verified to fail when the original line is put back, so the next occurrence is caught by a pull request rather than by a broken release.

Note this does not by itself restore Sparkle updates for existing users: `releases/latest/download/appcast.xml` stays 404 until a release is actually published with the appcast attached.
