### PR TITLE
ci(release): let release-please use a real account when one is configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ on:
         default: false
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  # Keyed by event as well as branch: the release scripts dispatch this workflow and wait on that exact run, so a pull_request run on the same branch must not cancel it. Feature branches only ever get the pull_request run (push is restricted to main), so this still collapses superseded runs of the same kind.
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
         continue-on-error: true
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A pull request opened with GITHUB_TOKEN is authored by github-actions[bot], and its pull_request CI run is parked in action_required until a maintainer approves it, so it expires and shows a red check. RELEASE_PLEASE_TOKEN, when set, makes the pull request come from a real account and CI runs on its own.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Test and merge release pull request
         if: ${{ github.event_name == 'push' && steps.release.outputs.prs_created == 'true' }}
         id: merge_release_pr
@@ -80,7 +81,8 @@ jobs:
         id: finalized_release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A pull request opened with GITHUB_TOKEN is authored by github-actions[bot], and its pull_request CI run is parked in action_required until a maintainer approves it, so it expires and shows a red check. RELEASE_PLEASE_TOKEN, when set, makes the pull request come from a real account and CI runs on its own.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Create draft release for promoted commit
         if: ${{ github.event_name == 'push' && steps.promote_release_commit.outputs.promoted == 'true' }}
         id: finalized_promoted_release

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -47,10 +47,12 @@ class ReleaseConfigurationTests(unittest.TestCase):
         workflow = (PROJECT_ROOT / ".github/workflows/ci.yml").read_text()
 
         self.assertIn(
-            "group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}",
+            "group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}",
             workflow,
         )
         self.assertIn("cancel-in-progress: true", workflow)
+        # merge-release-pr.sh dispatches ci.yml and waits on that run with --exit-status, so a pull_request run on the same branch must land in a different concurrency group or it cancels the release.
+        self.assertIn("${{ github.event_name }}", workflow.split("concurrency:", 1)[1].split("permissions:", 1)[0])
         self.assertIn("on:\n  push:\n    branches:\n      - main\n  pull_request:\n", workflow)
 
     def test_current_repository_links_use_the_canonical_apple_repository(self):


### PR DESCRIPTION
A pull request opened with `GITHUB_TOKEN` is authored by `github-actions[bot]`. Its `pull_request` CI run is created in `action_required` and waits for a maintainer, so without approval it expires and the release pull request carries a red check. #225 and the two releases before it merged with no pull-request checks at all, relying on the separate `workflow_dispatch` run the release scripts fire.

The gate cannot be closed from the workflow file: approval applies when the run is created, so job-level conditions never get a say, and `pull_request.branches` filters the base branch rather than the head. Both the repository and the organization are already on the loosest policy (`first_time_contributors_new_to_github`), so there is nothing left to relax.

This reads `RELEASE_PLEASE_TOKEN` when present and falls back to `GITHUB_TOKEN`, so it changes nothing until that secret exists. `actionlint` is clean.

**Manual step required to actually take effect:** add a `RELEASE_PLEASE_TOKEN` secret holding a token for a real account with `contents: write` and `pull-requests: write` on this repository. Until then the behaviour is exactly as today.