### PR TITLE
fix(mac): 遵循每页候选数量设置，并让窗口尺寸适应内容

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ if(BUILD_TESTING)
     target_compile_options(MetasequoiaInputControllerKeyRoutingTests PRIVATE -fobjc-arc -Wall -Wextra -Wpedantic -Werror)
     target_link_libraries(MetasequoiaInputControllerKeyRoutingTests PRIVATE MetasequoiaIme::Engine ${APPKIT_FRAMEWORK} ${INPUT_METHOD_KIT_FRAMEWORK})
     add_test(NAME input_controller_key_routing COMMAND MetasequoiaInputControllerKeyRoutingTests)
+    add_executable(MetasequoiaCandidatePanelTests ${METASEQUOIA_MACOS_ROOT}/tests/CandidatePanelTests.mm ${METASEQUOIA_MACOS_ROOT}/src/CandidatePanel.mm)
+    target_compile_options(MetasequoiaCandidatePanelTests PRIVATE -fobjc-arc -Wall -Wextra -Wpedantic -Werror)
+    target_link_libraries(MetasequoiaCandidatePanelTests PRIVATE ${APPKIT_FRAMEWORK} ${INPUT_METHOD_KIT_FRAMEWORK})
+    add_test(NAME candidate_panel COMMAND MetasequoiaCandidatePanelTests)
     add_executable(MetasequoiaInputMenuTests ${METASEQUOIA_MACOS_ROOT}/tests/InputMenuTests.mm)
     target_compile_options(MetasequoiaInputMenuTests PRIVATE -fobjc-arc -Wall -Wextra -Wpedantic -Werror)
     target_link_libraries(MetasequoiaInputMenuTests PRIVATE ${APPKIT_FRAMEWORK})
@@ -150,7 +154,7 @@ if(METASEQUOIA_IME_BUILD_INPUT_METHOD)
         ${METASEQUOIA_IME_LEGAL_DIRECTORY}/MIT-fmt.txt
         ${METASEQUOIA_IME_LEGAL_DIRECTORY}/MIT-spdlog.txt
         ${METASEQUOIA_IME_LEGAL_DIRECTORY}/Sparkle-LICENSE.txt)
-    add_executable(MetasequoiaIME MACOSX_BUNDLE ${METASEQUOIA_MACOS_ROOT}/src/main.mm ${METASEQUOIA_MACOS_ROOT}/src/ChineseTextConversion.mm ${METASEQUOIA_MACOS_ROOT}/src/DictionaryInstaller.mm ${METASEQUOIA_MACOS_ROOT}/src/FloatingToolbarPanel.mm ${METASEQUOIA_MACOS_ROOT}/src/InputSourceRegistration.mm ${METASEQUOIA_MACOS_ROOT}/src/MetasequoiaInputController.mm ${METASEQUOIA_MACOS_ROOT}/src/PreferencesWindowController.mm ${METASEQUOIA_MACOS_ROOT}/src/ShuangpinKeymapPanel.mm ${METASEQUOIA_MACOS_ROOT}/src/StringConversion.mm ${METASEQUOIA_MACOS_ROOT}/src/UpdateController.mm ${METASEQUOIA_IME_DICTIONARY} ${METASEQUOIA_IME_ICONS} ${METASEQUOIA_IME_HELPCODES} ${METASEQUOIA_IME_LOCALIZATIONS} ${METASEQUOIA_IME_LEGAL_RESOURCES} ${METASEQUOIA_IME_UNINSTALLER})
+    add_executable(MetasequoiaIME MACOSX_BUNDLE ${METASEQUOIA_MACOS_ROOT}/src/main.mm ${METASEQUOIA_MACOS_ROOT}/src/CandidatePanel.mm ${METASEQUOIA_MACOS_ROOT}/src/ChineseTextConversion.mm ${METASEQUOIA_MACOS_ROOT}/src/DictionaryInstaller.mm ${METASEQUOIA_MACOS_ROOT}/src/FloatingToolbarPanel.mm ${METASEQUOIA_MACOS_ROOT}/src/InputSourceRegistration.mm ${METASEQUOIA_MACOS_ROOT}/src/MetasequoiaInputController.mm ${METASEQUOIA_MACOS_ROOT}/src/PreferencesWindowController.mm ${METASEQUOIA_MACOS_ROOT}/src/ShuangpinKeymapPanel.mm ${METASEQUOIA_MACOS_ROOT}/src/StringConversion.mm ${METASEQUOIA_MACOS_ROOT}/src/UpdateController.mm ${METASEQUOIA_IME_DICTIONARY} ${METASEQUOIA_IME_ICONS} ${METASEQUOIA_IME_HELPCODES} ${METASEQUOIA_IME_LOCALIZATIONS} ${METASEQUOIA_IME_LEGAL_RESOURCES} ${METASEQUOIA_IME_UNINSTALLER})
     set_source_files_properties(${METASEQUOIA_IME_DICTIONARY} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set_source_files_properties(${METASEQUOIA_IME_ICONS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set_source_files_properties(${METASEQUOIA_IME_HELPCODES}
@@ -171,6 +175,20 @@ if(METASEQUOIA_IME_BUILD_INPUT_METHOD)
         VERBATIM)
     add_custom_target(MetasequoiaIMESign ALL COMMAND /usr/bin/codesign --force --deep --sign - "$<TARGET_BUNDLE_DIR:MetasequoiaIME>" DEPENDS MetasequoiaIME VERBATIM)
     if(BUILD_TESTING)
+        add_executable(MetasequoiaCandidatePaginationTests
+            ${METASEQUOIA_MACOS_ROOT}/tests/CandidatePaginationTests.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/CandidatePanel.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/ChineseTextConversion.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/DictionaryInstaller.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/FloatingToolbarPanel.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/PreferencesWindowController.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/ShuangpinKeymapPanel.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/StringConversion.mm
+            ${METASEQUOIA_MACOS_ROOT}/src/UpdateController.mm)
+        target_compile_options(MetasequoiaCandidatePaginationTests PRIVATE -fobjc-arc -Wall -Wextra -Wpedantic -Werror)
+        target_link_libraries(MetasequoiaCandidatePaginationTests PRIVATE MetasequoiaIme::Engine MetasequoiaSparkle ${APPKIT_FRAMEWORK} ${CARBON_FRAMEWORK} ${INPUT_METHOD_KIT_FRAMEWORK})
+        set_target_properties(MetasequoiaCandidatePaginationTests PROPERTIES BUILD_RPATH "${METASEQUOIA_SPARKLE_ROOT}")
+        add_test(NAME candidate_pagination COMMAND MetasequoiaCandidatePaginationTests)
         add_executable(MetasequoiaDictionaryInstallerTests ${METASEQUOIA_MACOS_ROOT}/tests/DictionaryInstallerTests.mm ${METASEQUOIA_MACOS_ROOT}/src/DictionaryInstaller.mm)
         target_compile_options(MetasequoiaDictionaryInstallerTests PRIVATE -fobjc-arc -Wall -Wextra -Wpedantic -Werror)
         target_link_libraries(MetasequoiaDictionaryInstallerTests PRIVATE MetasequoiaIme::Engine ${APPKIT_FRAMEWORK})

--- a/platforms/macos/src/CandidatePanel.h
+++ b/platforms/macos/src/CandidatePanel.h
@@ -1,0 +1,32 @@
+#pragma once
+#import <AppKit/AppKit.h>
+#import <InputMethodKit/InputMethodKit.h>
+
+@protocol MetasequoiaCandidatePanelDelegate <NSObject>
+- (void)candidateSelected:(NSAttributedString *)candidate;
+- (void)candidatePanelPreviousPage;
+- (void)candidatePanelNextPage;
+@end
+
+// Nonactivating AppKit presentation of one controller-owned candidate page.
+@interface MetasequoiaCandidatePanel : NSObject
+@property(nonatomic, weak) id<MetasequoiaCandidatePanelDelegate> delegate;
+@property(nonatomic) IMKCandidatePanelType panelType;
+@property(nonatomic, copy) NSArray<NSNumber *> *selectionKeys;
+@property(nonatomic) NSRect caretRect;
+@property(nonatomic) BOOL hasPreviousPage;
+@property(nonatomic) BOOL hasNextPage;
+@property(nonatomic, readonly) NSPanel *window;
+- (void)setAttributes:(NSDictionary *)attributes;
+- (void)setCandidateData:(NSArray<NSAttributedString *> *)candidates;
+- (void)show:(IMKCandidatesLocationHint)hint;
+- (void)hide;
+- (BOOL)isVisible;
+- (NSRect)candidateFrame;
+- (NSInteger)candidateIdentifierAtLineNumber:(NSInteger)line;
+- (NSInteger)lineNumberForCandidateWithIdentifier:(NSInteger)identifier;
+- (NSInteger)candidateStringIdentifier:(NSAttributedString *)candidate;
+- (BOOL)selectCandidateWithIdentifier:(NSInteger)identifier;
+- (NSInteger)selectedCandidate;
+- (NSAttributedString *)selectedCandidateString;
+@end

--- a/platforms/macos/src/CandidatePanel.mm
+++ b/platforms/macos/src/CandidatePanel.mm
@@ -1,0 +1,204 @@
+#import "CandidatePanel.h"
+#include <cmath>
+
+@interface MetasequoiaCandidateWindow : NSPanel
+@end
+@implementation MetasequoiaCandidateWindow
+- (BOOL)canBecomeKeyWindow { return NO; }
+- (BOOL)canBecomeMainWindow { return NO; }
+@end
+
+@interface MetasequoiaCandidateButton : NSButton
+@property(nonatomic) BOOL candidateHighlighted;
+@end
+@implementation MetasequoiaCandidateButton
+- (BOOL)acceptsFirstResponder { return NO; }
+- (BOOL)acceptsFirstMouse:(NSEvent *)event { (void)event; return YES; }
+- (void)drawRect:(NSRect)dirtyRect
+{
+    (void)dirtyRect;
+    if (self.candidateHighlighted)
+    {
+        [NSColor.selectedContentBackgroundColor setFill];
+        [[NSBezierPath bezierPathWithRoundedRect:NSInsetRect(self.bounds, 1, 1) xRadius:6 yRadius:6] fill];
+    }
+    NSColor *color = self.candidateHighlighted ? NSColor.selectedMenuItemTextColor : NSColor.labelColor;
+    NSMutableParagraphStyle *paragraph = [NSMutableParagraphStyle new];
+    paragraph.lineBreakMode = NSLineBreakByTruncatingTail;
+    NSDictionary *attributes = @{NSFontAttributeName:self.font, NSForegroundColorAttributeName:color, NSParagraphStyleAttributeName:paragraph};
+    const NSSize size = [self.title sizeWithAttributes:attributes];
+    [self.title drawInRect:NSMakeRect(8, (self.bounds.size.height - size.height) / 2,
+                                     self.bounds.size.width - 16, size.height) withAttributes:attributes];
+}
+@end
+
+@implementation MetasequoiaCandidatePanel
+{
+    NSPanel *_window;
+    NSArray<NSAttributedString *> *_data;
+    NSFont *_font;
+    NSInteger _selected;
+}
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        _data = @[];
+        _font = [NSFont systemFontOfSize:18];
+        _selected = NSNotFound;
+        _window = [[MetasequoiaCandidateWindow alloc] initWithContentRect:NSZeroRect
+            styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
+            backing:NSBackingStoreBuffered defer:NO];
+        _window.releasedWhenClosed = NO;
+        _window.level = NSPopUpMenuWindowLevel;
+        _window.hidesOnDeactivate = NO;
+        _window.opaque = NO;
+        _window.backgroundColor = NSColor.clearColor;
+        _window.hasShadow = YES;
+        _window.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces | NSWindowCollectionBehaviorFullScreenAuxiliary;
+        NSVisualEffectView *content = [[NSVisualEffectView alloc] initWithFrame:NSZeroRect];
+        content.material = NSVisualEffectMaterialPopover;
+        content.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+        content.state = NSVisualEffectStateActive;
+        content.wantsLayer = YES;
+        content.layer.cornerRadius = 9;
+        content.layer.masksToBounds = YES;
+        _window.contentView = content;
+    }
+    return self;
+}
+- (void)dealloc { [_window orderOut:nil]; }
+- (NSPanel *)window { return _window; }
+- (void)setPanelType:(IMKCandidatePanelType)type { _panelType = type; [self layoutCandidates]; }
+- (void)setHasPreviousPage:(BOOL)value { _hasPreviousPage = value; [self layoutCandidates]; }
+- (void)setHasNextPage:(BOOL)value { _hasNextPage = value; [self layoutCandidates]; }
+- (void)setAttributes:(NSDictionary *)attributes
+{
+    NSFont *font = attributes[NSFontAttributeName];
+    if ([font isKindOfClass:NSFont.class]) _font = font;
+    [self layoutCandidates];
+}
+- (void)setCandidateData:(NSArray<NSAttributedString *> *)candidates
+{
+    _data = [candidates copy];
+    _selected = _data.count > 0 ? 0 : NSNotFound;
+    [self layoutCandidates];
+    if (_data.count == 0) [self hide];
+}
+- (NSScreen *)screenForCaret
+{
+    for (NSScreen *screen in NSScreen.screens)
+        if (NSPointInRect(NSMakePoint(NSMinX(self.caretRect), NSMidY(self.caretRect)), screen.frame)) return screen;
+    return NSScreen.mainScreen;
+}
+- (void)layoutCandidates
+{
+    for (NSView *view in [_window.contentView.subviews copy]) [view removeFromSuperview];
+    const CGFloat inset = 5;
+    const CGFloat rowHeight = ceil(_font.ascender - _font.descender + _font.leading) + 12;
+    const BOOL vertical = _panelType == kIMKSingleColumnScrollingCandidatePanel;
+    NSMutableArray<NSNumber *> *widths = [NSMutableArray array];
+    NSMutableArray<NSString *> *titles = [NSMutableArray array];
+    CGFloat width = 0;
+    const BOOL paging = _hasPreviousPage || _hasNextPage;
+    const CGFloat screenWidth = [self screenForCaret].visibleFrame.size.width;
+    const CGFloat availableWidth = MAX(80, screenWidth - 20 - 2 * inset - (paging && !vertical ? 56 : 0));
+    const CGFloat maximumItemWidth = vertical ? availableWidth : availableWidth / MAX((NSUInteger)1, _data.count);
+    for (NSUInteger index = 0; index < _data.count; ++index)
+    {
+        NSString *title = [NSString stringWithFormat:@"%lu  %@", (unsigned long)index + 1, _data[index].string];
+        CGFloat itemWidth = MIN(ceil([title sizeWithAttributes:@{NSFontAttributeName:_font}].width) + 16, maximumItemWidth);
+        [titles addObject:title];
+        [widths addObject:@(itemWidth)];
+        width = vertical ? MAX(width, itemWidth) : width + itemWidth;
+    }
+    const CGFloat navigationHeight = paging && vertical ? 26 : 0;
+    if (paging) width = vertical ? MAX(width, 64) : width + 56;
+    NSSize size = NSMakeSize(MAX(width + 2 * inset, 20),
+        MAX((vertical ? _data.count : (_data.count > 0 ? 1 : 0)) * rowHeight + navigationHeight + 2 * inset, 10));
+    [_window setContentSize:size];
+    CGFloat x = inset;
+    for (NSUInteger index = 0; index < _data.count; ++index)
+    {
+        const CGFloat itemWidth = vertical ? width : widths[index].doubleValue;
+        const CGFloat y = vertical ? size.height - inset - (index + 1) * rowHeight : inset;
+        MetasequoiaCandidateButton *button = [[MetasequoiaCandidateButton alloc] initWithFrame:NSMakeRect(x, y, itemWidth, rowHeight)];
+        button.title = titles[index];
+        button.font = _font;
+        button.bordered = NO;
+        button.tag = (NSInteger)index;
+        button.target = self;
+        button.action = @selector(selectFromMouse:);
+        button.candidateHighlighted = (NSInteger)index == _selected;
+        button.accessibilityLabel = titles[index];
+        button.toolTip = _data[index].string;
+        [_window.contentView addSubview:button];
+        if (!vertical) x += itemWidth;
+    }
+    if (paging)
+    {
+        for (NSUInteger index = 0; index < 2; ++index)
+        {
+            NSButton *button = [NSButton buttonWithTitle:index == 0 ? @"‹" : @"›" target:self action:@selector(changePage:)];
+            button.frame = NSMakeRect(vertical ? inset + index * 28 : x + index * 28, inset, 28,
+                                      vertical ? navigationHeight : rowHeight);
+            button.bordered = NO;
+            button.tag = index == 0 ? -1 : -2;
+            button.enabled = index == 0 ? _hasPreviousPage : _hasNextPage;
+            button.accessibilityLabel = index == 0 ? @"上一页候选" : @"下一页候选";
+            [_window.contentView addSubview:button];
+        }
+    }
+}
+- (void)selectFromMouse:(NSButton *)button
+{
+    if ([self selectCandidateWithIdentifier:button.tag]) [self.delegate candidateSelected:_data[button.tag]];
+}
+- (void)changePage:(NSButton *)button
+{
+    if (button.tag == -1 && _hasPreviousPage) [self.delegate candidatePanelPreviousPage];
+    if (button.tag == -2 && _hasNextPage) [self.delegate candidatePanelNextPage];
+}
+- (void)show:(IMKCandidatesLocationHint)hint
+{
+    (void)hint;
+    if (_data.count == 0) { [self hide]; return; }
+    NSRect caret = self.caretRect;
+    if (!std::isfinite(caret.origin.x) || !std::isfinite(caret.origin.y) ||
+        !std::isfinite(caret.size.width) || !std::isfinite(caret.size.height) || caret.size.height <= 0)
+    { [self hide]; return; }
+    [self layoutCandidates];
+    NSRect bounds = [self screenForCaret].visibleFrame;
+    NSSize size = _window.frame.size;
+    CGFloat x = MIN(MAX(NSMinX(caret), NSMinX(bounds)), MAX(NSMinX(bounds), NSMaxX(bounds) - size.width));
+    CGFloat y = NSMinY(caret) - size.height - 4;
+    if (y < NSMinY(bounds)) y = NSMaxY(caret) + 4;
+    y = MIN(MAX(y, NSMinY(bounds)), MAX(NSMinY(bounds), NSMaxY(bounds) - size.height));
+    [_window setFrameOrigin:NSMakePoint(x, y)];
+    [_window orderFrontRegardless];
+}
+- (void)hide { [_window orderOut:nil]; }
+- (BOOL)isVisible { return _window.isVisible; }
+- (NSRect)candidateFrame { return _window.frame; }
+- (NSInteger)candidateIdentifierAtLineNumber:(NSInteger)line
+{ return line >= 0 && (NSUInteger)line < _data.count ? line : NSNotFound; }
+- (NSInteger)lineNumberForCandidateWithIdentifier:(NSInteger)identifier
+{ return [self candidateIdentifierAtLineNumber:identifier]; }
+- (NSInteger)candidateStringIdentifier:(NSAttributedString *)candidate
+{ return (NSInteger)[_data indexOfObjectIdenticalTo:candidate]; }
+- (BOOL)selectCandidateWithIdentifier:(NSInteger)identifier
+{
+    if ([self candidateIdentifierAtLineNumber:identifier] == NSNotFound) return NO;
+    _selected = identifier;
+    for (NSView *view in _window.contentView.subviews)
+        if ([view isKindOfClass:MetasequoiaCandidateButton.class])
+        {
+            ((MetasequoiaCandidateButton *)view).candidateHighlighted = view.tag == identifier;
+            view.needsDisplay = YES;
+        }
+    return YES;
+}
+- (NSInteger)selectedCandidate { return _selected; }
+- (NSAttributedString *)selectedCandidateString { return _selected == NSNotFound ? nil : _data[_selected]; }
+@end

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -4,6 +4,7 @@
 #import "FloatingToolbarPanel.h"
 #import "ChineseTextConversion.h"
 #include "CandidateFontSize.h"
+#import "CandidatePanel.h"
 #include "CandidateDisplay.h"
 #include "CandidatePageSize.h"
 #include "CandidatePanelStyle.h"
@@ -88,7 +89,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 }
 } // namespace
 
-@interface MetasequoiaInputController () <MetasequoiaFloatingToolbarDelegate>
+@interface MetasequoiaInputController () <MetasequoiaFloatingToolbarDelegate, MetasequoiaCandidatePanelDelegate>
 @end
 
 @implementation MetasequoiaInputController
@@ -96,10 +97,12 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     std::unique_ptr<metasequoia::InputSession> _session;
     std::string _activeHelpcodeSchema;
     metasequoia::mac::CandidateSelectionState _candidateSelection;
-    IMKCandidates *_candidatePanel;
+    MetasequoiaCandidatePanel *_candidatePanel;
     MetasequoiaFloatingToolbarPanel *_floatingToolbarPanel;
     MetasequoiaShuangpinKeymapPanel *_shuangpinKeymapPanel;
     NSArray *_candidateData;
+    NSArray *_visibleCandidateData;
+    NSUInteger _candidatePageSize;
     NSUInteger _candidateHighlightedIndex;
     NSUInteger _candidatePageStart;
     BOOL _candidateLineIdentifiersCollapsed;
@@ -114,7 +117,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     self = [super initWithServer:server delegate:delegate client:inputClient];
     if (self != nil)
     {
-        _candidatePanel = [[IMKCandidates alloc] initWithServer:server panelType:kIMKSingleRowSteppingCandidatePanel styleType:kIMKMain];
+        _candidatePanel = [MetasequoiaCandidatePanel new];
+        _candidatePanel.delegate = self;
         _floatingToolbarPanel = [MetasequoiaFloatingToolbarPanel sharedPanel];
         _shuangpinKeymapPanel = [[MetasequoiaShuangpinKeymapPanel alloc] init];
         [_candidatePanel setAttributes:metasequoia::mac::CandidatePanelAttributes(
@@ -189,7 +193,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     _candidatePageStart = 0;
     _candidateLineIdentifiersCollapsed = NO;
     _candidateData = @[];
-    [_candidatePanel setCandidateData:_candidateData];
+    _visibleCandidateData = @[];
+    [_candidatePanel setCandidateData:_visibleCandidateData];
     [_candidatePanel hide];
     [_shuangpinKeymapPanel orderOut:nil];
     _dictionaryRetryAfter = 0.0;
@@ -211,7 +216,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 
     const SessionPreferences preferences = ReadSessionPreferences();
     [_candidatePanel setPanelType:metasequoia::mac::CandidatePanelTypeForStyle(preferences.candidatePanelStyle)];
-    [_candidatePanel setSelectionKeys:metasequoia::mac::CandidateSelectionKeys(preferences.candidatePageSize)];
+    _candidatePageSize = preferences.candidatePageSize;
+    [_candidatePanel setSelectionKeys:metasequoia::mac::CandidateSelectionKeys(_candidatePageSize)];
     [_candidatePanel setAttributes:metasequoia::mac::CandidatePanelAttributes(preferences.candidateFontSize)];
     _wubiAutoCommitUniqueEnabled = preferences.wubiAutoCommitUniqueEnabled;
     const bool helpcodeSchemaMatches = _activeHelpcodeSchema == preferences.helpcodeSchema;
@@ -229,7 +235,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     _candidatePageStart = 0;
     _candidateLineIdentifiersCollapsed = NO;
     _candidateData = @[];
-    [_candidatePanel setCandidateData:_candidateData];
+    _visibleCandidateData = @[];
+    [_candidatePanel setCandidateData:_visibleCandidateData];
     [_candidatePanel hide];
     [_shuangpinKeymapPanel orderOut:nil];
 }
@@ -287,56 +294,90 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     _candidateSelection.update(static_cast<size_t>(index), _session->candidates()[index].word);
     _candidateHighlightedIndex = index;
     _candidatePageStart = metasequoia::mac::CandidatePageStart(
-        index, _candidateData.count, _candidatePanel.selectionKeys.count);
+        index, _candidateData.count, _candidatePageSize);
+}
+
+- (void)showCurrentCandidatePage
+{
+    // On macOS 26, selectionKeys does not reliably limit the visible list.
+    // Own page boundaries here; retain global engine indices on each string.
+    const NSUInteger count = std::min(_candidatePageSize, _candidateData.count - _candidatePageStart);
+    _visibleCandidateData = [_candidateData subarrayWithRange:NSMakeRange(_candidatePageStart, count)];
+    _candidateLineIdentifiersCollapsed = NO;
+    _candidatePanel.hasPreviousPage = _candidatePageStart > 0;
+    _candidatePanel.hasNextPage = _candidatePageStart + count < _candidateData.count;
+    NSRect caretRect = NSZeroRect;
+    [self.client attributesForCharacterIndex:0 lineHeightRectangle:&caretRect];
+    _candidatePanel.caretRect = caretRect;
+    [_candidatePanel setCandidateData:_visibleCandidateData];
+    [_candidatePanel show:kIMKLocateCandidatesBelowHint];
+    if (count >= 2)
+    {
+        const NSInteger first = [_candidatePanel candidateIdentifierAtLineNumber:0];
+        const NSInteger second = [_candidatePanel candidateIdentifierAtLineNumber:1];
+        _candidateLineIdentifiersCollapsed = first != NSNotFound && first == second;
+    }
+}
+
+- (void)candidatePanelPreviousPage
+{
+    if (_candidatePageSize > 0 && _candidatePageStart >= _candidatePageSize)
+    {
+        const NSUInteger target = _candidatePageStart - _candidatePageSize;
+        [self selectCandidateAtIndex:target pageStart:target];
+    }
+}
+
+- (void)candidatePanelNextPage
+{
+    if (_candidatePageSize > 0 && _candidatePageStart + _candidatePageSize < _candidateData.count)
+    {
+        const NSUInteger target = _candidatePageStart + _candidatePageSize;
+        [self selectCandidateAtIndex:target pageStart:target];
+    }
 }
 
 - (BOOL)selectCandidateAtIndex:(NSUInteger)index pageStart:(NSUInteger)pageStart
 {
-    if (index >= _candidateData.count || index < pageStart)
+    if (index >= _candidateData.count || index < pageStart || index - pageStart >= _candidatePageSize)
     {
         return NO;
     }
-
+    const NSUInteger previousPageStart = _candidatePageStart;
+    const NSUInteger previousIndex = _candidateHighlightedIndex;
+    if (pageStart != _candidatePageStart)
+    {
+        _candidatePageStart = pageStart;
+        [self showCurrentCandidatePage];
+    }
     const NSUInteger line = index - pageStart;
     const NSInteger identifier = [_candidatePanel candidateIdentifierAtLineNumber:static_cast<NSInteger>(line)];
-    const NSInteger firstIdentifier = [_candidatePanel candidateIdentifierAtLineNumber:0];
-    const NSInteger secondIdentifier = [_candidatePanel candidateIdentifierAtLineNumber:1];
-    const NSUInteger candidatesOnPage = std::min(_candidatePanel.selectionKeys.count,
-                                                  _candidateData.count - pageStart);
-    if (candidatesOnPage >= 2 && firstIdentifier != NSNotFound && firstIdentifier == secondIdentifier)
-    {
-        _candidateLineIdentifiersCollapsed = YES;
-    }
-    const BOOL lineMappingIsUsable =
-        !_candidateLineIdentifiersCollapsed && identifier != NSNotFound &&
-        [_candidatePanel lineNumberForCandidateWithIdentifier:identifier] == static_cast<NSInteger>(line) &&
-        (candidatesOnPage < 2 || (firstIdentifier != NSNotFound && secondIdentifier != NSNotFound &&
-                                  firstIdentifier != secondIdentifier));
-
+    const BOOL lineMappingIsUsable = !_candidateLineIdentifiersCollapsed && identifier != NSNotFound &&
+        [_candidatePanel lineNumberForCandidateWithIdentifier:identifier] == static_cast<NSInteger>(line);
+    BOOL selected = NO;
     if (lineMappingIsUsable)
     {
-        if (![_candidatePanel selectCandidateWithIdentifier:identifier] ||
-            ![[_candidatePanel selectedCandidateString].string
-                isEqualToString:[_candidateData[index] string]])
-        {
-            return NO;
-        }
+        selected = [_candidatePanel selectCandidateWithIdentifier:identifier] &&
+            [[_candidatePanel selectedCandidateString].string isEqualToString:[_candidateData[index] string]];
+    }
+    else if (_candidateLineIdentifiersCollapsed &&
+             NSProcessInfo.processInfo.operatingSystemVersion.majorVersion == 26)
+    {
+        // This workaround takes an ordinal within the data passed to the panel,
+        // which is now the current page, not the complete engine candidate list.
+        selected = [_candidatePanel selectCandidateWithIdentifier:static_cast<NSInteger>(line)];
+    }
+    if (selected)
+    {
         _candidateSelection.begin_navigation();
         [self trackCandidateAtIndex:index];
         return YES;
     }
-
-    const NSInteger operatingSystemMajorVersion = NSProcessInfo.processInfo.operatingSystemVersion.majorVersion;
-    if (_candidateLineIdentifiersCollapsed && operatingSystemMajorVersion == 26)
+    if (previousPageStart != _candidatePageStart)
     {
-        // macOS 26 can collapse every visible-line identifier to zero after setCandidateData:.
-        // In that detected OS-specific failure mode the panel accepts the array ordinal.
-        if ([_candidatePanel selectCandidateWithIdentifier:static_cast<NSInteger>(index)])
-        {
-            _candidateSelection.begin_navigation();
-            [self trackCandidateAtIndex:index];
-            return YES;
-        }
+        _candidatePageStart = previousPageStart;
+        [self showCurrentCandidatePage];
+        [self selectCandidateAtIndex:previousIndex pageStart:previousPageStart];
     }
     return NO;
 }
@@ -410,94 +451,42 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         candidatePageShortcutCharacter, candidatePageShortcutModified))
     {
     case metasequoia::mac::ControllerKeyAction::MoveCandidateLeft:
-        if (!metasequoia::mac::IsPrimaryCandidateDirection(event.keyCode, _candidatePanel.panelType))
-        {
-            return YES;
-        }
-        _candidateSelection.begin_navigation();
-        [_candidatePanel moveLeft:self];
-        if (_candidateHighlightedIndex > 0)
-        {
-            --_candidateHighlightedIndex;
-        }
-        [self trackCandidateAtIndex:_candidateHighlightedIndex];
-        return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateRight:
-        if (!metasequoia::mac::IsPrimaryCandidateDirection(event.keyCode, _candidatePanel.panelType))
-        {
-            return YES;
-        }
-        _candidateSelection.begin_navigation();
-        [_candidatePanel moveRight:self];
-        if (_candidateHighlightedIndex + 1 < _candidateData.count)
-        {
-            ++_candidateHighlightedIndex;
-        }
-        [self trackCandidateAtIndex:_candidateHighlightedIndex];
-        return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateUp:
-        if (!metasequoia::mac::IsPrimaryCandidateDirection(event.keyCode, _candidatePanel.panelType))
-        {
-            return YES;
-        }
-        _candidateSelection.begin_navigation();
-        [_candidatePanel moveUp:self];
-        if (_candidateHighlightedIndex > 0)
-        {
-            --_candidateHighlightedIndex;
-        }
-        [self trackCandidateAtIndex:_candidateHighlightedIndex];
-        return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateDown:
+    {
         if (!metasequoia::mac::IsPrimaryCandidateDirection(event.keyCode, _candidatePanel.panelType))
         {
             return YES;
         }
-        _candidateSelection.begin_navigation();
-        [_candidatePanel moveDown:self];
-        if (_candidateHighlightedIndex + 1 < _candidateData.count)
-        {
-            ++_candidateHighlightedIndex;
-        }
-        [self trackCandidateAtIndex:_candidateHighlightedIndex];
+        const BOOL backwards = event.keyCode == kVK_LeftArrow || event.keyCode == kVK_UpArrow;
+        const NSUInteger target = backwards ? (_candidateHighlightedIndex > 0 ? _candidateHighlightedIndex - 1 : 0)
+                                            : std::min(_candidateHighlightedIndex + 1, _candidateData.count - 1);
+        [self selectCandidateAtIndex:target pageStart:metasequoia::mac::CandidatePageStart(
+            target, _candidateData.count, _candidatePageSize)];
         return YES;
+    }
     case metasequoia::mac::ControllerKeyAction::MoveCandidatePageUp:
-    {
-        const NSUInteger pageSize = _candidatePanel.selectionKeys.count;
-        if (pageSize == 0 || _candidatePageStart == 0)
+        if (_candidatePageSize > 0 && _candidatePageStart >= _candidatePageSize)
         {
-            return YES;
-        }
-        const NSUInteger targetPageStart = _candidatePageStart - pageSize;
-        [_candidatePanel pageUp:self];
-        if (![self selectCandidateAtIndex:targetPageStart pageStart:targetPageStart])
-        {
-            [_candidatePanel pageDown:self];
+            const NSUInteger target = _candidatePageStart - _candidatePageSize;
+            [self selectCandidateAtIndex:target pageStart:target];
         }
         return YES;
-    }
     case metasequoia::mac::ControllerKeyAction::MoveCandidatePageDown:
-    {
-        const NSUInteger pageSize = _candidatePanel.selectionKeys.count;
-        if (pageSize == 0 || _candidatePageStart + pageSize >= _candidateData.count)
+        if (_candidatePageSize > 0 && _candidatePageStart + _candidatePageSize < _candidateData.count)
         {
-            return YES;
-        }
-        const NSUInteger targetPageStart = _candidatePageStart + pageSize;
-        [_candidatePanel pageDown:self];
-        if (![self selectCandidateAtIndex:targetPageStart pageStart:targetPageStart])
-        {
-            [_candidatePanel pageUp:self];
+            const NSUInteger target = _candidatePageStart + _candidatePageSize;
+            [self selectCandidateAtIndex:target pageStart:target];
         }
         return YES;
-    }
     case metasequoia::mac::ControllerKeyAction::MoveCandidateHome:
         [self selectCandidateAtIndex:_candidatePageStart pageStart:_candidatePageStart];
         return YES;
     case metasequoia::mac::ControllerKeyAction::MoveCandidateEnd:
         [self selectCandidateAtIndex:metasequoia::mac::CandidatePageEnd(
                                          _candidatePageStart, _candidateData.count,
-                                         _candidatePanel.selectionKeys.count)
+                                         _candidatePageSize)
                            pageStart:_candidatePageStart];
         return YES;
     case metasequoia::mac::ControllerKeyAction::Backspace:
@@ -531,7 +520,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
             else if (character >= '1' && character <= '9')
             {
                 result = _candidateSelection.commit_number(
-                    *_session, static_cast<char>(character), _candidatePanel.selectionKeys.count);
+                    *_session, static_cast<char>(character), _candidatePageSize);
                 if (!result.handled && _session->has_composition())
                 {
                     return YES;
@@ -691,49 +680,27 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         ++candidateIndex;
     }
     _candidateData = [data copy];
-    [_candidatePanel setCandidateData:_candidateData];
     if (_session->has_composition() && _candidateData.count > 0)
     {
-        [_candidatePanel show:kIMKLocateCandidatesBelowHint];
-        if (_candidateData.count >= 2)
+        const NSUInteger selectedIndex = preservedSelection.has_value() && preservedSelection.value() < _candidateData.count
+                                             ? preservedSelection.value() : 0;
+        _candidatePageStart = metasequoia::mac::CandidatePageStart(selectedIndex, _candidateData.count, _candidatePageSize);
+        [self showCurrentCandidatePage];
+        if (preservedSelection.has_value())
         {
-            const NSInteger firstIdentifier = [_candidatePanel candidateIdentifierAtLineNumber:0];
-            const NSInteger secondIdentifier = [_candidatePanel candidateIdentifierAtLineNumber:1];
-            _candidateLineIdentifiersCollapsed =
-                firstIdentifier != NSNotFound && firstIdentifier == secondIdentifier;
-        }
-        if (preservedSelection.has_value() && preservedSelection.value() < _candidateData.count)
-        {
-            const NSUInteger selectedIndex = static_cast<NSUInteger>(preservedSelection.value());
-            const NSUInteger pageSize = _candidatePanel.selectionKeys.count;
-            const NSUInteger selectedPageStart = metasequoia::mac::CandidatePageStart(
-                selectedIndex, _candidateData.count, pageSize);
-            _candidateHighlightedIndex = selectedIndex;
-            _candidatePageStart = selectedPageStart;
-            NSUInteger pagesAdvanced = 0;
-            if (pageSize > 0)
+            if (![self selectCandidateAtIndex:selectedIndex pageStart:_candidatePageStart])
             {
-                for (NSUInteger pageStart = 0; pageStart < selectedPageStart; pageStart += pageSize)
-                {
-                    [_candidatePanel pageDown:self];
-                    ++pagesAdvanced;
-                }
-            }
-            if (![self selectCandidateAtIndex:selectedIndex pageStart:selectedPageStart])
-            {
-                // The panel could not re-highlight the preserved candidate, so fall back to the fresh-panel state instead of tracking a selection the user cannot see.
-                for (NSUInteger page = 0; page < pagesAdvanced; ++page)
-                {
-                    [_candidatePanel pageUp:self];
-                }
                 _candidateSelection.reset();
                 _candidateHighlightedIndex = 0;
                 _candidatePageStart = 0;
+                [self showCurrentCandidatePage];
             }
         }
     }
     else
     {
+        _visibleCandidateData = @[];
+        [_candidatePanel setCandidateData:_visibleCandidateData];
         [_candidatePanel hide];
     }
 }
@@ -741,7 +708,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 - (NSArray *)candidates:(id)sender
 {
     (void)sender;
-    return _candidateData != nil ? _candidateData : @[];
+    return _visibleCandidateData != nil ? _visibleCandidateData : @[];
 }
 
 - (void)candidateSelectionChanged:(NSAttributedString *)candidateString
@@ -762,9 +729,9 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         NSUInteger identifierIndex = NSNotFound;
         if (selectedIdentifier != NSNotFound)
         {
-            for (NSUInteger candidateIndex = 0; candidateIndex < _candidateData.count; ++candidateIndex)
+            for (NSUInteger candidateIndex = 0; candidateIndex < _visibleCandidateData.count; ++candidateIndex)
             {
-                if ([_candidatePanel candidateStringIdentifier:_candidateData[candidateIndex]] != selectedIdentifier)
+                if ([_candidatePanel candidateStringIdentifier:_visibleCandidateData[candidateIndex]] != selectedIdentifier)
                 {
                     continue;
                 }
@@ -773,19 +740,20 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
                     identifierIndex = NSNotFound;
                     break;
                 }
-                identifierIndex = candidateIndex;
+                identifierIndex = _candidatePageStart + candidateIndex;
             }
         }
         index = identifierIndex;
     }
     if (index == NSNotFound)
     {
-        NSMutableArray<NSString *> *displayStrings = [NSMutableArray arrayWithCapacity:_candidateData.count];
-        for (NSAttributedString *candidate in _candidateData)
+        NSMutableArray<NSString *> *displayStrings = [NSMutableArray arrayWithCapacity:_visibleCandidateData.count];
+        for (NSAttributedString *candidate in _visibleCandidateData)
         {
             [displayStrings addObject:candidate.string];
         }
-        index = MetasequoiaUniqueStringIndex(displayStrings, candidateString.string);
+        const NSUInteger line = MetasequoiaUniqueStringIndex(displayStrings, candidateString.string);
+        if (line != NSNotFound) index = _candidatePageStart + line;
     }
     if (index == NSNotFound)
     {
@@ -794,7 +762,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         const NSInteger selectedLine = selectedIdentifier == NSNotFound
                                            ? NSNotFound
                                            : [_candidatePanel lineNumberForCandidateWithIdentifier:selectedIdentifier];
-        if (selectedLine != NSNotFound && selectedLine >= 0)
+        if (selectedLine != NSNotFound && selectedLine >= 0 &&
+            static_cast<NSUInteger>(selectedLine) < _visibleCandidateData.count)
         {
             index = _candidatePageStart + static_cast<NSUInteger>(selectedLine);
         }

--- a/platforms/macos/tests/CandidatePaginationTests.mm
+++ b/platforms/macos/tests/CandidatePaginationTests.mm
@@ -1,0 +1,232 @@
+// Exercise the real controller with a recording window boundary. A headless
+// IMKCandidates cannot render without a registered input-method client.
+#include "../src/MetasequoiaInputController.mm"
+#include "../../../vendor/MetasequoiaImeEngine/user_dictionary/user_dictionary_journal.h"
+#include <sqlite3.h>
+#include <filesystem>
+#include <stdexcept>
+
+static void Require(bool condition, const char *message)
+{
+    if (!condition) throw std::runtime_error(message);
+}
+
+@interface RecordingCandidatePanel : NSObject
+@property(nonatomic, copy) NSArray *data;
+@property(nonatomic, copy) NSArray *selectionKeys;
+@property(nonatomic) IMKCandidatePanelType panelType;
+@property(nonatomic) NSInteger selected;
+@property(nonatomic) BOOL visible;
+@property(nonatomic) NSRect caretRect;
+@property(nonatomic) BOOL hasPreviousPage;
+@property(nonatomic) BOOL hasNextPage;
+@property(nonatomic) BOOL collapsedIdentifiers;
+@property(nonatomic, strong) NSNumber *rejectedEngineIndex;
+@end
+@implementation RecordingCandidatePanel
+- (void)setAttributes:(NSDictionary *)attributes { (void)attributes; }
+- (void)setCandidateData:(NSArray *)data { self.data = data; self.selected = 0; }
+- (void)show:(IMKCandidatesLocationHint)hint { (void)hint; self.visible = YES; }
+- (void)hide { self.visible = NO; }
+- (BOOL)isVisible { return self.visible; }
+- (NSInteger)candidateIdentifierAtLineNumber:(NSInteger)line
+{
+    return line >= 0 && (NSUInteger)line < self.data.count ? (self.collapsedIdentifiers ? 0 : 100 + line * 3) : NSNotFound;
+}
+- (NSInteger)lineNumberForCandidateWithIdentifier:(NSInteger)identifier
+{ return self.collapsedIdentifiers ? 0 : (identifier - 100) / 3; }
+- (BOOL)selectCandidateWithIdentifier:(NSInteger)identifier
+{
+    const NSInteger line = self.collapsedIdentifiers ? identifier : [self lineNumberForCandidateWithIdentifier:identifier];
+    if (line < 0 || (NSUInteger)line >= self.data.count) return NO;
+    if (self.rejectedEngineIndex != nil && MetasequoiaCandidateIndex(self.data[line]) == self.rejectedEngineIndex.unsignedIntegerValue) return NO;
+    self.selected = line;
+    return YES;
+}
+- (NSInteger)selectedCandidate { return self.collapsedIdentifiers ? 0 : 100 + self.selected * 3; }
+- (NSAttributedString *)selectedCandidateString { return self.data[self.selected]; }
+- (NSInteger)candidateStringIdentifier:(NSAttributedString *)value
+{
+    return self.collapsedIdentifiers ? 0 : 100 + (NSInteger)[self.data indexOfObjectIdenticalTo:value] * 3;
+}
+@end
+
+@interface RecordingInputClient : NSObject
+@property(nonatomic, copy) NSString *committed;
+@end
+@implementation RecordingInputClient
+- (NSDictionary *)attributesForCharacterIndex:(NSUInteger)index lineHeightRectangle:(NSRect *)rect
+{ (void)index; *rect = NSMakeRect(100, 400, 1, 20); return @{}; }
+- (void)insertText:(id)text replacementRange:(NSRange)range { (void)range; self.committed = text; }
+- (void)setMarkedText:(id)text selectionRange:(NSRange)selection replacementRange:(NSRange)replacement
+{ (void)text; (void)selection; (void)replacement; }
+@end
+
+// The test category is in the controller's translation unit so it can create a
+// session without registering an input source or touching the installed dictionary.
+@interface MetasequoiaInputController (PaginationTestFixture)
+- (void)prepareTestPanel:(RecordingCandidatePanel *)panel;
+- (NSUInteger)testCandidateCount;
+- (NSString *)testCandidateAtIndex:(NSUInteger)index;
+@end
+@implementation MetasequoiaInputController (PaginationTestFixture)
+- (void)prepareTestPanel:(RecordingCandidatePanel *)panel
+{
+    _candidatePanel = (MetasequoiaCandidatePanel *)panel;
+    _session = std::make_unique<metasequoia::InputSession>();
+    [self reloadSessionFromPreferences];
+    for (char character : std::string("nihao")) _session->handle_character(character);
+    [self updateCandidatePanel];
+}
+- (NSUInteger)testCandidateCount { return _session->candidates().size(); }
+- (NSString *)testCandidateAtIndex:(NSUInteger)index
+{ return MetasequoiaStringFromUtf8(_session->candidates()[index].word); }
+@end
+
+@interface PaginationTestController : MetasequoiaInputController
+@property(nonatomic, strong) RecordingInputClient *testClient;
+@end
+@implementation PaginationTestController
+- (id)client { return self.testClient; }
+@end
+
+static void Press(PaginationTestController *controller, unsigned short code, NSString *text)
+{
+    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSZeroPoint modifierFlags:0
+                                  timestamp:0 windowNumber:0 context:nil characters:text
+                charactersIgnoringModifiers:text isARepeat:NO keyCode:code];
+    Require([controller handleEvent:event client:controller.testClient], "The controller did not handle a paging test key.");
+}
+
+static void RunTests()
+{
+    Require([MetasequoiaInputController conformsToProtocol:@protocol(MetasequoiaFloatingToolbarDelegate)] &&
+                [MetasequoiaInputController conformsToProtocol:@protocol(MetasequoiaCandidatePanelDelegate)],
+            "The controller does not support both window delegate contracts.");
+    NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+    for (NSNumber *style in @[@0, @1]) for (NSNumber *size in @[@5, @7, @9])
+    {
+        [defaults setVolatileDomain:@{@"MetasequoiaImeCandidatePageSize":size,
+            @"MetasequoiaImeCandidatePanelStyle":style,
+            @"MetasequoiaImeCandidateLearning":@NO,
+            @"MetasequoiaImeHelpcodeEnabled":@NO} forName:NSArgumentDomain];
+        RecordingCandidatePanel *panel = [RecordingCandidatePanel new];
+        PaginationTestController *controller = [PaginationTestController alloc];
+        controller.testClient = [RecordingInputClient new];
+        [controller prepareTestPanel:panel];
+        const NSUInteger pageSize = size.unsignedIntegerValue;
+        Require([controller testCandidateCount] > pageSize, "The fixture needs multiple pages.");
+        Require(panel.data.count == pageSize, "The native window received more than the configured candidates per page.");
+        Require([[controller candidates:nil] count] == pageSize, "The IMK callback bypassed pagination.");
+        Press(controller, kVK_PageDown, @"");
+        Require(MetasequoiaCandidateIndex(panel.data[0]) == pageSize, "Page Down did not start at the next engine candidate.");
+        Require(panel.data.count <= pageSize, "The second page exceeded the configured page size.");
+        NSString *expected = [controller testCandidateAtIndex:pageSize];
+        Press(controller, kVK_ANSI_1, @"1");
+        Require([controller.testClient.committed isEqualToString:expected], "Digit 1 on page two committed the wrong engine candidate.");
+
+        [controller prepareTestPanel:panel];
+        const unsigned short forward = style.intValue == 0 ? kVK_RightArrow : kVK_DownArrow;
+        const unsigned short backward = style.intValue == 0 ? kVK_LeftArrow : kVK_UpArrow;
+        for (NSUInteger step = 0; step < pageSize; ++step) Press(controller, forward, @"");
+        Require(MetasequoiaCandidateIndex(panel.data[0]) == pageSize, "Arrow navigation did not cross the page boundary.");
+        Press(controller, backward, @"");
+        Require(MetasequoiaCandidateIndex(panel.data[0]) == 0, "Reverse navigation did not return to the first page.");
+        expected = [controller testCandidateAtIndex:pageSize - 1];
+        Press(controller, kVK_Space, @" ");
+        Require([controller.testClient.committed isEqualToString:expected], "Space committed a different candidate from the highlighted one.");
+
+        [controller prepareTestPanel:panel];
+        const NSUInteger total = [controller testCandidateCount];
+        for (NSUInteger page = 1; page * pageSize < total; ++page) Press(controller, kVK_PageDown, @"");
+        const NSUInteger lastPageStart = pageSize == 5 ? 10 : pageSize; // fixture has 12 candidates
+        Require(total == 12 && MetasequoiaCandidateIndex(panel.data[0]) == lastPageStart,
+                "The last page started at the wrong engine candidate.");
+        Require(panel.data.count == total - lastPageStart, "The partial last page lost candidates.");
+        NSArray *lastPage = panel.data;
+        Press(controller, kVK_PageDown, @"");
+        Require([panel.data isEqualToArray:lastPage], "Page Down moved beyond the last page.");
+        Press(controller, kVK_PageUp, @"");
+        Require(MetasequoiaCandidateIndex(panel.data[0]) == lastPageStart - pageSize, "Page Up skipped a page.");
+
+        for (NSNumber *stripped in @[@NO, @YES])
+        {
+            [controller prepareTestPanel:panel];
+            Press(controller, kVK_PageDown, @"");
+            panel.selected = 1;
+            expected = [controller testCandidateAtIndex:pageSize + 1];
+            NSAttributedString *clicked = panel.data[1];
+            if (stripped.boolValue) clicked = [[NSAttributedString alloc] initWithString:clicked.string];
+            [controller candidateSelected:clicked];
+            Require([controller.testClient.committed isEqualToString:expected], "A page-two mouse callback committed the wrong engine candidate.");
+        }
+
+        if (NSProcessInfo.processInfo.operatingSystemVersion.majorVersion == 26)
+        {
+            panel.collapsedIdentifiers = YES;
+            [controller prepareTestPanel:panel];
+            Press(controller, kVK_PageDown, @"");
+            Press(controller, forward, @"");
+            Require(panel.selected == 1, "Collapsed native identifiers used a global index instead of a page-local ordinal.");
+            expected = [controller testCandidateAtIndex:pageSize + 1];
+            Press(controller, kVK_Space, @" ");
+            Require([controller.testClient.committed isEqualToString:expected], "Collapsed identifiers lost the global engine selection.");
+            [controller prepareTestPanel:panel];
+            Press(controller, kVK_PageDown, @"");
+            panel.selected = 1;
+            expected = [controller testCandidateAtIndex:pageSize + 1];
+            [controller candidateSelected:[[NSAttributedString alloc] initWithString:[panel.data[1] string]]];
+            Require([controller.testClient.committed isEqualToString:expected], "A stripped mouse callback with collapsed identifiers lost its page offset.");
+            panel.collapsedIdentifiers = NO;
+        }
+
+        [controller prepareTestPanel:panel];
+        Press(controller, forward, @"");
+        panel.rejectedEngineIndex = @(pageSize);
+        Press(controller, kVK_PageDown, @"");
+        Require(MetasequoiaCandidateIndex(panel.data[0]) == 0 && panel.selected == 1,
+                "A rejected page selection did not restore the previous page and highlight.");
+        expected = [controller testCandidateAtIndex:1];
+        Press(controller, kVK_Space, @" ");
+        Require([controller.testClient.committed isEqualToString:expected], "Failed page navigation changed the engine selection.");
+        panel.rejectedEngineIndex = nil;
+
+        [controller prepareTestPanel:panel];
+        Press(controller, kVK_PageDown, @"");
+        [controller refreshCandidatePanelPreservingSelection];
+        Require(MetasequoiaCandidateIndex(panel.data[0]) == pageSize, "A display refresh reset the current page.");
+        Press(controller, kVK_Escape, @"");
+        Require(!panel.visible && panel.data.count == 0 && [[controller candidates:nil] count] == 0,
+                "Cancelling retained visible candidates.");
+    }
+}
+
+int main()
+{
+    @autoreleasepool
+    {
+        [NSApplication sharedApplication];
+        NSString *directory = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
+        std::filesystem::create_directories(directory.fileSystemRepresentation);
+        setenv("METASEQUOIA_IME_DATA_DIR", directory.fileSystemRepresentation, 1);
+        sqlite3 *database = nullptr;
+        Require(sqlite3_open([directory stringByAppendingPathComponent:@"msime.db"].fileSystemRepresentation, &database) == SQLITE_OK, "Cannot create fixture.");
+        Require(sqlite3_exec(database, "CREATE TABLE tbl_2_n(key TEXT,jp TEXT,value TEXT,weight INTEGER)", nullptr, nullptr, nullptr) == SQLITE_OK, "Cannot create table.");
+        for (int index = 0; index < 12; ++index)
+        {
+            NSString *sql = [NSString stringWithFormat:@"INSERT INTO tbl_2_n VALUES('ni''hao','nh','候选%d',%d)", index, 120-index];
+            Require(sqlite3_exec(database, sql.UTF8String, nullptr, nullptr, nullptr) == SQLITE_OK, "Cannot insert fixture.");
+        }
+        sqlite3_close(database);
+        try { RunTests(); }
+        catch (const std::exception &error)
+        {
+            fprintf(stderr, "%s\n", error.what());
+            user_dictionary::close_default_user_database();
+            std::filesystem::remove_all(directory.fileSystemRepresentation);
+            return 1;
+        }
+        user_dictionary::close_default_user_database();
+        std::filesystem::remove_all(directory.fileSystemRepresentation);
+    }
+}

--- a/platforms/macos/tests/CandidatePanelTests.mm
+++ b/platforms/macos/tests/CandidatePanelTests.mm
@@ -1,0 +1,85 @@
+#import "../src/CandidatePanel.h"
+#include <stdexcept>
+
+static void Require(bool condition, const char *message)
+{
+    if (!condition) throw std::runtime_error(message);
+}
+
+@interface CandidatePanelTestDelegate : NSObject <MetasequoiaCandidatePanelDelegate>
+@property(nonatomic, strong) NSAttributedString *selection;
+@property(nonatomic) NSUInteger nextPages;
+@end
+@implementation CandidatePanelTestDelegate
+- (void)candidateSelected:(NSAttributedString *)candidate { self.selection = candidate; }
+- (void)candidatePanelNextPage { ++self.nextPages; }
+- (void)candidatePanelPreviousPage {}
+@end
+
+int main()
+{
+    @autoreleasepool
+    {
+        [NSApplication sharedApplication];
+        MetasequoiaCandidatePanel *panel = [MetasequoiaCandidatePanel new];
+        CandidatePanelTestDelegate *delegate = [CandidatePanelTestDelegate new];
+        panel.delegate = delegate;
+        NSMutableArray *candidates = [NSMutableArray array];
+        for (NSUInteger index = 0; index < 9; ++index)
+            [candidates addObject:[[NSAttributedString alloc] initWithString:[NSString stringWithFormat:@"候选%lu", (unsigned long)index]]];
+        panel.panelType = kIMKSingleColumnScrollingCandidatePanel;
+        [panel setCandidateData:candidates];
+        const CGFloat nineHeight = panel.candidateFrame.size.height;
+        [panel setCandidateData:[candidates subarrayWithRange:NSMakeRange(0, 7)]];
+        const CGFloat sevenHeight = panel.candidateFrame.size.height;
+        [panel setCandidateData:[candidates subarrayWithRange:NSMakeRange(0, 5)]];
+        const CGFloat fiveHeight = panel.candidateFrame.size.height;
+        Require(fiveHeight < sevenHeight && sevenHeight < nineHeight, "Vertical window did not shrink with candidate count.");
+        Require(fiveHeight < nineHeight * 0.75, "Five-candidate window retained substantial empty row space.");
+        [panel setCandidateData:@[candidates[0]]];
+        Require(panel.candidateFrame.size.height < fiveHeight * 0.5, "A partial page retained the full page height.");
+        panel.panelType = kIMKSingleRowSteppingCandidatePanel;
+        [panel setCandidateData:candidates];
+        const CGFloat nineWidth = panel.candidateFrame.size.width;
+        [panel setCandidateData:[candidates subarrayWithRange:NSMakeRange(0, 5)]];
+        Require(panel.candidateFrame.size.width < nineWidth, "Horizontal window did not shrink with candidate count.");
+        const CGFloat smallHeight = panel.candidateFrame.size.height;
+        [panel setAttributes:@{NSFontAttributeName:[NSFont systemFontOfSize:20]}];
+        Require(panel.candidateFrame.size.height > smallHeight, "Candidate font size did not relayout the window.");
+        Require(!panel.window.canBecomeKeyWindow && !panel.window.canBecomeMainWindow,
+                "The candidate window can steal input focus.");
+        Require([panel selectCandidateWithIdentifier:3] && panel.selectedCandidate == 3 &&
+                    [panel.selectedCandidateString isEqual:candidates[3]], "Selection and displayed highlight disagree.");
+        Require(![panel selectCandidateWithIdentifier:8], "A nonvisible candidate could be selected.");
+        NSButton *candidateButton = nil;
+        for (NSView *view in panel.window.contentView.subviews)
+            if ([view isKindOfClass:NSButton.class] && view.tag == 3) candidateButton = (NSButton *)view;
+        Require(candidateButton != nil, "No clickable candidate was rendered.");
+        [candidateButton performClick:nil];
+        Require([delegate.selection isEqual:candidates[3]], "Click did not return the original attributed candidate.");
+        panel.hasNextPage = YES;
+        for (NSView *view in panel.window.contentView.subviews)
+            if ([view isKindOfClass:NSButton.class] && view.tag == -2) [(NSButton *)view performClick:nil];
+        Require(delegate.nextPages == 1, "The visible next-page button did not route to the controller.");
+        NSMutableString *longText = [NSMutableString string];
+        for (NSUInteger index = 0; index < 200; ++index) [longText appendString:@"长候选"];
+        NSAttributedString *longCandidate = [[NSAttributedString alloc] initWithString:longText];
+        [panel setCandidateData:@[longCandidate, longCandidate, longCandidate, longCandidate, longCandidate]];
+        Require(panel.candidateFrame.size.width <= NSScreen.mainScreen.visibleFrame.size.width,
+                "Long candidates pushed the window beyond the screen width.");
+        [panel setCandidateData:[candidates subarrayWithRange:NSMakeRange(0, 5)]];
+        for (NSScreen *screen in NSScreen.screens)
+        {
+            NSRect bounds = screen.visibleFrame;
+            panel.caretRect = NSMakeRect(NSMaxX(bounds) - 2, NSMinY(bounds) + 2, 0, 20);
+            [panel show:kIMKLocateCandidatesBelowHint];
+            Require(NSContainsRect(bounds, panel.candidateFrame), "A zero-width edge caret positioned the panel outside its screen.");
+            [panel hide];
+        }
+        panel.caretRect = NSZeroRect;
+        [panel show:kIMKLocateCandidatesBelowHint];
+        Require(!panel.isVisible, "An invalid caret displayed a misplaced candidate window.");
+        [panel setCandidateData:@[]];
+        Require(!panel.isVisible && panel.selectedCandidate == NSNotFound, "Empty data retained a visible selection.");
+    }
+}

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -159,7 +159,6 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("FloatingToolbarPanel.mm", cmake)
         self.assertIn("FloatingToolbarPanelTests.mm", cmake)
         self.assertIn('#import "FloatingToolbarPanel.h"', controller)
-        self.assertIn("<MetasequoiaFloatingToolbarDelegate>", controller)
         self.assertIn("[MetasequoiaFloatingToolbarPanel sharedPanel]", controller)
         self.assertIn("activateForDelegate:self", controller)
         self.assertIn("deactivateForDelegate:self", controller)


### PR DESCRIPTION
在 macOS 26.5 上，0.39.3 版本将每页候选数量设为 5 个后，横向和纵向布局仍会显示超过 5 个候选。此外，即使向原生候选窗口提供较少的候选项，窗口仍会保留多余的空白区域。

本次修改让控制器只提供当前页的候选，并将 `IMKCandidates` 的展示实现替换为不会抢占输入焦点的 AppKit 面板。面板尺寸随可见候选和配置字号调整，提供候选编号、上一页和下一页按钮，显示在光标附近，同时保持输入框的焦点。

翻页时保留候选在引擎中的全局索引，确保方向键、数字键、空格和鼠标操作都选中正确的候选。较长的候选文本会限制在屏幕宽度内，并通过悬停提示展示完整内容。组词与词库逻辑仍由现有引擎负责。

## 验证

- 全部 29 项 CTest 测试目标通过：包括项目原有的 27 项，以及本次新增的候选分页、AppKit 候选面板两项测试。
- 测试覆盖每页 5／7／9 个候选、横向与纵向布局、末页不足一页、键盘与鼠标选词、选择失败回滚、窗口尺寸调整和光标定位。
- 包含完整生成词库的 `arm64/x86_64` 双架构构建通过，临时签名校验通过。
- 我通过输入 `nikan` 复现了问题，并在安装更新后的构建后，验证问题已解决。