### PR TITLE
fix(apple): keep the engine's helpcode and English paths out of the Apple frontends

### DIFF
--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -60,6 +60,19 @@ int RunTest() {
     Require(!adapter.handle_character('N').handled,
             "Unsupported uppercase input was swallowed by the adapter.");
 
+    // The engine treats A-Z during a composition as helpcode input, so testing uppercase with no
+    // composition proves nothing any more: that path was always unhandled. Pin the state that
+    // actually changed, and pin that the composition survives untouched.
+    Require(adapter.handle_character('n').handled &&
+                adapter.handle_character('i').handled,
+            "The uppercase fixture did not start a composition.");
+    const auto uppercaseDuringComposition = adapter.handle_character('H');
+    Require(!uppercaseDuringComposition.handled,
+            "Uppercase input during a composition was swallowed instead of passed to the client.");
+    Require(uppercaseDuringComposition.preedit == "ni",
+            "Uppercase input during a composition altered the preedit.");
+    Require(adapter.cancel().handled, "The uppercase fixture did not clear its composition.");
+
     const auto punctuation = adapter.handle_punctuation('.');
     Require(punctuation.handled && punctuation.commit.has_value() &&
                 *punctuation.commit == "。",

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -334,5 +334,22 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertEqual(missing, [], f"engine directories missing from the bridge target: {missing}")
 
 
+    def test_chinese_mode_never_sends_uppercase_to_the_session(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        # The engine consumes A-Z during a composition as helpcode input. The bridge rejects uppercase,
+        # but this keyboard is the other half of that contract: in Chinese mode the shift key is hidden,
+        # shift handling returns early, and key titles stay lowercase, so an uppercase letter never
+        # reaches handleCharacter in the first place. Losing any one of the three would send capitals
+        # into the session and swallow them instead of inserting them.
+        self.assertIn("button.isHidden = isChineseMode", controller)
+        shift_handler = controller.split("private func toggleLetterCase", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("guard !isChineseMode else { return }", shift_handler)
+        self.assertIn("let usesUppercase = !isChineseMode && letterCaseState != .lowercase", controller)
+        character_handler = controller.split("private func handleCharacter", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("render(session.handleCharacter(character))", character_handler)
+        self.assertNotIn("uppercased()", character_handler.split("} else {", 1)[0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -131,6 +131,26 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertNotIn("character <= 'Z'", character_branch)
         self.assertIn("HandleCharacterWithWubiAutoCommit", character_branch)
 
+    def test_engine_english_learning_stays_unreachable_from_macos(self):
+        controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
+        installer = (MACOS_ROOT / "src/DictionaryInstaller.mm").read_text()
+
+        # The engine writes learned English words to data_file_path("english.db"), while this installer
+        # replays the English journal into msime_english.db and only backs that name up when learned data
+        # is reset. The two never meet today because macOS never turns the engine's English paths on, so
+        # the divergence is latent. Wiring any of these up without first reconciling the filename would
+        # orphan learned English words in a file no macOS code reads, migrates or clears.
+        self.assertIn("msime_english.db", installer)
+        for switch in (
+            "set_dedicated_english_mode",
+            "set_english_input_options",
+            "set_frequency_adjustment",
+            "set_mixed_expressive_options",
+        ):
+            self.assertNotIn(switch, controller, f"{switch} reaches the engine's english.db path; reconcile the filename with msime_english.db first")
+        # handle_character's second parameter is what routes Shift+letter into the English and local modes.
+        self.assertIn("_session->handle_character(static_cast<char>(character))", controller)
+
     def test_input_controller_owns_a_native_floating_status_toolbar(self):
         cmake = (PROJECT_ROOT / "CMakeLists.txt").read_text()
         controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -32,6 +32,12 @@ InputSessionAdapter::InputSessionAdapter() : impl_(std::make_unique<Impl>()) {}
 InputSessionAdapter::~InputSessionAdapter() = default;
 
 InputSnapshot InputSessionAdapter::handle_character(char character) {
+  // The engine accepts A-Z during a composition as helpcode input, which no Apple frontend offers.
+  // Reject it here so an uppercase letter stays unhandled and the frontend passes it to the client,
+  // matching what core/input_session.h still documents and what the macOS controller does.
+  if (character >= 'A' && character <= 'Z') {
+    return MakeSnapshot(impl_->session, KeyResult{});
+  }
   return MakeSnapshot(impl_->session,
                       impl_->session.handle_character(character));
 }


### PR DESCRIPTION
Three gaps the engine bump (#222) left on the Apple side. None is a live user-facing defect; each is one small change away from becoming one, and the coverage that was supposed to catch them had stopped working.

## The shared bridge still fed uppercase into the session

#223 stopped the macOS controller forwarding `A-Z`, but `InputSessionAdapter` did not, and the keyboard extension goes through the adapter. The engine consumes `A-Z` during a composition as helpcode input, so a capital would be swallowed instead of inserted.

iOS is safe today only because three separate things in `KeyboardViewController` happen to hold: the shift key is hidden in Chinese mode, `toggleLetterCase` returns early, and key titles stay lowercase. Any one of them changing exposes the bug.

The adapter now rejects uppercase, matching the macOS controller and what `core/input_session.h` still documents ("Other input is rejected as unhandled so the frontend can pass it through to the client application").

## The test that was supposed to cover this had gone vacuous

`InputSessionAdapterTests` called `handle_character('N')` immediately after `commit_raw()` cleared the composition — the one state the engine did not change — so it kept passing while the real path broke. It now starts a composition first, then asserts the capital comes back unhandled with the preedit untouched.

Verified against a reverted adapter: without the guard the test fails with `Uppercase input during a composition was swallowed instead of passed to the client`. Built and run locally through ctest, not just reasoned about.

## `english.db` versus `msime_english.db`

The engine learns English words into `data_file_path("english.db")`. `DictionaryInstaller.mm` replays the English journal into `msime_english.db` and `MutableDictionaryFileNames()` only backs that name up when learned data is reset. The two never meet because nothing on macOS reaches the engine's English paths — that is the whole reason this is latent rather than broken.

This pins that precondition. Wiring up `set_dedicated_english_mode`, `set_english_input_options`, `set_frequency_adjustment` or `set_mixed_expressive_options` now fails here, with a message pointing at the filename, instead of silently orphaning learned English words in a file no macOS code reads, migrates or clears.

## Verification

All three guards were checked against a reverted source and confirmed to fail: showing the shift key in Chinese mode, removing the adapter's uppercase rejection, and wiring up dedicated English mode. `ReleaseConfigurationTests` (15), `ProjectConfigurationTests` (28) and the `apple_input_session_adapter` ctest all pass.
