### PR TITLE
chore: advance the engine, check submodules daily, and auto-merge inert bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 5

--- a/.github/workflows/engine-bump-triage.yml
+++ b/.github/workflows/engine-bump-triage.yml
@@ -1,0 +1,90 @@
+name: Engine bump triage
+
+# Dependabot opens the engine submodule bump; this decides whether it can merge itself.
+#
+# The rule is an allowlist, not a blocklist: the bump merges on green CI only when every file the
+# engine changed across the range is provably inert. Anything else waits for a human. A blocklist
+# would have let the utfcpp bump through, because it appears in the range as a bare submodule
+# pointer rather than as a source file.
+
+on:
+  pull_request:
+    paths:
+      - 'vendor/MetasequoiaImeEngine'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  triage:
+    if: github.actor == 'dependabot[bot]'
+    name: Classify the engine range
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUBMODULE: vendor/MetasequoiaImeEngine
+      ENGINE: metasequoiaime/MSIME-Engine
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve the engine range
+        id: range
+        run: |
+          set -euo pipefail
+          base=$(git rev-parse "origin/${{ github.base_ref }}:$SUBMODULE")
+          head=$(git rev-parse "HEAD:$SUBMODULE")
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$head" >> "$GITHUB_OUTPUT"
+          echo "引擎 $base -> $head"
+
+      - name: Classify the changed files
+        id: classify
+        run: |
+          set -euo pipefail
+          base='${{ steps.range.outputs.base }}'
+          head='${{ steps.range.outputs.head }}'
+          if [ "$base" = "$head" ]; then
+            echo "verdict=inert" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(gh api --paginate "repos/$ENGINE/compare/$base...$head" --jq '.files[].filename')
+          echo "改动文件:"; echo "$files" | sed 's/^/  /'
+
+          # Provably inert: documentation, CI wiring, dependency manifests, licence text. Everything
+          # else - sources, build files, and bare paths such as a nested submodule pointer - needs a
+          # human. Note the trailing anchors: 'utfcpp' matches none of these patterns and so lands
+          # in review, which is the behaviour we want.
+          suspicious=$(echo "$files" | grep -vE '(^|/)[^/]+\.md$|^\.github/|^vcpkg\.json$|^vcpkg-configuration\.json$|^LICENSE$|^\.gitignore$' || true)
+
+          if [ -z "$suspicious" ]; then
+            echo "verdict=inert" >> "$GITHUB_OUTPUT"
+          else
+            echo "verdict=review" >> "$GITHUB_OUTPUT"
+            {
+              echo 'reason<<EOF'
+              echo "$suspicious"
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enable auto-merge
+        if: steps.classify.outputs.verdict == 'inert'
+        run: |
+          set -euo pipefail
+          gh pr merge --auto --squash "$PR_URL"
+          gh pr comment "$PR_URL" --body "引擎 \`${{ steps.range.outputs.base }}\` → \`${{ steps.range.outputs.head }}\` 的改动全部落在文档、CI 配置和依赖清单里，没有源码、构建文件或嵌套 submodule 指针。已开启自动合并，CI 通过后自行合入。"
+
+      - name: Hold for review
+        if: steps.classify.outputs.verdict == 'review'
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_URL" --add-label "needs-review" || true
+          gh pr comment "$PR_URL" --body "$(printf '引擎 `%s` → `%s` 的改动里有需要人看一眼的部分，未开启自动合并：\n\n```\n%s\n```\n\n源码、`CMakeLists.txt` 或嵌套 submodule 指针的变化都可能改变行为，而前端 CI 未必覆盖得到——`helpcode_enabled()` 与 `handle_character()` 的语义变更就是这样漏过去的。' '${{ steps.range.outputs.base }}' '${{ steps.range.outputs.head }}' '${{ steps.classify.outputs.reason }}')"

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -610,7 +610,14 @@ class ReleaseConfigurationTests(unittest.TestCase):
 
         self.assertEqual(dependabot.count('package-ecosystem: "github-actions"'), 1)
         self.assertEqual(dependabot.count('package-ecosystem: "gitsubmodule"'), 1)
-        self.assertEqual(dependabot.count('interval: "monthly"'), 2)
+        # Assert each ecosystem's own interval rather than a total count: counting means changing
+        # either schedule fails on an arithmetic mismatch that says nothing about which one moved.
+        actions_block = dependabot.split('package-ecosystem: "github-actions"', 1)[1].split("- package-ecosystem:", 1)[0]
+        submodule_block = dependabot.split('package-ecosystem: "gitsubmodule"', 1)[1].split("- package-ecosystem:", 1)[0]
+        self.assertIn('interval: "monthly"', actions_block)
+        # The engine submodule moves fast enough that a monthly sweep lets it drift far enough for a
+        # single bump to carry unrelated behaviour changes, which is how #222 landed two regressions.
+        self.assertIn('interval: "daily"', submodule_block)
         self.assertEqual(dependabot.count('prefix: "chore(deps)"'), 2)
         self.assertEqual(submodule_value("vendor/MetasequoiaImeEngine", "path"), "vendor/MetasequoiaImeEngine")
         self.assertEqual(


### PR DESCRIPTION
## What

Engine submodule `8cc306c` -> `55839c8`, eleven commits.

## Why this one is not like #222

I bumped this pin once before and it shipped two regressions, so here is the check I should have run then.

`git diff --name-only 8cc306c origin/main` over the engine matches **zero** `.cpp` / `.h` files. The whole range is:

```
M  .github/workflows/ci.yml
M  .gitmodules
A  AGENTS.md
M  CMakeLists.txt
M  README.md
M  utfcpp
A  vcpkg-configuration.json
```

#222 was different in kind: it crossed the cross-platform rework, which respecified `InputSession::helpcode_enabled()` and made `handle_character()` consume `A-Z` during a composition. Those were behavioural contract changes, and reading the range as "+5162 / -144, deletions are rewrites" did not surface them. There is no engine source in this range at all, so there is no contract to have changed.

## The two things in the range that are not documentation

**`CMakeLists.txt`** — the engine stopped exporting `WIN32_LEAN_AND_MEAN` as a `PUBLIC` compile definition. The block is inside `if(MSVC)`, so it is a no-op here.

**`utfcpp` `65701fe` -> `2d8e20b`** — the one item worth a reviewer's attention. 37 upstream commits touching `source/utf8/{core,checked,unchecked,cpp17}.h`. Mostly `static_cast` hygiene and an internal `validate_next` -> `decode_next` rename, but `checked.h` gains a `throw invalid_utf16` path where malformed UTF-16 previously fell through differently.

The engine uses the checked API — `utf8to32`, `utf16to8`, `utf8to16`, `utf32to8`, `next`, `distance`, `append`, no `utf8::unchecked::` anywhere — so that path is reachable in principle. It is a stricter error on input that was already malformed rather than a change to valid-input behaviour, and the engine's own suite passes against this utfcpp on Ubuntu, Windows and macOS. If something surfaces after this merge, that is the first place to look.

MSIME-Server already carries this utfcpp; it landed between `8cc306c` and `f91cd20`.

## Verification

Range inspected file by file, and the utfcpp delta read through the GitHub compare API rather than assumed from the commit subject. Beyond that this rests on CI here.


---

## 顺带把 dependabot 调成 daily

这个 pin 之所以要人手工追，不是 submodule 机制的问题，是节奏配错了：`gitsubmodule` 的 schedule 是 `monthly`，而 MSIME-Engine 一天大约 15 个 commit。结果是 dependabot 在这个仓库至今开过 **0** 个 submodule PR，每次 pin 前进都靠人注意到再手写——三个前端漂到三个不同 engine commit 的直接原因就是这个。

改成 `daily` 之后最多一天一个 PR。`github-actions` 那块保持 monthly，action 的 pin 没那么频繁。

---

## 让无害的 bump 自己合（新增 workflow）

daily 只解决了滞后，没解决噪音——engine 一天 15 个 commit，三个前端加起来一天 3 个 PR、一周 21 个。所以加一个 triage workflow：dependabot 开的 engine bump PR 进来时，先判断这次 range 里到底改了什么，**只有全部落在可证明无害的路径里才开自动合并**，其余打 `needs-review` 标签并留言说明是哪几个文件卡住的。

用白名单不用黑名单，这个区别是关键：

| range 里的改动 | 结果 |
|---|---|
| `*.md`、`.github/**`、`vcpkg*.json`、`LICENSE`、`.gitignore` | CI 绿 → 自动合 |
| 其余一切（源码、`CMakeLists.txt`、`.gitmodules`、嵌套 submodule 指针） | `needs-review`，等人 |

本 PR 自己就是白名单必要性的例子。它跨的 engine range 里非文档项只有三个：`CMakeLists.txt`、`.gitmodules`，和一个裸的 `utfcpp` submodule 指针。按扩展名做黑名单会直接放行 utfcpp——嵌套 submodule 在 compare API 里是一个没有扩展名、没有 patch 的裸路径。白名单拦得住。

提交前拿两个真实 range 验证过分类器：

```
f91cd20..main  ->  inert（AGENTS.md / README.md / vcpkg-configuration.json）
8cc306c..main  ->  review，卡住的是 CMakeLists.txt、.gitmodules、utfcpp
源码反例       ->  review，卡住的是 quanpin/engine.cpp
```

另外已在三个仓库建好 `needs-review` 标签，并打开 MSIME-Linux 的 `allow_auto_merge`（Apple 和 Server 本来就开着）。
