### PR TITLE
feat(ios): add traditional Chinese output

### DIFF
--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -4,6 +4,7 @@ import UIKit
 struct OnboardingView: View {
   @State private var sampleText = ""
   @State private var usesShuangpin = InputSchemePreference.usesShuangpin
+  @State private var usesTraditionalOutput = ChineseOutputPreference.usesTraditional
 
   private let steps = [
     ("1", "打开键盘设置", "前往“设置 → 通用 → 键盘 → 键盘”。"),
@@ -66,6 +67,35 @@ struct OnboardingView: View {
           .onChange(of: usesShuangpin) { newValue in
             InputSchemePreference.usesShuangpin = newValue
           }
+
+          Divider()
+
+          HStack(spacing: 12) {
+            Image(systemName: "character.book.closed")
+              .font(.system(size: 17, weight: .semibold))
+              .foregroundStyle(MetasequoiaTheme.forest)
+              .frame(width: 38, height: 38)
+              .background(MetasequoiaTheme.mist, in: Circle())
+
+            VStack(alignment: .leading, spacing: 3) {
+              Text("输出字形")
+                .font(.headline)
+                .foregroundStyle(MetasequoiaTheme.ink)
+              Text("词库保持简体，仅转换候选和上屏文字")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            }
+          }
+
+          Picker("输出字形", selection: $usesTraditionalOutput) {
+            Text("简体").tag(false)
+            Text("繁体").tag(true)
+          }
+          .pickerStyle(.segmented)
+          .accessibilityIdentifier("chineseOutputPicker")
+          .onChange(of: usesTraditionalOutput) { newValue in
+            ChineseOutputPreference.usesTraditional = newValue
+          }
         }
         .padding(18)
         .background(.background, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
@@ -75,6 +105,7 @@ struct OnboardingView: View {
         }
         .onAppear {
           usesShuangpin = InputSchemePreference.usesShuangpin
+          usesTraditionalOutput = ChineseOutputPreference.usesTraditional
         }
 
         VStack(alignment: .leading, spacing: 10) {

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -23,6 +23,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private var hasComposition = false
   private var isChineseMode = true
   private var usesShuangpin = false
+  private var usesTraditionalOutput = false
+  private var visiblePreedit = ""
+  private var visibleCandidates: [String] = []
   private var showsSymbols = false
   private var letterCaseState = LetterCaseState.lowercase
   private var isAutomaticShift = false
@@ -44,6 +47,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   override func viewDidLoad() {
     super.viewDidLoad()
     usesShuangpin = InputSchemePreference.usesShuangpin
+    usesTraditionalOutput = ChineseOutputPreference.usesTraditional
     if usesShuangpin {
       _ = session.switch(toShuangpin: true)
     }
@@ -56,6 +60,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     synchronizeInputSchemePreference()
+    synchronizeChineseOutputPreference()
   }
 
   override func textWillChange(_ textInput: UITextInput?) {
@@ -482,6 +487,21 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     render(snapshot)
   }
 
+  // The output script may change in the host app while the keyboard is loaded, so it is re-read on
+  // every appearance. Unlike the input scheme it never touches the session, so an active composition
+  // only needs its visible candidates redrawn.
+  private func synchronizeChineseOutputPreference() {
+    let sharedValue = ChineseOutputPreference.usesTraditional
+    guard sharedValue != usesTraditionalOutput else { return }
+
+    usesTraditionalOutput = sharedValue
+    renderCandidateStrip()
+  }
+
+  private func chineseOutput(_ text: String) -> String {
+    ChineseTextConversion.outputString(text, traditional: usesTraditionalOutput)
+  }
+
   private func updateSchemeButton() {
     var configuration = UIButton.Configuration.plain()
     configuration.title = usesShuangpin ? "小鹤" : "全拼"
@@ -577,30 +597,38 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
   private func render(_ snapshot: MetasequoiaInputSnapshot) {
     if let commitText = snapshot.commitText {
-      textDocumentProxy.insertText(commitText)
+      textDocumentProxy.insertText(chineseOutput(commitText))
     }
     hasComposition = !snapshot.preedit.isEmpty
     updateCandidateStrip(preedit: snapshot.preedit, candidates: snapshot.candidates)
   }
 
   private func updateCandidateStrip(preedit: String, candidates: [String]) {
+    visiblePreedit = preedit
+    visibleCandidates = candidates
+    renderCandidateStrip()
+  }
+
+  private func renderCandidateStrip() {
     preeditLabel.text =
-      preedit.isEmpty ? (isChineseMode ? "水杉输入法" : "英文输入") : preedit
+      visiblePreedit.isEmpty ? (isChineseMode ? "水杉输入法" : "英文输入") : visiblePreedit
     for view in candidateStack.arrangedSubviews {
       candidateStack.removeArrangedSubview(view)
       view.removeFromSuperview()
     }
 
-    for (index, candidate) in candidates.prefix(9).enumerated() {
+    for (index, candidate) in visibleCandidates.prefix(9).enumerated() {
       candidateStack.addArrangedSubview(
         makeCandidateButton(candidate: candidate, number: index + 1))
     }
-    candidateScrollView.isHidden = candidates.isEmpty
+    candidateScrollView.isHidden = visibleCandidates.isEmpty
   }
 
+  // Selection stays on the engine index, so only the shown text is converted.
   private func makeCandidateButton(candidate: String, number: Int) -> UIButton {
+    let display = chineseOutput(candidate)
     var configuration = UIButton.Configuration.plain()
-    configuration.title = "\(number)  \(candidate)"
+    configuration.title = "\(number)  \(display)"
     configuration.baseForegroundColor = .label
     configuration.contentInsets = NSDirectionalEdgeInsets(
       top: 4, leading: 9, bottom: 4, trailing: 9)
@@ -616,7 +644,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         self.playInputClick()
         self.render(self.session.selectCandidate(at: UInt(number - 1)))
       })
-    button.accessibilityLabel = "候选词 \(number)：\(candidate)"
+    button.accessibilityLabel = "候选词 \(number)：\(display)"
     button.accessibilityIdentifier = "candidate-\(number)"
     return button
   }

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -25,4 +25,6 @@ The keyboard routes letter input, composition editing, raw/candidate commit, can
 
 The host app exposes the same input-scheme setting as a native segmented control. A changed setting is picked up when the keyboard appears or before the next composition begins; an active composition keeps its original scheme until it is committed or cancelled.
 
+The host app also exposes a simplified/traditional output setting, shared through the same App Group and defaulting to simplified. The engine and the packaged dictionary keep their original simplified strings; only the candidates shown in the keyboard and the text it commits are converted, through Core Foundation's `Simplified-Traditional` transform. Candidate selection continues to use engine indexes, and the preedit is left alone because it carries pinyin rather than Chinese output.
+
 `prepare_dictionary.py` first builds the canonical database, then retains all single-syllable entries and common multi-syllable entries with weight 2000 or greater. The generated database and its SHA-256 sidecar are ignored build artifacts. At runtime the extension atomically installs a changed bundled database into its private writable Application Support directory, keeping dictionary access local without requesting Open Access.

--- a/platforms/ios/SharedUI/ChineseOutputPreference.swift
+++ b/platforms/ios/SharedUI/ChineseOutputPreference.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+// Output script shared by the host app and the keyboard extension. The key is new in the App Group,
+// so unlike the input scheme there is no standard-defaults value to migrate.
+enum ChineseOutputPreference {
+  private static let key = "chineseOutputUsesTraditional"
+
+  static var usesTraditional: Bool {
+    get { defaults.bool(forKey: key) }
+    set { defaults.set(newValue, forKey: key) }
+  }
+
+  private static var defaults: UserDefaults {
+    UserDefaults(suiteName: InputSchemePreference.appGroupIdentifier) ?? .standard
+  }
+}

--- a/platforms/ios/SharedUI/ChineseTextConversion.swift
+++ b/platforms/ios/SharedUI/ChineseTextConversion.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// Renders engine output in the script the user chose. The engine and its dictionary keep their
+// original simplified strings, so only visible candidates and committed text pass through here,
+// matching the macOS render/commit boundary. An empty string or a failed transform returns the
+// original value, so input stays available without a bundled conversion database.
+enum ChineseTextConversion {
+  static func outputString(_ text: String, traditional: Bool) -> String {
+    guard traditional, !text.isEmpty else { return text }
+
+    let buffer = NSMutableString(string: text)
+    guard
+      CFStringTransform(
+        buffer as CFMutableString, nil, "Simplified-Traditional" as CFString, false)
+    else {
+      return text
+    }
+    return buffer as String
+  }
+}

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -18,6 +18,11 @@ final class OnboardingUITests: XCTestCase {
     XCTAssertTrue(schemePicker.buttons["全拼"].exists)
     XCTAssertTrue(schemePicker.buttons["小鹤双拼"].exists)
 
+    let outputPicker = app.segmentedControls["chineseOutputPicker"]
+    XCTAssertTrue(outputPicker.exists)
+    XCTAssertTrue(outputPicker.buttons["简体"].exists)
+    XCTAssertTrue(outputPicker.buttons["繁体"].exists)
+
     let tryoutField = app.textFields["keyboardTryoutField"]
     XCTAssertTrue(tryoutField.exists)
     tryoutField.tap()

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -12,6 +12,10 @@ settings:
     MARKETING_VERSION: 0.1.0
     SWIFT_VERSION: 6.0
     IPHONEOS_DEPLOYMENT_TARGET: 15.0
+    # Xcode 26 no longer falls back to the target name when a target leaves PRODUCT_NAME unset, so a
+    # target without it links as a bare `-l` and builds products named `.xctest` or `-Runner.app`.
+    # Targets that publish a different product name still override this below.
+    PRODUCT_NAME: $(TARGET_NAME)
 
 targets:
   MetasequoiaAppleBridge:

--- a/platforms/ios/scripts/create_compact_dictionary.py
+++ b/platforms/ios/scripts/create_compact_dictionary.py
@@ -30,7 +30,10 @@ def compact_dictionary(source_path, output_path, minimum_weight):
     temporary_path.unlink(missing_ok=True)
 
     source = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True)
-    output = sqlite3.connect(temporary_path)
+    # ATTACH only interprets a file: URI when the connection was itself opened with URI handling.
+    # Some sqlite builds enable it globally and some do not, so ask for it here instead of relying
+    # on the interpreter's sqlite compile options.
+    output = sqlite3.connect(temporary_path.resolve().as_uri(), uri=True)
     try:
         output.execute("PRAGMA journal_mode=OFF")
         output.execute("PRAGMA synchronous=OFF")

--- a/platforms/ios/tests/ChineseTextConversionTests.swift
+++ b/platforms/ios/tests/ChineseTextConversionTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+private func expect(
+  _ expected: String,
+  _ text: String,
+  traditional: Bool,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  let actual = ChineseTextConversion.outputString(text, traditional: traditional)
+  precondition(
+    actual == expected,
+    "Expected \(expected) for \(text) with traditional \(traditional), got \(actual)",
+    file: file,
+    line: line)
+}
+
+@main
+struct ChineseTextConversionTests {
+  static func main() {
+    expect("水杉输入法", "水杉输入法", traditional: false)
+    expect("水杉輸入法", "水杉输入法", traditional: true)
+
+    expect("", "", traditional: true)
+    expect("metasequoia", "metasequoia", traditional: true)
+    expect("，。！", "，。！", traditional: true)
+
+    // Already-traditional and mixed text stays readable instead of being mangled.
+    expect("輸入法", "輸入法", traditional: true)
+    expect("輸入 abc 法", "输入 abc 法", traditional: true)
+  }
+}

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -66,6 +66,54 @@ class ProjectConfigurationTests(unittest.TestCase):
             )
             subprocess.run([str(executable)], check=True)
 
+    def test_chinese_output_conversion(self):
+        conversion = IOS_ROOT / "SharedUI/ChineseTextConversion.swift"
+        tests = IOS_ROOT / "tests/ChineseTextConversionTests.swift"
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            executable = Path(temporary_directory) / "ChineseTextConversionTests"
+            subprocess.run(
+                ["swiftc", str(conversion), str(tests), "-o", str(executable)],
+                check=True,
+            )
+            subprocess.run([str(executable)], check=True)
+
+    def test_host_and_keyboard_share_the_chinese_output_script(self):
+        preference = (IOS_ROOT / "SharedUI/ChineseOutputPreference.swift").read_text()
+        onboarding = (IOS_ROOT / "App/Sources/OnboardingView.swift").read_text()
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn('private static let key = "chineseOutputUsesTraditional"', preference)
+        self.assertIn("UserDefaults(suiteName: InputSchemePreference.appGroupIdentifier)", preference)
+
+        self.assertIn(
+            "@State private var usesTraditionalOutput = ChineseOutputPreference.usesTraditional",
+            onboarding,
+        )
+        self.assertIn('Picker("输出字形", selection: $usesTraditionalOutput)', onboarding)
+        self.assertIn('Text("简体").tag(false)', onboarding)
+        self.assertIn('Text("繁体").tag(true)', onboarding)
+        self.assertIn('.accessibilityIdentifier("chineseOutputPicker")', onboarding)
+        self.assertIn("ChineseOutputPreference.usesTraditional = newValue", onboarding)
+
+        self.assertIn("usesTraditionalOutput = ChineseOutputPreference.usesTraditional", controller)
+        self.assertIn("synchronizeChineseOutputPreference()", controller)
+
+    def test_only_visible_candidates_and_commits_change_script(self):
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        # The engine and the packaged dictionary stay simplified, so conversion belongs at the
+        # render and commit boundary only. Converting the preedit would rewrite pinyin, and
+        # converting before selection would break the engine index the candidate chips carry.
+        self.assertIn("textDocumentProxy.insertText(chineseOutput(commitText))", controller)
+        self.assertIn("let display = chineseOutput(candidate)", controller)
+        self.assertIn('configuration.title = "\\(number)  \\(display)"', controller)
+        self.assertIn("self.render(self.session.selectCandidate(at: UInt(number - 1)))", controller)
+
+        strip = controller.split("private func renderCandidateStrip", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("visiblePreedit", strip)
+        self.assertNotIn("chineseOutput(visiblePreedit)", strip)
+
     def test_backspace_repeats_only_while_the_delete_key_is_held(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
@@ -87,6 +135,19 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("UIDevice.current.playInputClick()", controller)
         self.assertIn("private func playInputClick()", controller)
         self.assertGreaterEqual(controller.count("playInputClick()"), 9)
+
+    def test_every_target_resolves_a_product_name(self):
+        # Xcode 26 stopped defaulting PRODUCT_NAME to the target name. Without the project-level
+        # fallback the bridge library links as a bare `-l` that swallows the next linker flag, and
+        # the UI-test target builds `.xctest` inside `-Runner.app`, which collide in the products
+        # directory. Both failures only appear at link and test time, so pin the setting here.
+        project = (IOS_ROOT / "project.yml").read_text()
+
+        self.assertIn("PRODUCT_NAME: $(TARGET_NAME)", project)
+        self.assertLess(
+            project.index("PRODUCT_NAME: $(TARGET_NAME)"),
+            project.index("targets:"),
+        )
 
     def test_project_defines_distinct_host_and_keyboard_identifiers(self):
         project = (IOS_ROOT / "project.yml").read_text()
@@ -185,9 +246,9 @@ class ProjectConfigurationTests(unittest.TestCase):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
         self.assertIn("makeCandidateButton(candidate: candidate, number: index + 1)", controller)
-        self.assertIn('configuration.title = "\\(number)  \\(candidate)"', controller)
+        self.assertIn('configuration.title = "\\(number)  \\(display)"', controller)
         self.assertIn("configuration.background.cornerRadius", controller)
-        self.assertIn('button.accessibilityLabel = "候选词 \\(number)：\\(candidate)"', controller)
+        self.assertIn('button.accessibilityLabel = "候选词 \\(number)：\\(display)"', controller)
 
     def test_apostrophe_reaches_the_engine_before_punctuation_conversion(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()


### PR DESCRIPTION
## Traditional Chinese output

The iOS host app gains a simplified/traditional output setting beside the input scheme, shared with the keyboard extension through the existing App Group and defaulting to simplified. It closes the parity gap with the macOS frontend, which already offers the switch through its input menu and floating toolbar.

The engine and the packaged dictionary keep their original simplified strings. Only the candidates the keyboard shows and the text it commits are converted, through Core Foundation's `Simplified-Traditional` transform — the same render/commit boundary the macOS frontend uses, and no new runtime dependency. Candidate selection still uses engine indexes, and the preedit is left alone because it carries pinyin rather than Chinese output. The keyboard re-reads the setting whenever it appears and redraws the visible candidates, so a change made in the host app does not require cancelling a composition.

The switch lives in the host app only. The candidate bar already carries the `中`/`英` and `全拼`/`小鹤` controls, and a third control would take roughly a third of the bar's width away from candidates on a 320pt screen.

## Two build fixes found while verifying this

Neither is caused by the feature; both blocked verification on a current Xcode and are fixed here rather than left for the next person.

- Xcode 26 stopped falling back to the target name when a target leaves `PRODUCT_NAME` unset. The bridge library then linked as a bare `-l` that swallowed the following linker flag, so the keyboard extension failed to link, and the UI-test target produced `.xctest` inside `-Runner.app`, whose paths collide in the products directory. Restoring the historical `$(TARGET_NAME)` default at the project level fixes both; targets that publish another product name still override it.
- `ATTACH` only interprets a `file:` URI when the connection itself was opened with URI handling enabled. Some sqlite builds turn that on globally and some do not, so `prepare_dictionary.py` and `DictionaryPackagingTests` failed with "unable to open database" on interpreters whose sqlite leaves it off.

## Verification

- `python3 platforms/ios/tests/ProjectConfigurationTests.py` — 32 tests, including the new conversion unit test compiled with `swiftc` and the wiring assertions for the shared preference and the render/commit boundary
- `python3 platforms/ios/tests/DictionaryPackagingTests.py`
- `xcodebuild ... -sdk iphonesimulator build` for the host app and keyboard extension
- `bash platforms/ios/scripts/run_ui_tests.sh` — the onboarding test now also asserts the 简体/繁体 picker

The keyboard extension's converted output was not exercised end to end on a simulator; enabling a third-party keyboard is outside what the existing UI test setup does. The conversion itself is unit tested and its call sites are asserted.
