### PR TITLE
chore: 忽略 iOS 词库打包生成的两个产物

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.DS_Store
 /platforms/ios/KeyboardExtension/Resources/msime.db
 /platforms/ios/KeyboardExtension/Resources/msime.db.sha256
+/platforms/ios/KeyboardExtension/Resources/dictionary-manifest.json
+/platforms/ios/KeyboardExtension/Resources/SHA256SUMS.txt


### PR DESCRIPTION
`platforms/ios/KeyboardExtension/Resources/` 下已经忽略了 `msime.db` 和 `msime.db.sha256`,但同一步还会写 `dictionary-manifest.json` 和 `SHA256SUMS.txt`,这两个没被覆盖,于是以未跟踪状态留在工作区,离 `git add -A` 只差一步。

它们是生成物的生成物:manifest 里记的是 `source_database_sha256`,提交进去之后词库一动就过期。

验证:在 Resources 下造出这三个文件再 `git add -A`,只有 `.gitignore` 被暂存。

顺带一提,`origin/architecture/dictionary-products` 那条分支(单个提交 `e6ae396`,**没有开 PR**)也加了同样的两条规则,但它同时重写了 `create_compact_dictionary.py`、`prepare_dictionary.py`、`build_dictionary.py` 并动了 Dict submodule pin——而 #239 已经把 `build_dictionary.py` 和 Dict submodule 从 main 删掉了,那条分支现在和 main 冲突面很大。这个 PR 只取两行 ignore 规则,不预判那条分支的去留。
