### PR TITLE
fix(ios): stop announcing the settings row icons

### DIFF
--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -42,11 +42,15 @@ struct OnboardingView: View {
 
         VStack(alignment: .leading, spacing: 16) {
           HStack(spacing: 12) {
+            // Decorative next to the row's own title and subtitle. Left visible to VoiceOver, a
+            // symbol reads either its system name ("插入文本") or, when it has none, its raw
+            // identifier, and neither says anything the row's text does not already say.
             Image(systemName: "character.cursor.ibeam")
               .font(.system(size: 17, weight: .semibold))
               .foregroundStyle(MetasequoiaTheme.forest)
               .frame(width: 38, height: 38)
               .background(MetasequoiaTheme.mist, in: Circle())
+              .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 3) {
               Text("输入方案")
@@ -76,6 +80,7 @@ struct OnboardingView: View {
               .foregroundStyle(MetasequoiaTheme.forest)
               .frame(width: 38, height: 38)
               .background(MetasequoiaTheme.mist, in: Circle())
+              .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 3) {
               Text("输出字形")

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -19,6 +19,8 @@ bash platforms/ios/scripts/run_ui_tests.sh
 
 The UI-test runner prefers an already booted iPhone Simulator, otherwise selects the newest available iPhone runtime, waits for its reported boot readiness, and runs the onboarding smoke test without fixed startup delays. Set `IOS_SIMULATOR_UDID` to target a specific device.
 
+`CODE_SIGNING_ALLOWED=NO` above keeps the Simulator build reproducible without a signing identity, but it also means the installed app carries no entitlements and the operating system never provisions the App Group. The host app and the keyboard extension then each get their own `group.com.houko.metasequoiaime.ios` preferences file inside their own container, so a setting changed in the host app never reaches the keyboard and the sharing looks broken when it is not. Build and install with signing enabled when the shared settings themselves are what needs verifying; the two containers are under `~/Library/Developer/CoreSimulator/Devices/<udid>/data/Containers/Data/` and reading both plists tells the two cases apart immediately.
+
 `BREW_PREFIX` defaults to `/opt/homebrew` in `project.yml`; override that build setting when dependencies are installed under another prefix.
 
 The keyboard routes letter input, composition editing, raw/candidate commit, cancellation, numbered candidate selection, and Chinese punctuation through the shared engine. Its candidate bar also provides a local `中` / `英` switch; entering English mode first commits the leading Engine candidate, then passes letters and symbols directly to the host app. The native `123` / `ABC` layer owns only key layout; it does not duplicate the engine's composition or punctuation policy.

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -175,6 +175,16 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("handleInputModeList(from:", controller)
         self.assertNotIn("URLSession", controller)
 
+    def test_setting_row_icons_stay_out_of_the_accessibility_tree(self):
+        # Both icons sit next to a title and a subtitle that already carry the row's meaning. Left
+        # visible, VoiceOver reads the symbol's system name where it has one and its raw identifier
+        # where it does not, which is how "character.book.closed" ended up being announced.
+        onboarding = (IOS_ROOT / "App/Sources/OnboardingView.swift").read_text()
+
+        for symbol in ("character.cursor.ibeam", "character.book.closed"):
+            row = onboarding.split(f'Image(systemName: "{symbol}")', 1)[1].split("\n\n", 1)[0]
+            self.assertIn(".accessibilityHidden(true)", row, f"{symbol} is still announced")
+
     def test_onboarding_exposes_a_regular_text_field_for_keyboard_tryout(self):
         onboarding = (IOS_ROOT / "App/Sources/OnboardingView.swift").read_text()
 


### PR DESCRIPTION
Two findings from driving the shipped iOS build on a Simulator through Orca, rather than from reading the code.

## The settings row icons were being announced

Both icons in the settings card sit next to a title and a subtitle that already carry the row's meaning, but they were still in the accessibility tree. VoiceOver reads the system name where a symbol has one and the raw identifier where it does not, so the accessibility snapshot showed:

```
image | 插入文本            <- character.cursor.ibeam, the input-scheme row
image | character.book.closed  <- the output-script row
```

Neither says anything the row's text does not already say, and the second one is just a symbol identifier read aloud. Both are now hidden, matching what the header mark in the same file already does. After the fix the snapshot contains only the two text rows.

## Why the shared settings look broken on a Simulator

Worth writing down because it cost real time to diagnose, and the next person hits it the same way: the README's own build command and CI both pass `CODE_SIGNING_ALLOWED=NO`, so the installed app carries no entitlements and the operating system never provisions the App Group. The host app and the keyboard extension then each get their own `group.com.houko.metasequoiaime.ios` preferences file inside their own container:

```
Containers/Data/Application/<id>/Library/Preferences/group.com.houko.metasequoiaime.ios.plist
  chineseOutputUsesTraditional => true      <- written by the host app

Containers/Data/PluginKitPlugin/<id>/Library/Preferences/group.com.houko.metasequoiaime.ios.plist
  inputSchemeUsesShuangpin => false         <- written by the keyboard
```

A setting changed in the host app never reaches the keyboard, and the keyboard's own scheme toggle never reaches the host app. Nothing is wrong with the sharing code; the entitlement simply is not there. The README now says so and points at the two containers.

## Verification

- `python3 platforms/ios/tests/ProjectConfigurationTests.py` — 33 tests, including the new assertion that both row icons stay out of the accessibility tree
- `xcodebuild ... -sdk iphonesimulator build`
- Installed on an iPhone 17 Simulator and read the accessibility tree through Orca before and after: the two `image` nodes are gone and only the `输入方案` / `输出字形` text rows remain

While the Simulator was up I also confirmed the traditional-output feature end to end, which the previous pull request could not: with the keyboard's own preference set to traditional, typing `shuru` in 全拼 gives candidates 輸入 / 書 / 數 and selecting the first one commits 輸入 into the field. With it unset the same keys give 输入 / 书 / 数. That exercises both the candidate-display and the commit conversion in the real extension.
