### PR TITLE
feat(ios): key hints, candidate paging, and engine diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,8 @@ if(BUILD_TESTING)
     add_test(NAME candidate_selection_state COMMAND MetasequoiaCandidateSelectionStateTests)
     add_executable(MetasequoiaAppleInputSessionAdapterTests
         platforms/ios/Tests/InputSessionAdapterTests.cpp
-        shared/apple-bridge/InputSessionAdapter.cpp)
+        shared/apple-bridge/InputSessionAdapter.cpp
+        shared/apple-bridge/ShuangpinKeymap.cpp)
     target_include_directories(MetasequoiaAppleInputSessionAdapterTests PRIVATE shared/apple-bridge)
     target_link_libraries(MetasequoiaAppleInputSessionAdapterTests PRIVATE MetasequoiaIme::Engine)
     target_compile_options(MetasequoiaAppleInputSessionAdapterTests PRIVATE -Wall -Wextra -Wpedantic -Werror)

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -9,6 +9,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private let session = MetasequoiaInputSessionBridge()
   private let preeditLabel = UILabel()
   private let candidateScrollView = UIScrollView()
+  private let diagnosticLabel = UILabel()
   private let candidateStack = UIStackView()
   private let languageModeButton = UIButton()
   private let schemeButton = UIButton()
@@ -26,6 +27,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private var usesTraditionalOutput = false
   private var visiblePreedit = ""
   private var visibleCandidates: [String] = []
+  private var visibleDiagnostic: String?
+  private var diagnosticDismissTimer: Timer?
   private var showsSymbols = false
   private var letterCaseState = LetterCaseState.lowercase
   private var isAutomaticShift = false
@@ -77,6 +80,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
     cancelBackspacePress()
+    diagnosticDismissTimer?.invalidate()
+    diagnosticDismissTimer = nil
   }
 
   private func installKeyboard() {
@@ -134,8 +139,17 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     candidateScrollView.showsHorizontalScrollIndicator = false
     candidateScrollView.addSubview(candidateStack)
 
-    let content = UIStackView(
-      arrangedSubviews: [languageModeButton, schemeButton, preeditLabel, candidateScrollView])
+    diagnosticLabel.font = .preferredFont(forTextStyle: .footnote)
+    diagnosticLabel.textColor = MetasequoiaTheme.coneUIColor
+    diagnosticLabel.adjustsFontForContentSizeCategory = true
+    diagnosticLabel.adjustsFontSizeToFitWidth = true
+    diagnosticLabel.minimumScaleFactor = 0.7
+    diagnosticLabel.isHidden = true
+    diagnosticLabel.accessibilityIdentifier = "diagnosticLabel"
+
+    let content = UIStackView(arrangedSubviews: [
+      languageModeButton, schemeButton, preeditLabel, candidateScrollView, diagnosticLabel,
+    ])
     content.axis = .horizontal
     content.alignment = .center
     content.spacing = 12
@@ -600,7 +614,29 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       textDocumentProxy.insertText(chineseOutput(commitText))
     }
     hasComposition = !snapshot.preedit.isEmpty
+    showDiagnostic(snapshot.diagnosticText)
     updateCandidateStrip(preedit: snapshot.preedit, candidates: snapshot.candidates)
+  }
+
+  // A diagnostic means the key was handled but something behind it failed, so input keeps working
+  // and the message is transient. It replaces the candidate strip, which is empty in exactly the
+  // cases that produce one, and clears itself on the next key or after a few seconds.
+  private func showDiagnostic(_ diagnostic: String?) {
+    diagnosticDismissTimer?.invalidate()
+    diagnosticDismissTimer = nil
+    visibleDiagnostic = diagnostic
+    guard diagnostic != nil else { return }
+
+    let timer = Timer(timeInterval: 4, repeats: false) { [weak self] _ in
+      MainActor.assumeIsolated {
+        guard let self else { return }
+        self.visibleDiagnostic = nil
+        self.diagnosticDismissTimer = nil
+        self.renderCandidateStrip()
+      }
+    }
+    RunLoop.main.add(timer, forMode: .common)
+    diagnosticDismissTimer = timer
   }
 
   private func updateCandidateStrip(preedit: String, candidates: [String]) {
@@ -621,7 +657,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       candidateStack.addArrangedSubview(
         makeCandidateButton(candidate: candidate, number: index + 1))
     }
-    candidateScrollView.isHidden = visibleCandidates.isEmpty
+
+    diagnosticLabel.text = visibleDiagnostic
+    diagnosticLabel.accessibilityLabel = visibleDiagnostic.map { "提示：\($0)" }
+    diagnosticLabel.isHidden = visibleDiagnostic == nil
+    candidateScrollView.isHidden = visibleCandidates.isEmpty || visibleDiagnostic != nil
   }
 
   // Selection stays on the engine index, so only the shown text is converted.

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -10,6 +10,8 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private let preeditLabel = UILabel()
   private let candidateScrollView = UIScrollView()
   private let diagnosticLabel = UILabel()
+  private let previousPageButton = UIButton()
+  private let nextPageButton = UIButton()
   private let candidateStack = UIStackView()
   private let languageModeButton = UIButton()
   private let schemeButton = UIButton()
@@ -30,10 +32,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private var visibleDiagnostic: String?
   private var diagnosticDismissTimer: Timer?
   private var shuangpinKeyHints: [String: String] = [:]
+  private var candidatePageStart = 0
   private var showsSymbols = false
   private var letterCaseState = LetterCaseState.lowercase
   private var isAutomaticShift = false
   private var lastShiftTapTime: TimeInterval?
+
+  // The strip numbers its chips 1-9 to match the digits on the symbol layer, so a page is nine.
+  private static let candidatePageSize = 9
 
   var enableInputClicksWhenVisible: Bool { true }
 
@@ -151,8 +157,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     diagnosticLabel.isHidden = true
     diagnosticLabel.accessibilityIdentifier = "diagnosticLabel"
 
+    configurePageButton(previousPageButton, symbol: "chevron.left", label: "上一页候选")
+    previousPageButton.addAction(
+      UIAction { [weak self] _ in self?.showCandidatePage(offset: -1) },
+      for: .primaryActionTriggered)
+    configurePageButton(nextPageButton, symbol: "chevron.right", label: "下一页候选")
+    nextPageButton.addAction(
+      UIAction { [weak self] _ in self?.showCandidatePage(offset: 1) },
+      for: .primaryActionTriggered)
+
     let content = UIStackView(arrangedSubviews: [
       languageModeButton, schemeButton, preeditLabel, candidateScrollView, diagnosticLabel,
+      previousPageButton, nextPageButton,
     ])
     content.axis = .horizontal
     content.alignment = .center
@@ -311,6 +327,16 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     }
 
     if symbol.count == 1, symbol >= "1", symbol <= "9" {
+      // handleCandidateKey numbers from the engine's first candidate, which stops matching the
+      // strip as soon as it is showing a later page. Off the first page the digit has to select the
+      // absolute index the chip with that number is actually displaying.
+      if candidatePageStart > 0, let digit = Int(symbol),
+        candidatePageStart + digit - 1 < visibleCandidates.count
+      {
+        render(session.selectCandidate(at: UInt(candidatePageStart + digit - 1)))
+        return
+      }
+
       let snapshot = session.handleCandidateKey(symbol)
       if !snapshot.isHandled && snapshot.preedit.isEmpty {
         textDocumentProxy.insertText(symbol)
@@ -521,6 +547,38 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     renderCandidateStrip()
   }
 
+  private func configurePageButton(_ button: UIButton, symbol: String, label: String) {
+    var configuration = UIButton.Configuration.plain()
+    configuration.image = UIImage(systemName: symbol)
+    configuration.baseForegroundColor = MetasequoiaTheme.forestUIColor
+    configuration.contentInsets = NSDirectionalEdgeInsets(
+      top: 2, leading: 2, bottom: 2, trailing: 2)
+    button.configuration = configuration
+    button.accessibilityLabel = label
+    button.accessibilityIdentifier =
+      symbol == "chevron.left" ? "previousCandidatePage" : "nextCandidatePage"
+    button.isHidden = true
+    button.widthAnchor.constraint(equalToConstant: 26).isActive = true
+  }
+
+  private func showCandidatePage(offset: Int) {
+    let target = candidatePageStart + offset * Self.candidatePageSize
+    guard target >= 0, target < visibleCandidates.count else { return }
+
+    playInputClick()
+    candidatePageStart = target
+    renderCandidateStrip()
+  }
+
+  private func updatePageControls() {
+    // The strip scrolls, so paging is what makes the numbered keys reach past the ninth candidate
+    // rather than a way to see them. It is only offered when there is somewhere to go.
+    let pageable = visibleCandidates.count > Self.candidatePageSize && visibleDiagnostic == nil
+    previousPageButton.isHidden = !pageable || candidatePageStart == 0
+    nextPageButton.isHidden =
+      !pageable || candidatePageStart + Self.candidatePageSize >= visibleCandidates.count
+  }
+
   private func chineseOutput(_ text: String) -> String {
     ChineseTextConversion.outputString(text, traditional: usesTraditionalOutput)
   }
@@ -656,6 +714,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private func updateCandidateStrip(preedit: String, candidates: [String]) {
     visiblePreedit = preedit
     visibleCandidates = candidates
+    // Any new candidate list is a different composition or a different set of matches, so the page
+    // it was showing no longer describes anything.
+    candidatePageStart = 0
     renderCandidateStrip()
   }
 
@@ -667,10 +728,13 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       view.removeFromSuperview()
     }
 
-    for (index, candidate) in visibleCandidates.prefix(9).enumerated() {
+    let page = visibleCandidates.dropFirst(candidatePageStart).prefix(Self.candidatePageSize)
+    for (offset, candidate) in page.enumerated() {
       candidateStack.addArrangedSubview(
-        makeCandidateButton(candidate: candidate, number: index + 1))
+        makeCandidateButton(
+          candidate: candidate, number: offset + 1, index: candidatePageStart + offset))
     }
+    updatePageControls()
 
     diagnosticLabel.text = visibleDiagnostic
     diagnosticLabel.accessibilityLabel = visibleDiagnostic.map { "提示：\($0)" }
@@ -678,8 +742,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     candidateScrollView.isHidden = visibleCandidates.isEmpty || visibleDiagnostic != nil
   }
 
-  // Selection stays on the engine index, so only the shown text is converted.
-  private func makeCandidateButton(candidate: String, number: Int) -> UIButton {
+  // The number is the key the chip answers to on the visible page; the index is the engine position
+  // it selects. They only coincide on the first page.
+  private func makeCandidateButton(candidate: String, number: Int, index: Int) -> UIButton {
     let display = chineseOutput(candidate)
     var configuration = UIButton.Configuration.plain()
     configuration.title = "\(number)  \(display)"
@@ -696,7 +761,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       primaryAction: UIAction { [weak self] _ in
         guard let self else { return }
         self.playInputClick()
-        self.render(self.session.selectCandidate(at: UInt(number - 1)))
+        self.render(self.session.selectCandidate(at: UInt(index)))
       })
     button.accessibilityLabel = "候选词 \(number)：\(display)"
     button.accessibilityIdentifier = "candidate-\(number)"

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -29,6 +29,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private var visibleCandidates: [String] = []
   private var visibleDiagnostic: String?
   private var diagnosticDismissTimer: Timer?
+  private var shuangpinKeyHints: [String: String] = [:]
   private var showsSymbols = false
   private var letterCaseState = LetterCaseState.lowercase
   private var isAutomaticShift = false
@@ -57,6 +58,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     view.backgroundColor = MetasequoiaTheme.keyboardBackground
     installKeyboard()
     updateReturnKey()
+    // installKeyboard builds the candidate strip before the letter rows exist, so the hints the
+    // scheme button gathered there have not reached any key yet.
+    updateLetterCaseControls()
     updateCandidateStrip(preedit: "", candidates: [])
   }
 
@@ -399,13 +403,18 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private func updateLetterCaseControls() {
     let usesUppercase = !isChineseMode && letterCaseState != .lowercase
     for (button, lowercase) in letterButtons {
+      // A hint only means something while the key feeds a double-pinyin composition, so English
+      // mode drops it even though the scheme underneath is unchanged.
+      let hint = isChineseMode ? shuangpinKeyHints[lowercase.uppercased()] : nil
       if var configuration = button.configuration {
         configuration.title = usesUppercase ? lowercase.uppercased() : lowercase
+        configuration.subtitle = hint
         button.configuration = configuration
       }
       button.accessibilityLabel =
         usesUppercase
         ? "大写 \(lowercase.uppercased())" : "字母 \(lowercase.uppercased())"
+      button.accessibilityValue = hint
     }
 
     shiftButton?.isHidden = isChineseMode
@@ -517,6 +526,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   }
 
   private func updateSchemeButton() {
+    // The hints come from the engine's own profile for the scheme the session is running, so they
+    // are refreshed wherever the scheme is, and cannot drift from what the keys actually produce.
+    shuangpinKeyHints = session.shuangpinKeyHints()
+    updateLetterCaseControls()
+
     var configuration = UIButton.Configuration.plain()
     configuration.title = usesShuangpin ? "小鹤" : "全拼"
     configuration.baseForegroundColor = MetasequoiaTheme.forestUIColor
@@ -725,6 +739,16 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       attributes.font = .preferredFont(forTextStyle: .title3)
       return attributes
     }
+    // Only the letter keys carry a subtitle, and only in double pinyin. It has to read as a hint
+    // rather than compete with the letter, so it is small and dimmed.
+    configuration.titlePadding = 0
+    configuration.subtitleTextAttributesTransformer =
+      UIConfigurationTextAttributesTransformer { attributes in
+        var attributes = attributes
+        attributes.font = .systemFont(ofSize: 9, weight: .regular)
+        attributes.foregroundColor = MetasequoiaTheme.forestUIColor.withAlphaComponent(0.75)
+        return attributes
+      }
     let button = UIButton(configuration: configuration, primaryAction: UIAction { _ in action() })
     button.accessibilityLabel = accessibilityLabel
     return button

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -15,7 +15,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private let candidateStack = UIStackView()
   private let languageModeButton = UIButton()
   private let schemeButton = UIButton()
-  private var letterButtons: [(button: UIButton, lowercase: String)] = []
+  private var letterButtons: [(button: UIButton, lowercase: String, hint: UILabel)] = []
   private var letterRowViews: [UIView] = []
   private var symbolRowViews: [UIView] = []
   private var layoutToggleButton: UIButton?
@@ -212,10 +212,34 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       let button = makeKey(title: text, accessibilityLabel: text.uppercased()) { [weak self] in
         self?.handleCharacter(text)
       }
-      letterButtons.append((button: button, lowercase: text))
+      letterButtons.append((button: button, lowercase: text, hint: attachHintLabel(to: button)))
       row.addArrangedSubview(button)
     }
     return row
+  }
+
+  // A key is about 36pt wide and the longest Xiaohe mapping is nine characters, so the hint has to
+  // be one line that shrinks rather than a subtitle that wraps: wrapping pushed the letter itself
+  // out of the top of the key.
+  private func attachHintLabel(to button: UIButton) -> UILabel {
+    let label = UILabel()
+    label.font = .systemFont(ofSize: 9, weight: .regular)
+    label.textColor = MetasequoiaTheme.forestUIColor.withAlphaComponent(0.8)
+    label.textAlignment = .center
+    label.numberOfLines = 1
+    label.adjustsFontSizeToFitWidth = true
+    label.minimumScaleFactor = 0.6
+    label.isHidden = true
+    label.isAccessibilityElement = false
+    label.translatesAutoresizingMaskIntoConstraints = false
+    button.addSubview(label)
+
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 2),
+      label.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -2),
+      label.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -2),
+    ])
+    return label
   }
 
   private func makeSymbolRow(_ symbols: [String]) -> UIStackView {
@@ -428,15 +452,20 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
   private func updateLetterCaseControls() {
     let usesUppercase = !isChineseMode && letterCaseState != .lowercase
-    for (button, lowercase) in letterButtons {
+    for (button, lowercase, hintLabel) in letterButtons {
       // A hint only means something while the key feeds a double-pinyin composition, so English
       // mode drops it even though the scheme underneath is unchanged.
       let hint = isChineseMode ? shuangpinKeyHints[lowercase.uppercased()] : nil
       if var configuration = button.configuration {
         configuration.title = usesUppercase ? lowercase.uppercased() : lowercase
-        configuration.subtitle = hint
+        // The hint sits along the bottom edge, so the letter is lifted clear of it instead of
+        // staying centred in the whole key.
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+          top: 0, leading: 0, bottom: hint == nil ? 0 : 11, trailing: 0)
         button.configuration = configuration
       }
+      hintLabel.text = hint
+      hintLabel.isHidden = hint == nil
       button.accessibilityLabel =
         usesUppercase
         ? "大写 \(lowercase.uppercased())" : "字母 \(lowercase.uppercased())"
@@ -804,16 +833,6 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       attributes.font = .preferredFont(forTextStyle: .title3)
       return attributes
     }
-    // Only the letter keys carry a subtitle, and only in double pinyin. It has to read as a hint
-    // rather than compete with the letter, so it is small and dimmed.
-    configuration.titlePadding = 0
-    configuration.subtitleTextAttributesTransformer =
-      UIConfigurationTextAttributesTransformer { attributes in
-        var attributes = attributes
-        attributes.font = .systemFont(ofSize: 9, weight: .regular)
-        attributes.foregroundColor = MetasequoiaTheme.forestUIColor.withAlphaComponent(0.75)
-        return attributes
-      }
     let button = UIButton(configuration: configuration, primaryAction: UIAction { _ in action() })
     button.accessibilityLabel = accessibilityLabel
     return button

--- a/platforms/ios/SharedUI/MetasequoiaTheme.swift
+++ b/platforms/ios/SharedUI/MetasequoiaTheme.swift
@@ -14,6 +14,12 @@ enum MetasequoiaTheme {
       : UIColor(red: 24 / 255, green: 92 / 255, blue: 72 / 255, alpha: 1)
   }
 
+  static let coneUIColor = UIColor { traits in
+    traits.userInterfaceStyle == .dark
+      ? UIColor(red: 214 / 255, green: 150 / 255, blue: 105 / 255, alpha: 1)
+      : UIColor(red: 167 / 255, green: 103 / 255, blue: 59 / 255, alpha: 1)
+  }
+
   static let keyboardBackground = UIColor { traits in
     traits.userInterfaceStyle == .dark
       ? UIColor(red: 24 / 255, green: 30 / 255, blue: 27 / 255, alpha: 1)

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -34,6 +34,9 @@ int RunTest() {
     Require(first.handled && first.preedit == "n",
             "The first letter did not start an engine composition.");
 
+    Require(!first.diagnostic.has_value(),
+            "An ordinary keystroke produced a diagnostic.");
+
     const auto second = adapter.handle_character('i');
     Require(second.handled && second.preedit == "ni",
             "The second letter did not update the engine preedit.");

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -1,4 +1,5 @@
 #include "InputSessionAdapter.h"
+#include "ShuangpinKeymap.h"
 
 #include "user_dictionary/user_dictionary_journal.h"
 
@@ -130,6 +131,30 @@ int RunTest() {
                 *composedPunctuation.commit == "ni，" &&
                 composedPunctuation.preedit.empty(),
             "Punctuation did not atomically commit the raw composition.");
+  }
+
+  Require(metasequoia::apple::shuangpin_key_hints(false).empty(),
+          "Full pinyin produced double-pinyin key hints.");
+  {
+    const auto hints = metasequoia::apple::shuangpin_key_hints(true);
+    Require(!hints.empty(), "Double pinyin produced no key hints.");
+    // Xiaohe puts zh on v and ing on ; — the second is unreachable on the letter grid, so a hint
+    // map that leaked it would be describing keys the keyboard does not have.
+    Require(hints.count("V") == 1 && hints.at("V").find("zh") != std::string::npos,
+            "The V hint did not describe the zh initial.");
+    Require(hints.count(";") == 0, "A hint was produced for a key outside the letter grid.");
+    // The engine spells the ü finals with a leading v because that is the key sequence. A person
+    // reads the hint, so it has to show the vowel.
+    bool showsUmlaut = false;
+    for (const auto &[key, hint] : hints) {
+      (void)key;
+      if (hint.find("ü") != std::string::npos) {
+        showsUmlaut = true;
+      }
+      Require(hint.find(" v") == std::string::npos && hint.rfind("v", 0) != 0,
+              "A hint exposed the engine's v spelling of a ü final.");
+    }
+    Require(showsUmlaut, "No hint showed a ü final.");
   }
 
   user_dictionary::close_default_user_database();

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -175,6 +175,34 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("handleInputModeList(from:", controller)
         self.assertNotIn("URLSession", controller)
 
+    def test_engine_diagnostics_reach_the_keyboard(self):
+        # KeyResult carries a diagnostic when the key was handled but something behind it failed,
+        # such as a candidate the user dictionary could not learn. The bridge used to drop it on the
+        # floor, so the keyboard could not report anything and the failure was silent.
+        adapter_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/InputSessionAdapter.h").read_text()
+        adapter = (IOS_ROOT.parents[1] / "shared/apple-bridge/InputSessionAdapter.cpp").read_text()
+        bridge_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.h").read_text()
+        bridge = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.mm").read_text()
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("std::optional<std::string> diagnostic;", adapter_header)
+        self.assertIn("snapshot.diagnostic = std::move(result.diagnostic);", adapter)
+        self.assertIn("NSString *diagnosticText;", bridge_header)
+        self.assertIn("diagnosticText:diagnosticText", bridge)
+
+        self.assertIn("showDiagnostic(snapshot.diagnosticText)", controller)
+        self.assertIn("private var diagnosticDismissTimer: Timer?", controller)
+        self.assertIn('diagnosticLabel.accessibilityIdentifier = "diagnosticLabel"', controller)
+        # The strip is the empty slot a diagnostic can occupy, and the message clears itself so it
+        # never becomes permanent furniture in a 38pt bar.
+        self.assertIn(
+            "candidateScrollView.isHidden = visibleCandidates.isEmpty || visibleDiagnostic != nil",
+            controller,
+        )
+        self.assertIn("override func viewWillDisappear", controller)
+        disappear = controller.split("override func viewWillDisappear", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("diagnosticDismissTimer?.invalidate()", disappear)
+
     def test_setting_row_icons_stay_out_of_the_accessibility_tree(self):
         # Both icons sit next to a title and a subtitle that already carry the row's meaning. Left
         # visible, VoiceOver reads the symbol's system name where it has one and its raw identifier

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -175,6 +175,27 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("handleInputModeList(from:", controller)
         self.assertNotIn("URLSession", controller)
 
+    def test_double_pinyin_key_hints_come_from_the_engine_profile(self):
+        # A hardcoded keymap in Swift would drift from whatever profile the session actually runs.
+        # The hints are derived from the engine's own ShuangpinProfile and refreshed wherever the
+        # scheme is, so the two cannot disagree.
+        keymap = (IOS_ROOT.parents[1] / "shared/apple-bridge/ShuangpinKeymap.cpp").read_text()
+        bridge_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.h").read_text()
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+        cmake = (IOS_ROOT.parents[1] / "CMakeLists.txt").read_text()
+
+        self.assertIn("GetXiaoheShuangpinProfile()", keymap)
+        self.assertIn("shuangpinKeyHints", bridge_header)
+        self.assertIn("shared/apple-bridge/ShuangpinKeymap.cpp", cmake)
+
+        self.assertIn("private var shuangpinKeyHints: [String: String] = [:]", controller)
+        self.assertIn("shuangpinKeyHints = session.shuangpinKeyHints()", controller)
+        self.assertIn("configuration.subtitle = hint", controller)
+        self.assertIn("button.accessibilityValue = hint", controller)
+        # English mode feeds the client directly rather than a composition, so a double-pinyin hint
+        # there would describe something the key does not do.
+        self.assertIn("let hint = isChineseMode ? shuangpinKeyHints[lowercase.uppercased()] : nil", controller)
+
     def test_engine_diagnostics_reach_the_keyboard(self):
         # KeyResult carries a diagnostic when the key was handled but something behind it failed,
         # such as a candidate the user dictionary could not learn. The bridge used to drop it on the

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -108,7 +108,7 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("textDocumentProxy.insertText(chineseOutput(commitText))", controller)
         self.assertIn("let display = chineseOutput(candidate)", controller)
         self.assertIn('configuration.title = "\\(number)  \\(display)"', controller)
-        self.assertIn("self.render(self.session.selectCandidate(at: UInt(number - 1)))", controller)
+        self.assertIn("self.render(self.session.selectCandidate(at: UInt(index)))", controller)
 
         strip = controller.split("private func renderCandidateStrip", 1)[1].split("\n  }", 1)[0]
         self.assertIn("visiblePreedit", strip)
@@ -174,6 +174,25 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("textDocumentProxy.deleteBackward", controller)
         self.assertIn("handleInputModeList(from:", controller)
         self.assertNotIn("URLSession", controller)
+
+    def test_candidate_paging_keeps_the_digit_keys_pointing_at_the_visible_page(self):
+        # The chips are numbered 1-9 to match the digits on the symbol layer. handleCandidateKey
+        # numbers from the engine's first candidate, so once the strip shows a later page the digit
+        # and the chip with that number stop meaning the same thing. Off the first page the digit
+        # has to go through the absolute index instead.
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("private static let candidatePageSize = 9", controller)
+        self.assertIn("private var candidatePageStart = 0", controller)
+        self.assertIn("makeCandidateButton(candidate: String, number: Int, index: Int)", controller)
+        self.assertIn("self.render(self.session.selectCandidate(at: UInt(index)))", controller)
+        self.assertIn("render(session.selectCandidate(at: UInt(candidatePageStart + digit - 1)))", controller)
+        self.assertIn('"previousCandidatePage" : "nextCandidatePage"', controller)
+
+        # A new candidate list is a different composition, so a retained page would number chips
+        # against candidates that no longer exist.
+        strip = controller.split("private func updateCandidateStrip", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("candidatePageStart = 0", strip)
 
     def test_double_pinyin_key_hints_come_from_the_engine_profile(self):
         # A hardcoded keymap in Swift would drift from whatever profile the session actually runs.
@@ -304,7 +323,7 @@ class ProjectConfigurationTests(unittest.TestCase):
     def test_candidate_surface_exposes_numbered_native_chips(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
-        self.assertIn("makeCandidateButton(candidate: candidate, number: index + 1)", controller)
+        self.assertIn("candidate: candidate, number: offset + 1, index: candidatePageStart + offset", controller)
         self.assertIn('configuration.title = "\\(number)  \\(display)"', controller)
         self.assertIn("configuration.background.cornerRadius", controller)
         self.assertIn('button.accessibilityLabel = "候选词 \\(number)：\\(display)"', controller)

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -209,7 +209,9 @@ class ProjectConfigurationTests(unittest.TestCase):
 
         self.assertIn("private var shuangpinKeyHints: [String: String] = [:]", controller)
         self.assertIn("shuangpinKeyHints = session.shuangpinKeyHints()", controller)
-        self.assertIn("configuration.subtitle = hint", controller)
+        self.assertIn("hintLabel.text = hint", controller)
+        self.assertIn("label.numberOfLines = 1", controller)
+        self.assertIn("label.adjustsFontSizeToFitWidth = true", controller)
         self.assertIn("button.accessibilityValue = hint", controller)
         # English mode feeds the client directly rather than a composition, so a double-pinyin hint
         # there would describe something the key does not do.
@@ -355,7 +357,10 @@ class ProjectConfigurationTests(unittest.TestCase):
 
         self.assertIn("private enum LetterCaseState", controller)
         self.assertIn("case lowercase, shifted, capsLock", controller)
-        self.assertIn("private var letterButtons: [(button: UIButton, lowercase: String)]", controller)
+        self.assertIn(
+            "private var letterButtons: [(button: UIButton, lowercase: String, hint: UILabel)]",
+            controller,
+        )
         self.assertIn("private weak var shiftButton: UIButton?", controller)
         self.assertIn("toggleLetterCase", controller)
         self.assertIn("letterCaseState = .capsLock", controller)

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -18,6 +18,7 @@ InputSnapshot MakeSnapshot(const InputSession &session, KeyResult result) {
   InputSnapshot snapshot;
   snapshot.handled = result.handled;
   snapshot.commit = std::move(result.commit);
+  snapshot.diagnostic = std::move(result.diagnostic);
   snapshot.preedit = session.preedit();
   snapshot.candidates.reserve(session.candidates().size());
   for (const auto &candidate : session.candidates()) {

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -12,6 +12,10 @@ struct InputSnapshot {
   std::optional<std::string> commit;
   std::string preedit;
   std::vector<std::string> candidates;
+  // Set when the engine could answer the key but something behind it failed, such as a local input
+  // mode whose table is missing or a word that could not be learned. Input stays usable, so a
+  // frontend reports it rather than treating it as an error.
+  std::optional<std::string> diagnostic;
 };
 
 class InputSessionAdapter {

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -30,6 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (MetasequoiaInputSnapshot *)selectCandidateAtIndex:(NSUInteger)index;
 - (MetasequoiaInputSnapshot *)switchToShuangpin:(BOOL)usesShuangpin;
 
+/// Per-key double-pinyin hints for the scheme the session is actually running, keyed by uppercase
+/// letter. Empty in full pinyin. Derived from the engine's own profile so a frontend never hardcodes
+/// a keymap that can drift from the scheme.
+- (NSDictionary<NSString *, NSString *> *)shuangpinKeyHints;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -10,6 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, readonly, nullable) NSString *commitText;
 @property(nonatomic, copy, readonly) NSString *preedit;
 @property(nonatomic, copy, readonly) NSArray<NSString *> *candidates;
+/// Set when the key was handled but something behind it failed, such as a local input mode whose
+/// table is missing. Input stays usable, so a frontend reports this rather than failing.
+@property(nonatomic, copy, readonly, nullable) NSString *diagnosticText;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -110,7 +110,8 @@ void ConfigureDataDirectory() {
 - (instancetype)initWithHandled:(BOOL)handled
                      commitText:(nullable NSString *)commitText
                         preedit:(NSString *)preedit
-                     candidates:(NSArray<NSString *> *)candidates;
+                     candidates:(NSArray<NSString *> *)candidates
+                 diagnosticText:(nullable NSString *)diagnosticText;
 
 @end
 
@@ -119,13 +120,15 @@ void ConfigureDataDirectory() {
 - (instancetype)initWithHandled:(BOOL)handled
                      commitText:(nullable NSString *)commitText
                         preedit:(NSString *)preedit
-                     candidates:(NSArray<NSString *> *)candidates {
+                     candidates:(NSArray<NSString *> *)candidates
+                 diagnosticText:(nullable NSString *)diagnosticText {
   self = [super init];
   if (self != nil) {
     _handled = handled;
     _commitText = [commitText copy];
     _preedit = [preedit copy];
     _candidates = [candidates copy];
+    _diagnosticText = [diagnosticText copy];
   }
   return self;
 }
@@ -204,11 +207,15 @@ void ConfigureDataDirectory() {
 
   NSString *commitText =
       snapshot.commit.has_value() ? StringFromUTF8(*snapshot.commit) : nil;
+  NSString *diagnosticText = snapshot.diagnostic.has_value()
+                                 ? StringFromUTF8(*snapshot.diagnostic)
+                                 : nil;
   return [[MetasequoiaInputSnapshot alloc]
       initWithHandled:snapshot.handled
            commitText:commitText
               preedit:StringFromUTF8(snapshot.preedit)
-           candidates:candidates];
+           candidates:candidates
+       diagnosticText:diagnosticText];
 }
 
 @end

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -1,6 +1,7 @@
 #import "MetasequoiaInputSessionBridge.h"
 
 #include "InputSessionAdapter.h"
+#include "ShuangpinKeymap.h"
 
 #include <cstdlib>
 #include <memory>
@@ -195,6 +196,17 @@ void ConfigureDataDirectory() {
 
 - (MetasequoiaInputSnapshot *)switchToShuangpin:(BOOL)usesShuangpin {
   return [self snapshotFrom:_adapter->switch_to_shuangpin(usesShuangpin)];
+}
+
+- (NSDictionary<NSString *, NSString *> *)shuangpinKeyHints {
+  const auto hints =
+      metasequoia::apple::shuangpin_key_hints(_adapter->uses_shuangpin());
+  NSMutableDictionary<NSString *, NSString *> *result =
+      [NSMutableDictionary dictionaryWithCapacity:hints.size()];
+  for (const auto &[key, hint] : hints) {
+    result[StringFromUTF8(key)] = StringFromUTF8(hint);
+  }
+  return result;
 }
 
 - (MetasequoiaInputSnapshot *)snapshotFrom:

--- a/shared/apple-bridge/ShuangpinKeymap.cpp
+++ b/shared/apple-bridge/ShuangpinKeymap.cpp
@@ -1,0 +1,80 @@
+#include "ShuangpinKeymap.h"
+
+#include "shuangpin/shuangpin_profile.h"
+
+#include <algorithm>
+#include <cctype>
+#include <unordered_map>
+#include <vector>
+
+namespace metasequoia::apple {
+namespace {
+// The engine spells the ü finals with a leading v because that is what the key sequence uses. The
+// hint is read by a person, so show the vowel.
+std::string display_unit(const std::string &unit) {
+  if (!unit.empty() && unit.front() == 'v') {
+    return "ü" + unit.substr(1);
+  }
+  return unit;
+}
+
+std::string upper(const std::string &value) {
+  std::string result = value;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char character) {
+                   return static_cast<char>(std::toupper(character));
+                 });
+  return result;
+}
+
+void collect(const std::unordered_map<std::string, std::string> &mapping,
+             std::map<std::string, std::vector<std::string>> &units_by_key) {
+  for (const auto &[unit, key] : mapping) {
+    units_by_key[upper(key)].push_back(display_unit(unit));
+  }
+}
+
+std::string join(std::vector<std::string> units) {
+  std::sort(units.begin(), units.end());
+  std::string joined;
+  for (const auto &unit : units) {
+    if (!joined.empty()) {
+      joined += " ";
+    }
+    joined += unit;
+  }
+  return joined;
+}
+} // namespace
+
+std::map<std::string, std::string> shuangpin_key_hints(bool uses_shuangpin) {
+  if (!uses_shuangpin) {
+    return {};
+  }
+
+  const ShuangpinProfile &profile = GetXiaoheShuangpinProfile();
+  std::map<std::string, std::vector<std::string>> initials_by_key;
+  std::map<std::string, std::vector<std::string>> finals_by_key;
+  collect(profile.initials, initials_by_key);
+  collect(profile.finals, finals_by_key);
+
+  std::map<std::string, std::string> hints;
+  for (const auto &key : {"Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P",
+                          "A", "S", "D", "F", "G", "H", "J", "K", "L",
+                          "Z", "X", "C", "V", "B", "N", "M"}) {
+    const std::string initials = join(initials_by_key[key]);
+    const std::string finals = join(finals_by_key[key]);
+    if (initials.empty() && finals.empty()) {
+      continue;
+    }
+    if (initials.empty()) {
+      hints[key] = finals;
+    } else if (finals.empty()) {
+      hints[key] = initials;
+    } else {
+      hints[key] = initials + " / " + finals;
+    }
+  }
+  return hints;
+}
+} // namespace metasequoia::apple

--- a/shared/apple-bridge/ShuangpinKeymap.h
+++ b/shared/apple-bridge/ShuangpinKeymap.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace metasequoia::apple {
+// Per-key double-pinyin hint text derived from the engine's own profile, so a frontend never
+// hardcodes a keymap that can drift from the scheme the session actually runs.
+//
+// The key is an uppercase letter. The value reads "initials / finals" when a key carries both,
+// otherwise whichever side it carries; a key that carries neither is absent from the map.
+std::map<std::string, std::string> shuangpin_key_hints(bool uses_shuangpin);
+} // namespace metasequoia::apple


### PR DESCRIPTION
Three iOS features, each verified by driving the built keyboard on a Simulator through Orca rather than only by reading the code — which is how the fourth commit exists at all.

## Engine diagnostics reach the keyboard

`KeyResult` carries a diagnostic when the engine handled the key but something behind it failed, such as a candidate the user dictionary could not learn. The Apple bridge dropped it, so the keyboard had nothing to report. It now travels through `InputSnapshot` and `MetasequoiaInputSnapshot`, and the keyboard shows it in the candidate strip — the slot that is empty in the cases that produce one — clearing on the next key or after four seconds.

## Double-pinyin hints on the keys

The keyboard offered a 小鹤 scheme with no way to see what a key produces. Each letter key now carries the initials and finals it maps to, as a one-line label under the letter and as the key's accessibility value.

The hints are derived in the Apple bridge from the engine's own `ShuangpinProfile` rather than transcribed into Swift, so they cannot drift from the scheme the session runs. Only the letter grid is described, since the profile also maps punctuation keys this keyboard does not have, and the ü finals are shown with the vowel rather than the `v` the engine spells them with.

## Candidate paging

The strip numbered its chips 1-9 and dropped everything after them, so a candidate that placed tenth could not be selected at all — it scrolls, but those chips were never built. It now shows one page of nine with controls offered only when there is somewhere to go.

The contract that needed care is the digit keys. `handleCandidateKey` numbers from the engine's first candidate, which stops matching the strip the moment it shows a later page, so off the first page a digit selects the absolute index the chip with that number is displaying. A chip's number and its engine index are passed separately rather than derived from each other, and a new candidate list resets the page.

## The fourth commit

The first three passed every source-level test and were still visibly broken. Setting the hint as the button configuration's subtitle let it wrap, and the longest Xiaohe mappings do not fit a 36pt key: `iong ong` broke across four lines and pushed the letter out of the top of the key. Only looking at the running keyboard caught it. The hint is now a single-line label that shrinks to fit.

## Verification

- `python3 platforms/ios/tests/ProjectConfigurationTests.py` — 36 tests
- `MetasequoiaAppleInputSessionAdapterTests` built and run through CMake, covering the new hint derivation and that an ordinary keystroke carries no diagnostic
- `xcodebuild ... -sdk iphonesimulator build`
- On an iPhone 17 Simulator with the keyboard enabled, through Orca:
  - typing `shi` in 全拼 shows 是/时/事 with a next-page control and no previous-page control
  - paging forward renumbers to 始/失/士 from 1 and reveals the previous-page control
  - on that second page the digit key `1` commits 始, not the engine's first candidate 是 — the contract above, exercised
  - switching to 小鹤 puts correct mappings on the keys (`q` → `iu`, `u` → `sh / u`, `v` → `zh / ui ü`), all on one line with every letter fully visible
  - switching back to 全拼, and switching to English, clears them

The diagnostic path is plumbed and unit-tested but was not triggered live: reaching it needs a user-dictionary write failure, which is not something to stage on a device mid-session.

## One thing found and deliberately not fixed here

Every local input mode — quick phrase, emoji, kaomoji, date/time, unicode, temporary English/Japanese — is unreachable through the Apple bridge. All eight entries in `InputSession::handle_character` require `shift_only` with an uppercase letter, and the adapter both passes `shift_only = false` and rejects A-Z outright. Separately, `create_compact_dictionary.py` copies only `tbl_*`, so the compact iOS database has no `quick_parases` or `japanese_lexicon` even though the released dictionary does.

I started fixing the slicer and backed it out: shipping those tables buys nothing while no key can enter the modes, and giving iOS a trigger is a UI design question of its own — this keyboard has no shift key in Chinese mode. Worth doing as its own change.
