### PR TITLE
fix(release): wait for the pull request's own checks before merging

### DIFF
--- a/platforms/macos/scripts/merge-release-pr.sh
+++ b/platforms/macos/scripts/merge-release-pr.sh
@@ -75,6 +75,24 @@ if [[ "$(jq -er .state <<< "$current_pr_json")" != OPEN || \
     exit 1
 fi
 
+# The dispatched run above proves this commit builds, but main requires the pull_request checks
+# specifically, and those are a separate set of runs started when the release pull request opened.
+# They normally finish first; wait rather than letting a slow queue abort the release.
+for ((attempt = 1; attempt <= max_polls; ++attempt)); do
+    rollup=$(gh pr view "$pr_number" --repo "$GH_REPO" --json statusCheckRollup \
+        --jq '[.statusCheckRollup[] | select(.conclusion != null or .status != null)]')
+    pending=$(jq -r '[.[] | select((.conclusion // .status) as $s | $s == "QUEUED" or $s == "IN_PROGRESS" or $s == "PENDING" or $s == null)] | length' <<< "$rollup")
+    failed=$(jq -r '[.[] | select((.conclusion // "") as $c | $c == "FAILURE" or $c == "TIMED_OUT" or $c == "CANCELLED" or $c == "ACTION_REQUIRED")] | length' <<< "$rollup")
+    if [[ "$failed" != 0 ]]; then
+        printf '%s\n' "Release PR #$pr_number has a failing check; refusing to merge it." >&2
+        exit 1
+    fi
+    if [[ "$pending" == 0 ]]; then
+        break
+    fi
+    sleep "$poll_interval"
+done
+
 gh pr merge "$pr_number" --repo "$GH_REPO" --squash --delete-branch \
     --match-head-commit "$head_sha" --subject "$title" \
     --body "Automated release PR merge after CI passed."

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -24,7 +24,10 @@ SIGNING_SECRETS = (
 
 
 class ReleaseAutomationTests(unittest.TestCase):
-    def run_merge(self, current_base=BASE_SHA, ci_exit_code="0"):
+    ALL_GREEN = '[{"conclusion":"SUCCESS"},{"conclusion":"SUCCESS"},{"conclusion":"SUCCESS"}]'
+
+    def run_merge(self, current_base=BASE_SHA, ci_exit_code="0", check_rollup=None):
+        check_rollup = self.ALL_GREEN if check_rollup is None else check_rollup
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary = Path(temporary_directory)
             log = temporary / "gh.log"
@@ -34,7 +37,9 @@ class ReleaseAutomationTests(unittest.TestCase):
                 """#!/bin/zsh
 set -euo pipefail
 print -r -- "$*" >> "$FAKE_GH_LOG"
-if [[ "$1 $2" == "pr view" ]]; then
+if [[ "$*" == *statusCheckRollup* ]]; then
+    print -r -- "$FAKE_CHECK_ROLLUP"
+elif [[ "$1 $2" == "pr view" ]]; then
     print -r -- "{\\"number\\":42,\\"state\\":\\"OPEN\\",\\"isDraft\\":false,\\"headRefName\\":\\"release-please--branches--main--components--MetasequoiaImeApple\\",\\"headRefOid\\":\\"$FAKE_HEAD_SHA\\",\\"baseRefName\\":\\"main\\",\\"baseRefOid\\":\\"$FAKE_BASE_SHA\\",\\"title\\":\\"chore(main): release 1.2.3\\"}"
 elif [[ "$1 $2" == "workflow run" ]]; then
     exit 0
@@ -68,6 +73,7 @@ fi
                     "FAKE_BASE_SHA": BASE_SHA,
                     "FAKE_CURRENT_BASE": current_base,
                     "FAKE_CI_EXIT_CODE": ci_exit_code,
+                    "FAKE_CHECK_ROLLUP": check_rollup,
                     "FAKE_HEAD_SHA": HEAD_SHA,
                     "METASEQUOIA_RELEASE_CI_MAX_POLLS": "1",
                     "METASEQUOIA_RELEASE_CI_POLL_INTERVAL": "0",
@@ -98,6 +104,18 @@ fi
         self.assertIn("run watch 9001", calls)
         self.assertNotIn("pr merge 42", calls)
         self.assertEqual(output, "merged=false\n")
+
+    def test_release_pull_request_is_not_merged_when_its_own_checks_fail(self):
+        # main requires the pull_request checks, which are separate runs from the dispatched one this
+        # script watches. Merging on the dispatched run alone would be refused by branch protection.
+        result, calls, output = self.run_merge(
+            check_rollup='[{"conclusion":"SUCCESS"},{"conclusion":"FAILURE"}]'
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("run watch 9001", calls)
+        self.assertNotIn("pr merge 42", calls)
+        self.assertIn("failing check", result.stderr)
 
     def test_release_pull_request_stays_open_when_ci_fails(self):
         result, calls, output = self.run_merge(ci_exit_code="1")

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -284,6 +284,15 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual(used_actions, allowed_actions)
         self.assertIn("steps.release.outputs.release_created", workflow)
         self.assertIn("run: bash platforms/macos/scripts/merge-release-pr.sh", workflow)
+        merge_release_pr_script = (MACOS_ROOT / "scripts/merge-release-pr.sh").read_text()
+        # main requires the pull_request checks, which are a different set of runs from the one this
+        # script dispatches and watches. Merging on the dispatched run alone is refused by the branch
+        # protection whenever the pull_request runs are still queued.
+        self.assertIn("gh pr view \"$pr_number\" --repo \"$GH_REPO\" --json statusCheckRollup", merge_release_pr_script)
+        self.assertLess(
+            merge_release_pr_script.index("statusCheckRollup"),
+            merge_release_pr_script.index("gh pr merge"),
+        )
         self.assertIn("id: merge_release_pr", workflow)
         self.assertIn("id: promote_release_commit", workflow)
         self.assertIn("id: release_branch_before", workflow)


### PR DESCRIPTION
Prerequisite for requiring status checks on `main`.

`merge-release-pr.sh` dispatches `ci.yml`, watches that specific run with `gh run watch --exit-status`, and then merges directly. Once `main` requires the three CI checks, that merge is evaluated against the **pull_request** runs instead — a separate set, started when the release pull request opened.

They normally finish first, so the merge would usually succeed and occasionally abort a release on a slow queue. That is the worst of both: it looks fine until it does not.

After the dispatched run passes, poll the pull request' own check rollup: proceed when nothing is pending, and refuse immediately on a failure rather than waiting out the timeout. The jq predicates were checked against all-green, still-running, failing and empty rollups.

Landing this before protection is enabled, so there is no window where a release can be blocked by the new requirement.