### PR TITLE
fix(ios): keep every candidate commit on the visible page

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -353,11 +353,14 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     if symbol.count == 1, symbol >= "1", symbol <= "9" {
       // handleCandidateKey numbers from the engine's first candidate, which stops matching the
       // strip as soon as it is showing a later page. Off the first page the digit has to select the
-      // absolute index the chip with that number is actually displaying.
-      if candidatePageStart > 0, let digit = Int(symbol),
-        candidatePageStart + digit - 1 < visibleCandidates.count
-      {
-        render(session.selectCandidate(at: UInt(candidatePageStart + digit - 1)))
+      // absolute index the chip with that number is actually displaying, and a digit with no chip
+      // on this page has to do nothing: falling through would hand it to handleCandidateKey and
+      // commit a first-page candidate the user cannot see.
+      if candidatePageStart > 0, let digit = Int(symbol) {
+        let index = candidatePageStart + digit - 1
+        if index < visibleCandidates.count {
+          render(session.selectCandidate(at: UInt(index)))
+        }
         return
       }
 
@@ -688,9 +691,22 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     handleBackspace()
   }
 
+  // Space means "commit the leading candidate", and that has to be the leading candidate the strip
+  // is showing. commitCandidate always takes the engine's first, which on a later page is off
+  // screen, so the page's own first chip is selected by index instead. On the first page the two
+  // are the same candidate, and only commitCandidate reports itself unhandled when there is
+  // nothing to commit, which is what tells the caller to insert its space. Return and the
+  // language switch flush the whole composition through finishComposition instead.
+  private func commitVisibleCandidate() -> MetasequoiaInputSnapshot {
+    if candidatePageStart > 0, candidatePageStart < visibleCandidates.count {
+      return session.selectCandidate(at: UInt(candidatePageStart))
+    }
+    return session.commitCandidate()
+  }
+
   private func handleSpace() {
     playInputClick()
-    let snapshot = session.commitCandidate()
+    let snapshot = commitVisibleCandidate()
     if !snapshot.isHandled {
       textDocumentProxy.insertText(" ")
     }

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -186,13 +186,47 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("private var candidatePageStart = 0", controller)
         self.assertIn("makeCandidateButton(candidate: String, number: Int, index: Int)", controller)
         self.assertIn("self.render(self.session.selectCandidate(at: UInt(index)))", controller)
-        self.assertIn("render(session.selectCandidate(at: UInt(candidatePageStart + digit - 1)))", controller)
+        self.assertIn("let index = candidatePageStart + digit - 1", controller)
+        self.assertIn("render(session.selectCandidate(at: UInt(index)))", controller)
         self.assertIn('"previousCandidatePage" : "nextCandidatePage"', controller)
 
         # A new candidate list is a different composition, so a retained page would number chips
         # against candidates that no longer exist.
         strip = controller.split("private func updateCandidateStrip", 1)[1].split("\n  }", 1)[0]
         self.assertIn("candidatePageStart = 0", strip)
+
+        # A digit with no chip on the current page must be swallowed, not fall through. The
+        # fall-through reached handleCandidateKey, which numbers from the engine's first candidate,
+        # so pressing 7 on a last page of six chips committed the seventh candidate overall — one
+        # the user could not see and had not asked for.
+        digits = controller.split('symbol >= "1", symbol <= "9"', 1)[1].split("\n    }", 1)[0]
+        self.assertIn("if candidatePageStart > 0, let digit = Int(symbol) {", digits)
+        paged = digits.split("if candidatePageStart > 0", 1)[1].split("\n      }", 1)[0]
+        self.assertIn("return", paged)
+        self.assertNotIn("handleCandidateKey", paged)
+
+    def test_committing_the_leading_candidate_follows_the_visible_page(self):
+        # commitCandidate always takes the engine's first candidate, which is off screen once the
+        # strip has paged. Space, return and the language switch all mean "take what is showing".
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+
+        self.assertIn("private func commitVisibleCandidate() -> MetasequoiaInputSnapshot {", controller)
+        helper = controller.split("private func commitVisibleCandidate", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("candidatePageStart > 0, candidatePageStart < visibleCandidates.count", helper)
+        self.assertIn("session.selectCandidate(at: UInt(candidatePageStart))", helper)
+        # The unhandled report is what tells space and return to insert their own character, and
+        # only commitCandidate produces it, so the first-page path has to keep using it.
+        self.assertIn("return session.commitCandidate()", helper)
+
+        space = controller.split("private func handleSpace", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("commitVisibleCandidate()", space)
+        self.assertNotIn("session.commitCandidate()", space)
+
+        # Return and the language switch flush the whole pending composition rather than pick one
+        # candidate, so they stay on finishComposition and are not part of this rule.
+        for caller in ("private func handleReturn", "private func toggleInputMode"):
+            body = controller.split(caller, 1)[1].split("\n  }", 1)[0]
+            self.assertIn("finishComposition()", body)
 
     def test_double_pinyin_key_hints_come_from_the_engine_profile(self):
         # A hardcoded keymap in Swift would drift from whatever profile the session actually runs.


### PR DESCRIPTION
Two ways the candidate strip and the engine's numbering could disagree. Both arrived with paging in #244, and both commit a word the user never saw.

## A digit with no chip on the page

The paged branch only handled a digit when the chip existed. Otherwise it fell through to `handleCandidateKey`, which numbers from the engine's first candidate.

Typing `shi` gives well over a hundred candidates. Page to the last one, which holds three chips, and press 9: the engine commits its ninth candidate — a first-page character. Nothing on screen carried a 9.

The digit is now swallowed on a later page when nothing there answers to it. That is what the first page already did: `handleCandidateKey` reports itself unhandled for a candidate that does not exist, and the digit is only inserted as text when there is no composition at all.

## Space, return and the language switch

All three committed through `commitCandidate`, which always takes the engine's first candidate. Once the strip has paged, that candidate is off screen — so "commit the leading candidate" meant a different word from the one the strip was leading with.

They now share one helper that selects the visible page's first chip by index. On the first page it falls back to `commitCandidate`, because the two are the same candidate there and only `commitCandidate` reports itself unhandled when there is nothing to commit, which is what tells space and return to insert their own character.

## Verification

Both fixes were exercised on an iPhone 17 Simulator with the keyboard enabled, driven through Orca, on the build from this branch:

- typed `shi` in 全拼 and paged to the last page — three chips, 鰘 / 鰤 / 鳾, and only a previous-page control
- pressed 9 on the digit layer: the field stayed empty and the strip stayed on the last page, unchanged. Before this change that keystroke committed the ninth candidate overall
- pressed space on the same page: it committed **鰘**, the page's first chip, rather than 是, the engine's first candidate

Also confirmed in passing that a keystroke which alters the composition resets the page — an accidental apostrophe rewrote the candidate list and the strip correctly returned to page 1.

`ProjectConfigurationTests` — 37 tests, including new assertions that the paged digit branch never reaches `handleCandidateKey` and that space, return and the language switch all go through the helper.
