### PR TITLE
fix(mac): keep the highlighted candidate when a commit happens automatically

### DIFF
--- a/platforms/macos/src/CandidateSelectionState.h
+++ b/platforms/macos/src/CandidateSelectionState.h
@@ -40,19 +40,32 @@ class CandidateSelectionState
         return selected_candidate_.has_value() ? std::optional<size_t>(selected_candidate_->index) : std::nullopt;
     }
 
+    // A tracked index only means something while the candidate list still holds the same word at
+    // it. The list is rebuilt on every keystroke, so an index kept across one is not the candidate
+    // the user was looking at.
+    std::optional<size_t> live_selected_index(const InputSession &session) const
+    {
+        if (!selected_candidate_.has_value())
+        {
+            return std::nullopt;
+        }
+        const auto &candidates = session.candidates();
+        if (selected_candidate_->index < candidates.size()
+            && candidates[selected_candidate_->index].word == selected_candidate_->word)
+        {
+            return selected_candidate_->index;
+        }
+        return std::nullopt;
+    }
+
     KeyResult commit(InputSession &session) const
     {
-        if (selected_candidate_.has_value())
+        if (const auto index = live_selected_index(session))
         {
-            const auto &candidates = session.candidates();
-            if (selected_candidate_->index < candidates.size()
-                && candidates[selected_candidate_->index].word == selected_candidate_->word)
+            const KeyResult selected = session.select_candidate(*index);
+            if (selected.handled)
             {
-                const KeyResult selected = session.select_candidate(selected_candidate_->index);
-                if (selected.handled)
-                {
-                    return selected;
-                }
+                return selected;
             }
         }
         return session.handle_command(Command::CommitCandidate);

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -565,7 +565,14 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     {
         return;
     }
-    const auto result = _session->finish_composition();
+    // Every automatic commit runs through here: losing focus, pressing a modifier, typing a key the
+    // session does not take, resetting learned data. finish_composition defaults to the engine's
+    // own first candidate for the leading segment, which threw away a candidate the user had
+    // arrowed onto — type shi, press Down to highlight 时, click into another application, and 是
+    // was committed. The rest of the composition still finishes from the engine's first candidate,
+    // which is what the default argument means and what this path already did.
+    const auto result =
+        _session->finish_composition(_candidateSelection.live_selected_index(*_session).value_or(0));
     if (result.handled)
     {
         [self applyResult:result client:sender];

--- a/platforms/macos/tests/CandidateSelectionStateTests.cpp
+++ b/platforms/macos/tests/CandidateSelectionStateTests.cpp
@@ -100,6 +100,39 @@ void run_tests() {
       stale.handled && stale.commit == stale_fallback,
       "A stale native highlight did not fall back to the leading candidate.");
 
+  // Every automatic commit — losing focus, a modifier, a key the session does not take — finishes
+  // the composition, and it has to finish it from the candidate the user arrowed onto rather than
+  // from the engine's own first one.
+  metasequoia::InputSession flush_session;
+  type(flush_session, "nihao");
+  const std::string flush_highlighted = flush_session.candidates()[1].word;
+  candidate_selection.begin_navigation();
+  candidate_selection.update(1, flush_highlighted);
+  require(candidate_selection.live_selected_index(flush_session) == 1,
+          "A live highlight was not offered to the automatic commit.");
+  const auto flushed = flush_session.finish_composition(
+      candidate_selection.live_selected_index(flush_session).value_or(0));
+  require(flushed.handled && flushed.commit == flush_highlighted,
+          "An automatic commit discarded the highlighted candidate.");
+
+  // With nothing highlighted, and with a highlight that no longer names the same word, the index
+  // has to come back empty so the automatic commit keeps its previous behaviour.
+  metasequoia::InputSession flush_default_session;
+  type(flush_default_session, "nihao");
+  const std::string flush_default_leading =
+      flush_default_session.candidates().front().word;
+  candidate_selection.reset();
+  require(!candidate_selection.live_selected_index(flush_default_session).has_value(),
+          "A cleared highlight still offered an index to the automatic commit.");
+  candidate_selection.begin_navigation();
+  candidate_selection.update(1, "candidate-from-an-old-composition");
+  require(!candidate_selection.live_selected_index(flush_default_session).has_value(),
+          "A stale highlight still offered an index to the automatic commit.");
+  const auto flushed_default = flush_default_session.finish_composition(
+      candidate_selection.live_selected_index(flush_default_session).value_or(0));
+  require(flushed_default.handled && flushed_default.commit == flush_default_leading,
+          "An automatic commit without a highlight did not take the leading candidate.");
+
   metasequoia::InputSession paged_session;
   type(paged_session, "nihao");
   require(paged_session.candidates().size() >= 11,


### PR DESCRIPTION
Found by scanning macOS for the defect class fixed on iOS in #252: a commit that ignores what the user is actually looking at.

`commitLeadingCandidate` is the path every automatic commit takes — losing focus, pressing a modifier, typing a key the session does not take, resetting learned data. It finished the composition from the engine's own first candidate and ignored the one the user had arrowed onto.

Type `shi`, press Down to highlight 时, then click into another application. macOS committed 是.

The deliberate commit on Space never had this problem: it goes through `CandidateSelectionState::commit`, which takes the tracked selection. Only the automatic path bypassed it.

## The fix

`InputSession::finish_composition` already accepts the index to use for the leading segment, so it is handed the tracked selection. The rest of the composition still finishes from the engine's first candidate — that is what the default argument means, and what this path already did, so #248's behaviour of flushing a whole partial selection is untouched.

Deciding whether a tracked index still names the candidate the user was looking at was buried inside `CandidateSelectionState::commit`, reachable only from Space. It is now `live_selected_index`, used by both paths. The candidate list is rebuilt on every keystroke, so an index carried across one is not the same candidate; the check compares the stored word against the word at that index and gives up when they differ.

Whenever nothing is highlighted, or the highlight has gone stale, the index comes back empty and `finish_composition` is called exactly as before.

## Verification

- 32 ctest targets pass
- `CandidateSelectionStateTests` gained three cases against a real dictionary fixture: an automatic commit takes the highlighted candidate; a cleared highlight offers no index; a highlight naming a word that is no longer at that index offers no index, and the commit falls back to the leading candidate

Not exercised by typing into a live input source — that means registering and selecting a real input method on this machine, which I am not doing mid-session. The behaviour is covered at the layer where the decision is made.
