### PR TITLE
Ship the locked release dictionary instead of rebuilding a subset of it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
         run: if brew tap | grep -Fxq aws/tap; then brew untap aws/tap; fi
       - name: Install dependencies
         run: brew install boost fmt spdlog
+      - name: Validate the product lock
+        run: python3 scripts/product_lock.py validate
+      # The unit tests run against a fixture rather than the released database: they assert behaviour
+      # around composition, not dictionary content, and downloading 100 MB per run to do it would buy
+      # nothing. The release build is what verifies the real data, against the digests in the lock.
       - name: Create test dictionary
         run: python3 platforms/macos/tests/create_fixture_dictionary.py "$RUNNER_TEMP/msime.db"
       - name: Type-check registration helper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,8 +208,8 @@ jobs:
           security list-keychains -d user -s "$keychain"
           security default-keychain -s "$keychain"
           xcrun notarytool store-credentials metasequoia-notary --keychain "$keychain" --apple-id "$NOTARY_APPLE_ID" --team-id "$NOTARY_TEAM_ID" --password "$NOTARY_PASSWORD"
-      - name: Build dictionary
-        run: python3 platforms/macos/scripts/build_dictionary.py
+      - name: Fetch the locked dictionary
+        run: python3 scripts/fetch_dictionary.py
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(METASEQUOIA_IME_BUILD_INPUT_METHOD)
         message(FATAL_ERROR "The InputMethodKit bundle can only be built on macOS.")
     endif()
     if(NOT EXISTS "${METASEQUOIA_IME_DICTIONARY}")
-        message(FATAL_ERROR "Dictionary not found at ${METASEQUOIA_IME_DICTIONARY}. Run platforms/macos/scripts/build_dictionary.py first.")
+        message(FATAL_ERROR "Dictionary not found at ${METASEQUOIA_IME_DICTIONARY}. Run scripts/fetch_dictionary.py first.")
     endif()
 
     file(SHA256 "${METASEQUOIA_IME_DICTIONARY}" METASEQUOIA_IME_DICTIONARY_SHA256)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ brew install cmake boost fmt spdlog
 ./platforms/macos/scripts/build.sh
 ```
 
-词库构建会从官方源数据生成 `vendor/MetasequoiaImeDict/out/msime.db`。该数据库文件有意不纳入版本库。
+构建脚本会下载 `product-lock.json` 锁定的那个 MSIME-Dict release，逐个校验 SHA256，再放到 `vendor/MetasequoiaImeDict/out/msime.db`。该数据库文件有意不纳入版本库。Windows 和 Linux 取的是同一份产物，所以三个平台分发的 `msime.db` 逐字节一致。
+
+换用新的词库版本：`python3 scripts/product_lock.py refresh --dictionary-tag dict-YYYY.MM.DD`，然后 review 产生的 diff。
+
+只有在改动词库源数据、需要在发布前看到结果时，才用 `python3 platforms/macos/scripts/build_dictionary.py` 从源码构建。
 
 ## 为当前用户安装
 

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -10,7 +10,7 @@ https://github.com/metasequoiaime/MSIME-Engine
 The application also incorporates the following components:
 
 - googlepinyinime-rev — Apache License 2.0
-  https://github.com/metasequoiaime/googlepinyinime-rev
+  https://github.com/metasequoiaime/Google-PinyinIME-Rev
 - utfcpp — Boost Software License 1.0
   https://github.com/nemtrif/utfcpp
 - Boost C++ Libraries — Boost Software License 1.0
@@ -26,3 +26,37 @@ The application also incorporates the following components:
 
 Complete license texts for these components are included alongside this
 notice in the application's Resources/Licenses directory.
+
+
+Dictionary and helpcode data
+============================
+
+The application installs data built from these repositories:
+
+  MSIME-Dict       https://github.com/metasequoiaime/MSIME-Dict
+  MSIME-HelpCode   https://github.com/metasequoiaime/MSIME-HelpCode
+
+Installed as msime.db and helpcodes/*.txt in the application's Resources directory. The database is the one MSIME-Dict publishes as a release asset; product-lock.json in this repository names the release and records the SHA256 of every file taken from it.
+
+Neither repository declares a license of its own, because most of their content is not their own work. They aggregate word lists and code tables from upstream projects. The upstream terms, which travel with the data, are as follows.
+
+Sources of msime.db, via MSIME-Dict:
+
+  rime-ice                GPL-3.0    https://github.com/iDvel/rime-ice
+  CustomPinyinDictionary  none       https://github.com/wuhgit/CustomPinyinDictionary
+  pinyin-data             MIT        https://github.com/mozillazg/pinyin-data
+  rime-wubi86-jidian      Apache-2.0 https://github.com/KyleBing/rime-wubi86-jidian
+  rime-jp_sela            none       https://github.com/Selaube/rime-jp_sela
+
+The Chinese tables that msime.db is built from (cn/BaseDictAllV1Part1.txt and cn/BaseDictAllV1Part2.txt) merge rime-ice with CustomPinyinDictionary. rime-ice is licensed under the GNU General Public License version 3, which is the same license this application is distributed under, so its terms are satisfied by the distribution as a whole; this notice serves as its attribution, and its source remains available at the URL above. The quick phrase table is written by the Metasequoia IME maintainers and is covered by that same license.
+
+Sources of helpcodes/*.txt, via MSIME-HelpCode:
+
+  helpcode.txt                    lantian      蓝天小雨点 helpcode scheme
+  zrm_helpcode_big_unique.txt     ziranma      自然码, derived from
+                                               https://github.com/copperay/ZRM_Aux-code
+  shouyou2_0_helpcode.txt         shouyou2_0   首右 2.0 helpcode scheme
+  shouyouplus_helpcode.txt        shouyouplus  首右 plus helpcode scheme
+  xiaohe_helpcode.txt             xiaohe       小鹤 shape-code scheme
+
+Unresolved: CustomPinyinDictionary, rime-jp_sela and ZRM_Aux-code publish no license, and the helpcode tables reproduce input schemes whose rights belong to their respective authors. Redistributors who need an explicit grant for those parts should raise it with the Metasequoia IME maintainers rather than assume one. This notice will be updated as those terms are clarified.

--- a/platforms/ios/scripts/prepare_dictionary.py
+++ b/platforms/ios/scripts/prepare_dictionary.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Build the canonical dictionary and package its compact iOS variant."""
+"""Fetch the canonical dictionary and package its compact iOS variant.
+
+This used to build the database from the vendored sources. It now takes the same released, digest-verified msime.db the macOS bundle ships, so the compact iOS variant is derived from exactly the data the other platforms use rather than from a locally rebuilt approximation of it.
+"""
 
 import subprocess
 from pathlib import Path
@@ -14,7 +17,7 @@ IOS_DICTIONARY = (
 
 def main():
     subprocess.run(
-        ["python3", "platforms/macos/scripts/build_dictionary.py"],
+        ["python3", "scripts/fetch_dictionary.py"],
         cwd=REPOSITORY_ROOT,
         check=True,
     )

--- a/platforms/macos/scripts/build.sh
+++ b/platforms/macos/scripts/build.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 project_root=${0:A:h:h:h:h}
-python3 "$project_root/platforms/macos/scripts/build_dictionary.py"
+# Take the released database rather than rebuilding it, so a local build ships what a release ships. Use platforms/macos/scripts/build_dictionary.py instead when you are changing dictionary sources.
+python3 "$project_root/scripts/fetch_dictionary.py"
 cmake -S "$project_root" -B "$project_root/build" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
 cmake --build "$project_root/build" --parallel
 ctest --test-dir "$project_root/build" --output-on-failure --timeout 20

--- a/platforms/macos/scripts/build_dictionary.py
+++ b/platforms/macos/scripts/build_dictionary.py
@@ -1,42 +1,69 @@
 #!/usr/bin/env python3
+"""Build msime.db from the vendored MSIME-Dict sources, for local development only.
 
+Releases do not use this. They run scripts/fetch_dictionary.py, which takes the database MSIME-Dict published and holds it to the digests in product-lock.json, so that macOS ships the same bytes as Windows and Linux. Reach for this script only when you are changing dictionary sources and need to see the result before it is released.
+
+It used to drive the MSIME-Dict step scripts directly, and ran two of the four stages that write into msime.db: the quick-phrase and Japanese lexicon tables were simply absent from every macOS build. build_all.py in MSIME-Dict is the authoritative pipeline and knows the full stage list and its ordering, so delegate to it rather than keeping a second, partial copy of that knowledge here.
+
+    python3 platforms/macos/scripts/build_dictionary.py
+
+The Japanese lexicon stage needs a reference checkout that is not vendored here; pass --fetch-references through to build_all.py to have it clone what it needs.
+"""
+
+from __future__ import annotations
+
+import argparse
 import sqlite3
 import subprocess
+import sys
 from pathlib import Path
-
 
 ROOT = Path(__file__).resolve().parents[3]
 DICTIONARY_ROOT = ROOT / "vendor" / "MetasequoiaImeDict"
+BUILD_ALL = DICTIONARY_ROOT / "build_all.py"
 OUTPUT = DICTIONARY_ROOT / "out" / "msime.db"
-QUANPIN_BUILD_SCRIPTS = DICTIONARY_ROOT / "makecikudb" / "quanpindb" / "makedb" / "multi_table_has_jp"
-WUBI_BUILD_SCRIPTS = DICTIONARY_ROOT / "makecikudb" / "wubi86db" / "makedb"
+
+# The stages build_all.py writes into msime.db. The bundle installs no other database, so the
+# english.db and others.db stages are skipped rather than built and thrown away.
+STAGES = ("quanpin", "wubi", "quick-phrases", "japanese-lexicon")
 
 
-def main() -> None:
-    if not QUANPIN_BUILD_SCRIPTS.is_dir() or not WUBI_BUILD_SCRIPTS.is_dir():
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--fetch-references",
+        action="store_true",
+        help="let build_all.py clone the reference checkouts its stages need",
+    )
+    args = parser.parse_args()
+
+    if not BUILD_ALL.is_file():
         raise SystemExit("Dictionary sources are missing. Run git submodule update --init --recursive first.")
 
-    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT.unlink(missing_ok=True)
-    for script in ("create_db_and_table.py", "insert_data.py", "create_index_for_db.py"):
-        subprocess.run(["python3", str(QUANPIN_BUILD_SCRIPTS / script)], cwd=DICTIONARY_ROOT, check=True)
-    for script in ("01create_table.py", "03insert_data.py", "02create_index.py"):
-        subprocess.run(["python3", str(WUBI_BUILD_SCRIPTS / script)], cwd=DICTIONARY_ROOT, check=True)
+    command = [sys.executable, str(BUILD_ALL), "--only", *STAGES, "--require-all"]
+    if args.fetch_references:
+        command.append("--fetch-references")
+    subprocess.run(command, cwd=DICTIONARY_ROOT, check=True)
 
     with sqlite3.connect(OUTPUT) as database:
         integrity = database.execute("PRAGMA integrity_check").fetchone()
-        candidate = database.execute("SELECT value FROM tbl_2_n WHERE key = ? ORDER BY weight DESC LIMIT 1", ("ni'hao",)).fetchone()
+        candidate = database.execute(
+            "SELECT value FROM tbl_2_n WHERE key = ? ORDER BY weight DESC LIMIT 1", ("ni'hao",)
+        ).fetchone()
+        quick_phrase = database.execute(
+            "SELECT value FROM quick_parases WHERE key = ? ORDER BY weight DESC,value LIMIT 1", ("yyds",)
+        ).fetchone()
         wubi_candidate = database.execute(
             "SELECT value FROM wubi86 WHERE key = ? ORDER BY weight DESC LIMIT 1", ("aaaa",)
         ).fetchone()
-    if integrity != ("ok",) or candidate is None or wubi_candidate is None:
-        OUTPUT.unlink(missing_ok=True)
+    if integrity != ("ok",) or candidate is None or quick_phrase != ("永远滴神",) or wubi_candidate is None:
         raise SystemExit("Generated dictionary failed integrity or candidate verification.")
     print(
         f"Generated {OUTPUT} ({OUTPUT.stat().st_size} bytes), "
-        f"ni'hao -> {candidate[0]}, aaaa -> {wubi_candidate[0]}"
+        f"ni'hao -> {candidate[0]}, yyds -> {quick_phrase[0]}, aaaa -> {wubi_candidate[0]}"
     )
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/product-lock.json
+++ b/product-lock.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "dictionary": {
+    "repository": "metasequoiaime/MSIME-Dict",
+    "tag": "dict-2026.09.05",
+    "assets": {
+      "msime.db": "9e68e88be036206fc14d44db7111376b1d92f9173b04d623e601e31edd664c2f",
+      "SHA256SUMS.txt": "32a9a5272926573c98ba9c81dd50b81ec24410fa2cc3716e6a832bf547a87f41"
+    }
+  }
+}

--- a/scripts/fetch_dictionary.py
+++ b/scripts/fetch_dictionary.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fetch the dictionary the product lock names and verify it against the committed digests.
+
+This used to be built here, by platforms/macos/scripts/build_dictionary.py, which ran two of the four MSIME-Dict stages that write into msime.db. The bundle therefore shipped a database without the quick-phrase and Japanese lexicon tables that MSIME-Windows and MSIME-Linux ship, from a submodule pin that was five commits behind the released tag, with no digest to catch either. Nothing reported it, because a smaller database is still a valid one.
+
+MSIME-Dict publishes msime.db and SHA256SUMS.txt as release assets and both other platforms already take them from there, so take them here too. That is what makes the claim in MSIME-Linux/scripts/fetch_dictionary.py true: all three platforms ship a byte-identical msime.db.
+
+The release tag cannot be overridden from the command line. product-lock.json names it and records the SHA256 of every asset, so a retagged release or a replaced database fails the build instead of shipping: rewriting the upstream SHA256SUMS.txt along with the data does not help, because that file is verified against a committed digest too. Move to a new release with `python3 scripts/product_lock.py refresh --dictionary-tag dict-YYYY.MM.DD` and review the resulting diff.
+
+    python3 scripts/fetch_dictionary.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import product_lock
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Unchanged from when the database was built here, so the METASEQUOIA_IME_DICTIONARY default in
+# CMakeLists.txt keeps working without edits.
+OUTPUT_DIR = ROOT / "vendor" / "MetasequoiaImeDict" / "out"
+
+
+def verify_contents(destination: Path) -> None:
+    """The digests prove we got what was reviewed; these probes prove it is usable.
+
+    The quick-phrase probe is the one that would have caught the old build: quick_parases is written by a stage platforms/macos/scripts/build_dictionary.py never ran.
+    """
+    main_db = destination / "msime.db"
+
+    with sqlite3.connect(main_db) as database:
+        integrity = database.execute("PRAGMA integrity_check").fetchone()
+        candidate = database.execute(
+            "SELECT value FROM tbl_2_n WHERE key = ? ORDER BY weight DESC LIMIT 1", ("ni'hao",)
+        ).fetchone()
+        quick_phrase = database.execute(
+            "SELECT value FROM quick_parases WHERE key = ? ORDER BY weight DESC,value LIMIT 1", ("yyds",)
+        ).fetchone()
+        wubi_candidate = database.execute(
+            "SELECT value FROM wubi86 WHERE key = ? ORDER BY weight DESC LIMIT 1", ("aaaa",)
+        ).fetchone()
+
+    if (
+        integrity != ("ok",)
+        or candidate is None
+        or quick_phrase != ("永远滴神",)
+        or wubi_candidate is None
+    ):
+        raise SystemExit("Downloaded dictionary failed integrity or candidate verification.")
+
+    print(
+        f"{main_db.name} ({main_db.stat().st_size} bytes), "
+        f"ni'hao -> {candidate[0]}, yyds -> {quick_phrase[0]}, aaaa -> {wubi_candidate[0]}"
+    )
+
+
+def main() -> None:
+    data = product_lock.load()
+    tag = data["dictionary"]["tag"]
+    print(f"Fetching {tag} from {data['dictionary']['repository']}")
+
+    # Everything is verified in a staging directory first. A failed or tampered download then leaves a previous usable checkout untouched instead of half replacing it. The staging directory sits inside the output directory because that path is gitignored and on the same filesystem, so it neither dirties the submodule checkout around it nor copies across devices.
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=OUTPUT_DIR) as temporary:
+        incoming = Path(temporary)
+        product_lock.download_assets(tag, incoming)
+        product_lock.verify_assets(incoming, data)
+        print(f"verified {len(product_lock.ASSETS)} assets against product-lock.json")
+        verify_contents(incoming)
+        for name in product_lock.ASSETS:
+            shutil.copyfile(incoming / name, OUTPUT_DIR / name)
+    print(f"staged into {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/product_lock.py
+++ b/scripts/product_lock.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Maintain and consume the reviewed Apple product dependency lock.
+
+This mirrors MSIME-Linux/scripts/product_lock.py deliberately, so the two can be diffed. The only intended difference is the asset set: the macOS bundle installs msime.db and nothing else, so others.db and english.db are not locked here. Add them here and to CMakeLists.txt together if the bundle ever ships them.
+
+The engine, helpcode and dictionary *source* pins are gitlinks. Git already makes those immutable and shows every move in a pull request diff, so they are not copied into this lock: doing that would only give the submodule pin a second home to drift from.
+
+The dictionary the bundle actually *ships* is the one input git does not pin. It is a release asset behind a tag that upstream can retag, and the SHA256SUMS.txt published beside it is exactly as mutable as the data. So product-lock.json holds the tag and the SHA256 of every asset, and the build verifies those committed digests instead.
+
+`refresh` is the only command that reaches upstream. `manifest` records what a build consumed: the source commit, every gitlink, the locked dictionary and the digest of the lock itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REPOSITORY = "metasequoiaime/MSIME-Apple"
+DICTIONARY_REPOSITORY = "metasequoiaime/MSIME-Dict"
+
+# Every gitlink this repository builds from. The manifest reads their commits here rather than from
+# a second copy in the lock, so there is one source of truth for what was checked out.
+SUBMODULES = {
+    "engine": ("metasequoiaime/MSIME-Engine", "vendor/MetasequoiaImeEngine"),
+    "helpcode": ("metasequoiaime/MSIME-HelpCode", "vendor/MetasequoiaImeHelpCode"),
+    "dict": (DICTIONARY_REPOSITORY, "vendor/MetasequoiaImeDict"),
+}
+
+# The database CMakeLists.txt installs into the bundle, plus the checksum file the release publishes
+# beside it. The checksum file is locked too so a rewritten one is caught rather than trusted.
+DATABASES = ("msime.db",)
+ASSETS = (*DATABASES, "SHA256SUMS.txt")
+
+SHA = re.compile(r"[0-9a-f]{40}\Z")
+DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+TAG = re.compile(r"dict-[A-Za-z0-9._-]+\Z")
+
+
+def validate(data: dict) -> dict:
+    if data.get("schema_version") != 1:
+        raise ValueError("Unsupported product lock schema_version")
+    dictionary = data.get("dictionary", {})
+    if dictionary.get("repository") != DICTIONARY_REPOSITORY:
+        raise ValueError("Unexpected dictionary repository")
+    if not TAG.fullmatch(dictionary.get("tag", "")):
+        raise ValueError("Dictionary tag must be an explicit dict-* release, never latest")
+    assets = dictionary.get("assets", {})
+    if set(assets) != set(ASSETS):
+        raise ValueError("Dictionary lock must cover every shipped database and the checksum file")
+    for name, digest in assets.items():
+        if not DIGEST.fullmatch(digest):
+            raise ValueError(f"Invalid SHA256 for {name}")
+    return data
+
+
+def load(path: Path = ROOT / "product-lock.json") -> dict:
+    return validate(json.loads(path.read_text(encoding="utf-8")))
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_assets(directory: Path, data: dict) -> None:
+    """Fail on the committed digest, never on the checksum file that shipped with the data."""
+    for name, expected in data["dictionary"]["assets"].items():
+        path = directory / name
+        if not path.is_file():
+            raise ValueError(f"Locked dictionary asset is missing: {name}")
+        actual = sha256(path)
+        if actual != expected:
+            raise ValueError(f"{name} does not match the product lock: expected {expected}, got {actual}")
+
+
+def download_assets(tag: str, destination: Path) -> None:
+    """Plain HTTPS rather than the GitHub CLI or the API.
+
+    The release assets of a public repository are served unauthenticated from a CDN, so this needs no credentials and stays off the API and its rate limits.
+    """
+    if not TAG.fullmatch(tag):
+        raise ValueError("Refusing to download from a tag that is not an explicit dict-* release")
+    destination.mkdir(parents=True, exist_ok=True)
+    for name in ASSETS:
+        url = f"https://github.com/{DICTIONARY_REPOSITORY}/releases/download/{tag}/{name}"
+        target = destination / name
+        last_error: Exception | None = None
+        for attempt in range(1, 4):
+            try:
+                with urllib.request.urlopen(url, timeout=120) as response, target.open("wb") as out:
+                    while chunk := response.read(1 << 20):
+                        out.write(chunk)
+                break
+            except (urllib.error.URLError, TimeoutError, OSError) as error:
+                last_error = error
+                print(f"  attempt {attempt} for {name} failed: {error}")
+        else:
+            raise ValueError(f"Could not download {url}: {last_error}")
+        print(f"downloaded {name} ({target.stat().st_size} bytes)")
+
+
+def published_checksums(directory: Path) -> dict[str, str]:
+    checksums = {}
+    for line in (directory / "SHA256SUMS.txt").read_text(encoding="utf-8").splitlines():
+        digest, _, name = line.partition("  ")
+        if name.strip():
+            checksums[name.strip()] = digest.strip()
+    return checksums
+
+
+def git(directory: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(directory), *args], text=True).strip()
+
+
+def gitlinks(directory: Path) -> dict:
+    submodules = {}
+    for name, (repository, path) in SUBMODULES.items():
+        fields = git(directory, "ls-tree", "HEAD", path).split()
+        if len(fields) != 4 or fields[0] != "160000" or not SHA.fullmatch(fields[2]):
+            raise ValueError(f"{path} is not a gitlink at an immutable commit in HEAD")
+        submodules[name] = {"repository": repository, "path": path, "commit": fields[2]}
+    return submodules
+
+
+def manifest(directory: Path, commit: str, lock: Path, data: dict) -> dict:
+    if not SHA.fullmatch(commit):
+        raise ValueError("The source commit must be a full immutable SHA")
+    return {
+        "schema_version": 1,
+        "source": {"repository": REPOSITORY, "commit": commit},
+        "submodules": gitlinks(directory),
+        "dictionary": data["dictionary"],
+        "lock_sha256": sha256(lock),
+    }
+
+
+def refresh(tag: str) -> dict:
+    """Resolve the digests of a dictionary release so a human can review the diff before it ships.
+
+    Trusting the published SHA256SUMS.txt is appropriate here and only here: this is the one moment the data is looked at deliberately, and the digests it produces are what every later build is held to.
+    """
+    if not TAG.fullmatch(tag):
+        raise ValueError("refresh requires an explicit dict-* release tag")
+    with tempfile.TemporaryDirectory() as temporary:
+        incoming = Path(temporary)
+        download_assets(tag, incoming)
+        published = published_checksums(incoming)
+        assets = {}
+        for name in ASSETS:
+            digest = sha256(incoming / name)
+            if name in published and published[name] != digest:
+                raise ValueError(f"{name} does not match the checksums published with {tag}")
+            assets[name] = digest
+        for name in DATABASES:
+            if name not in published:
+                raise ValueError(f"{name} has no entry in the SHA256SUMS.txt published with {tag}")
+    print(f"locked {len(assets)} assets from {DICTIONARY_REPOSITORY} at {tag}")
+    return validate({
+        "schema_version": 1,
+        "dictionary": {"repository": DICTIONARY_REPOSITORY, "tag": tag, "assets": assets},
+    })
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--lock", type=Path, default=ROOT / "product-lock.json")
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("validate")
+    commands.add_parser("tag")
+    verify = commands.add_parser("verify-dictionaries")
+    verify.add_argument("directory", type=Path)
+    record = commands.add_parser("manifest")
+    record.add_argument("--source-commit", required=True)
+    record.add_argument("--repository", type=Path, default=ROOT)
+    record.add_argument("--output", type=Path, required=True)
+    update = commands.add_parser("refresh")
+    update.add_argument("--dictionary-tag", required=True)
+    args = parser.parse_args()
+
+    if args.command == "refresh":
+        write_json(args.lock, refresh(args.dictionary_tag))
+        return
+
+    data = load(args.lock)
+    if args.command == "tag":
+        print(data["dictionary"]["tag"])
+    elif args.command == "verify-dictionaries":
+        verify_assets(args.directory, data)
+    elif args.command == "manifest":
+        write_json(args.output, manifest(args.repository, args.source_commit, args.lock, data))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, KeyError, OSError, subprocess.CalledProcessError) as error:
+        raise SystemExit(str(error)) from error


### PR DESCRIPTION
## The defect

`platforms/macos/scripts/build_dictionary.py` built `msime.db` by driving the MSIME-Dict step scripts directly. It ran two of the four stages that write into that database:

| | stages that write msime.db | source | digest check |
|---|---|---|---|
| MSIME-Windows | released asset | `dict-2026.09.05` | SHA256 against `product-lock.json` |
| MSIME-Linux | released asset | `dict-2026.09.05` | SHA256 against `product-lock.json` |
| MSIME-Apple (before) | `quanpin`, `wubi` | submodule at `dict-2026.09.05~5` | none |

`build_all.py --list` in MSIME-Dict shows the full set: `quanpin`, `wubi`, `quick-phrases`, `japanese-lexicon`. So every macOS build shipped a database with no quick-phrase table and no Japanese lexicon table, from a pin five commits behind the released tag, and nothing reported it — a smaller database is still a valid one.

## What changed

- `product-lock.json` and `scripts/product_lock.py` name the dictionary release and record the SHA256 of every asset taken from it. The script mirrors `MSIME-Linux/scripts/product_lock.py` so the two can be diffed; the only intended difference is the asset set, since the bundle installs no database other than `msime.db`.
- `scripts/fetch_dictionary.py` downloads and verifies against those committed digests. A retagged release or a replaced database fails the build instead of shipping, and rewriting the upstream `SHA256SUMS.txt` alongside the data does not help, because that file is verified against a committed digest too.
- The release workflow and `build.sh` use it. This is what makes the claim already written in `MSIME-Linux/scripts/fetch_dictionary.py` true: all three platforms now ship a byte-identical `msime.db`.
- `build_dictionary.py` remains the local path for changing dictionary sources, but delegates to MSIME-Dict's `build_all.py` rather than keeping a second, partial copy of the stage list. It passes `--require-all`, so a stage that cannot run now fails instead of silently going missing — the behaviour that hid this.
- CI validates the lock. The unit tests keep using the fixture dictionary, since they assert composition behaviour rather than dictionary content.

## Attribution

`THIRD_PARTY_NOTICES.txt` covered only code dependencies, while the bundle also installs `msime.db` and five helpcode tables. rime-ice is GPL-3.0 and requires attribution, so the notice now carries it, along with the sources whose terms are unresolved.

`rime-jp_sela`, which feeds the Japanese lexicon table on **every** platform, declares no license and is absent from MSIME-Dict's `NOTICE.md` and from the Linux notices as well. It is listed here as unresolved; the MSIME-Dict side is worth a follow-up.

The `googlepinyinime-rev` URL pointed at a name the repository no longer uses. It still redirects, but it now names the repository directly.

## Verification

`scripts/fetch_dictionary.py` was run end to end against the live release:

```
downloaded msime.db (107552768 bytes)
verified 2 assets against product-lock.json
msime.db (107552768 bytes), ni'hao -> 你好, yyds -> 永远滴神, aaaa -> 工
```

The `yyds` probe reads `quick_parases`, the table written by a stage the old script never ran, so it is precisely the assertion that would have caught this.

`product_lock.py validate` passes, both workflows parse, and `build_dictionary.py --help` runs. The macOS build itself is left to CI.
