### PR TITLE
feat(ios): reach the engine's local input modes

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -7,7 +7,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   }
 
   private let session = MetasequoiaInputSessionBridge()
-  private let preeditLabel = UILabel()
+  private let preeditButton = UIButton()
   private let candidateScrollView = UIScrollView()
   private let diagnosticLabel = UILabel()
   private let previousPageButton = UIButton()
@@ -128,10 +128,19 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     container.backgroundColor = MetasequoiaTheme.keyBackground.withAlphaComponent(0.82)
     container.layer.cornerRadius = 12
 
-    preeditLabel.font = .preferredFont(forTextStyle: .subheadline)
-    preeditLabel.textColor = MetasequoiaTheme.forestUIColor
-    preeditLabel.adjustsFontForContentSizeCategory = true
-    preeditLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+    var preeditConfiguration = UIButton.Configuration.plain()
+    preeditConfiguration.contentInsets = .zero
+    preeditConfiguration.baseForegroundColor = MetasequoiaTheme.forestUIColor
+    preeditConfiguration.titleTextAttributesTransformer =
+      UIConfigurationTextAttributesTransformer { attributes in
+        var attributes = attributes
+        attributes.font = .preferredFont(forTextStyle: .subheadline)
+        return attributes
+      }
+    preeditButton.configuration = preeditConfiguration
+    preeditButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+    preeditButton.showsMenuAsPrimaryAction = true
+    preeditButton.accessibilityIdentifier = "preeditButton"
 
     updateLanguageModeButton()
     languageModeButton.addAction(
@@ -167,7 +176,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       for: .primaryActionTriggered)
 
     let content = UIStackView(arrangedSubviews: [
-      languageModeButton, schemeButton, preeditLabel, candidateScrollView, diagnosticLabel,
+      languageModeButton, schemeButton, preeditButton, candidateScrollView, diagnosticLabel,
       previousPageButton, nextPageButton,
     ])
     content.axis = .horizontal
@@ -347,6 +356,13 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     playInputClick()
     if !isChineseMode {
       textDocumentProxy.insertText(symbol)
+      return
+    }
+
+    // Unicode mode reads a hexadecimal code point, so while it is open its digits are input rather
+    // than candidate numbers. Its letters already reach the session through handleCharacter.
+    if session.isInUnicodeMode, symbol.count == 1, symbol >= "0", symbol <= "9" {
+      render(session.handleCharacter(symbol))
       return
     }
 
@@ -611,6 +627,47 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       !pageable || candidatePageStart + Self.candidatePageSize >= visibleCandidates.count
   }
 
+  // The engine's local input modes open on a capital carried with a shift-only modifier, which this
+  // keyboard has no key for. While nothing is being composed the strip's own name is dead space, so
+  // it doubles as the way in; during a composition it goes back to showing the preedit and the menu
+  // is withdrawn, because a mode cannot open on top of a composition anyway.
+  private static let localInputModes = [
+    (trigger: "U", title: "Unicode 码点"),
+    (trigger: "T", title: "日期时间"),
+    (trigger: "J", title: "超级简拼"),
+  ]
+
+  private func updatePreeditButton() {
+    let idle = visiblePreedit.isEmpty
+    let title = idle ? (isChineseMode ? "水杉输入法" : "英文输入") : visiblePreedit
+    if var configuration = preeditButton.configuration {
+      configuration.title = title
+      preeditButton.configuration = configuration
+    }
+
+    let offersModes = idle && isChineseMode
+    preeditButton.menu =
+      offersModes
+      ? UIMenu(
+        title: "本地输入",
+        children: Self.localInputModes.map { mode in
+          UIAction(title: mode.title) { [weak self] _ in
+            self?.openLocalInputMode(mode.trigger)
+          }
+        })
+      : nil
+    // Withdrawing the menu is what makes the button inert; disabling it would dim the title, and
+    // this is the preedit, which has to keep reading as the text the user is composing.
+    preeditButton.accessibilityLabel = offersModes ? "本地输入模式" : title
+    preeditButton.accessibilityValue = offersModes ? nil : title
+    preeditButton.accessibilityTraits = offersModes ? .button : .staticText
+  }
+
+  private func openLocalInputMode(_ trigger: String) {
+    playInputClick()
+    render(session.openLocalMode(trigger))
+  }
+
   private func chineseOutput(_ text: String) -> String {
     ChineseTextConversion.outputString(text, traditional: usesTraditionalOutput)
   }
@@ -766,8 +823,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   }
 
   private func renderCandidateStrip() {
-    preeditLabel.text =
-      visiblePreedit.isEmpty ? (isChineseMode ? "水杉输入法" : "英文输入") : visiblePreedit
+    updatePreeditButton()
     for view in candidateStack.arrangedSubviews {
       candidateStack.removeArrangedSubview(view)
       view.removeFromSuperview()

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -165,15 +165,45 @@ int RunTest() {
   }
 
   {
-    // Every local input mode is unreachable from this adapter, and two of them have no data in the
-    // compact dictionary either. A trigger must therefore leave the session alone and come back
-    // unhandled, so the keyboard passes the capital to the host application.
     metasequoia::apple::InputSessionAdapter adapter;
+    // A capital typed as a key is still not a mode trigger. The keyboard has no shift in Chinese
+    // mode, and the engine reads A-Z during a composition as helpcode, which no Apple frontend
+    // offers, so it has to come back unhandled for the host application to insert.
     for (const char trigger : {'U', 'T', 'K', 'J', 'E', 'M', 'Y', 'R'}) {
-      const auto result = adapter.handle_character(trigger);
-      Require(!result.handled && result.preedit.empty(),
-              "A local input mode trigger was handled by the iOS adapter.");
+      const auto typed = adapter.handle_character(trigger);
+      Require(!typed.handled && typed.preedit.empty(),
+              "A capital typed as a key was taken as a local input mode trigger.");
     }
+
+    // Named explicitly, the three modes this frontend can answer open.
+    for (const char trigger : {'U', 'T', 'J'}) {
+      const auto opened = adapter.open_local_mode(trigger);
+      Require(opened.handled && opened.preedit == std::string(1, trigger),
+              "A serviceable local input mode did not open.");
+      Require(adapter.cancel().handled, "Cancel did not close the local input mode.");
+    }
+    Require(adapter.open_local_mode('U').handled && adapter.in_unicode_mode(),
+            "The Unicode mode did not report itself for digit routing.");
+    // Hexadecimal digits are input here, not candidate numbers.
+    const auto hexDigit = adapter.handle_character('4');
+    Require(hexDigit.handled && hexDigit.preedit == "U4",
+            "The Unicode mode rejected a hexadecimal digit.");
+    Require(adapter.cancel().handled && !adapter.in_unicode_mode(),
+            "Cancel left the Unicode mode open.");
+
+    // The modes whose data the mobile dictionary product does not carry stay shut even when named.
+    for (const char trigger : {'K', 'E', 'M', 'Y', 'R'}) {
+      const auto refused = adapter.open_local_mode(trigger);
+      Require(!refused.handled && refused.preedit.empty(),
+              "A local input mode without packaged data opened when it was named.");
+    }
+
+    // A mode cannot open on top of a composition; the engine guards every trigger on that.
+    Require(adapter.handle_character('n').handled, "The guard fixture did not start a composition.");
+    const auto duringComposition = adapter.open_local_mode('U');
+    Require(!duringComposition.handled && duringComposition.preedit == "n" && !adapter.in_unicode_mode(),
+            "A local input mode opened on top of a live composition.");
+    Require(adapter.cancel().handled, "The guard fixture did not cancel its composition.");
   }
 
   Require(metasequoia::apple::shuangpin_key_hints(false).empty(),

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -110,9 +110,9 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn('configuration.title = "\\(number)  \\(display)"', controller)
         self.assertIn("self.render(self.session.selectCandidate(at: UInt(index)))", controller)
 
-        strip = controller.split("private func renderCandidateStrip", 1)[1].split("\n  }", 1)[0]
-        self.assertIn("visiblePreedit", strip)
-        self.assertNotIn("chineseOutput(visiblePreedit)", strip)
+        preedit = controller.split("private func updatePreeditButton", 1)[1].split("\n  }", 1)[0]
+        self.assertIn("visiblePreedit", preedit)
+        self.assertNotIn("chineseOutput(visiblePreedit)", preedit)
 
     def test_backspace_repeats_only_while_the_delete_key_is_held(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
@@ -250,6 +250,51 @@ class ProjectConfigurationTests(unittest.TestCase):
         # English mode feeds the client directly rather than a composition, so a double-pinyin hint
         # there would describe something the key does not do.
         self.assertIn("let hint = isChineseMode ? shuangpinKeyHints[lowercase.uppercased()] : nil", controller)
+
+    def test_local_input_modes_are_reachable_and_only_the_serviceable_ones(self):
+        # The engine opens a local mode on a capital carried with its shift_only flag, which no iOS
+        # key can produce. The frontend names the mode instead and the bridge turns it back into the
+        # keystroke the engine expects.
+        adapter_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/InputSessionAdapter.h").read_text()
+        adapter = (IOS_ROOT.parents[1] / "shared/apple-bridge/InputSessionAdapter.cpp").read_text()
+        bridge_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/MetasequoiaInputSessionBridge.h").read_text()
+        controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
+        profile = (IOS_ROOT.parents[1] / "tools/MetasequoiaImeDict/build_profile.py").read_text()
+
+        self.assertIn("InputSnapshot open_local_mode(char trigger);", adapter_header)
+        self.assertIn("openLocalMode:", bridge_header)
+
+        # A mode cannot open on top of a composition, and the engine guards every trigger on that,
+        # so the bridge has to refuse rather than hand the capital over as helpcode.
+        opener = adapter.split("InputSessionAdapter::open_local_mode", 1)[1].split("\n}", 1)[0]
+        self.assertIn("impl_->session.has_composition()", opener)
+        self.assertIn("handle_character(trigger, true)", opener)
+
+        # Only the four this frontend can answer. The rest read others.db, english.db or
+        # dict_japanese.dat, none of which are packaged.
+        options = adapter.split("LocalModeOptions options;", 1)[1].split("set_local_mode_options", 1)[0]
+        for enabled in ("unicode", "date_time", "super_jianpin"):
+            self.assertIn(f"options.{enabled} = true;", options)
+        # quick_phrase reads quick_parases and temporary_japanese reads dict_japanese.dat, neither of
+        # which is in MSIME-Dict's mobile product: its manifest declares features ['pinyin']. Emoji
+        # and kaomoji read others.db and temporary English reads english.db, none of which Apple
+        # fetches at all.
+        for disabled in ("quick_phrase", "emoji", "kaomoji", "temporary_english", "temporary_japanese"):
+            self.assertIn(f"options.{disabled} = false;", options)
+        self.assertIn("['pinyin']", profile)
+
+        self.assertIn('(trigger: "U", title: "Unicode 码点")', controller)
+        self.assertNotIn('title: "快捷短语"', controller)
+        self.assertIn("session.openLocalMode(trigger)", controller)
+        self.assertIn('preeditButton.accessibilityIdentifier = "preeditButton"', controller)
+        # The entry point is the strip's own name, which is only dead space while nothing is being
+        # composed and the keyboard is in Chinese mode.
+        self.assertIn("let offersModes = idle && isChineseMode", controller)
+        # Disabling the button would dim the title, and the title is the preedit.
+        self.assertNotIn("preeditButton.isEnabled", controller)
+        self.assertIn("preeditButton.menu =", controller)
+        # Unicode reads hexadecimal, so its digits are input rather than candidate numbers.
+        self.assertIn("if session.isInUnicodeMode, symbol.count == 1, symbol >= \"0\", symbol <= \"9\" {", controller)
 
     def test_engine_diagnostics_reach_the_keyboard(self):
         # KeyResult carries a diagnostic when the key was handled but something behind it failed,

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -9,19 +9,20 @@ class InputSessionAdapter::Impl {
 public:
   explicit Impl(SchemeType scheme = SchemeType::Quanpin)
       : session{scheme, true, true, true, false} {
-    // The engine enables every local input mode by default and opens each one on a capital passed
-    // with shift_only. This adapter never passes it, and the iOS keyboard has no shift key in
-    // Chinese mode to pass it from, so all eight are unreachable here. Two of them could not work
-    // anyway: the compact dictionary this frontend packages keeps only the pinyin tables, so quick
-    // phrases and the Japanese lexicon are not in it. Saying so is better than shipping a session
-    // that reports modes it can neither enter nor answer.
+    // Only the modes this frontend can answer are offered, and that is decided by the dictionary
+    // product it ships. MSIME-Dict's mobile profile is compact pinyin — its manifest declares
+    // features ['pinyin'] — so quick phrases have no quick_parases table here, and temporary
+    // Japanese no dict_japanese.dat; emoji and kaomoji read others.db and temporary English reads
+    // english.db, neither of which is fetched on Apple at all. What is left needs nothing beyond
+    // the pinyin tables: Unicode parses its own input, date and time has a built-in provider, and
+    // super jianpin queries the pinyin tables directly.
     LocalModeOptions options;
-    options.unicode = false;
-    options.date_time = false;
+    options.unicode = true;
+    options.date_time = true;
     options.quick_phrase = false;
+    options.super_jianpin = true;
     options.emoji = false;
     options.kaomoji = false;
-    options.super_jianpin = false;
     options.temporary_english = false;
     options.temporary_japanese = false;
     session.set_local_mode_options(options);
@@ -58,6 +59,22 @@ InputSnapshot InputSessionAdapter::handle_character(char character) {
   }
   return MakeSnapshot(impl_->session,
                       impl_->session.handle_character(character));
+}
+
+InputSnapshot InputSessionAdapter::open_local_mode(char trigger) {
+  // The engine guards every trigger on there being no composition, so a mode opened on top of one
+  // would be a mode the user did not ask for. handle_character rejects A-Z outright, which is right
+  // for a keystroke and wrong here, so the session is called directly with the shift_only flag the
+  // triggers are keyed off.
+  if (trigger < 'A' || trigger > 'Z' || impl_->session.has_composition()) {
+    return MakeSnapshot(impl_->session, KeyResult{});
+  }
+  return MakeSnapshot(impl_->session,
+                      impl_->session.handle_character(trigger, true));
+}
+
+bool InputSessionAdapter::in_unicode_mode() const {
+  return impl_->session.local_input_mode() == LocalInputMode::Unicode;
 }
 
 InputSnapshot InputSessionAdapter::handle_candidate_key(char character) {

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -27,6 +27,14 @@ public:
   InputSessionAdapter &operator=(const InputSessionAdapter &) = delete;
 
   InputSnapshot handle_character(char character);
+  // Opens one of the engine's local input modes. The engine keys these off a capital delivered with
+  // its shift_only flag, which no iOS key can produce, so the frontend names the mode instead and
+  // this turns it back into the keystroke the engine expects. A mode that is switched off, or a
+  // letter that names none, leaves the session untouched and reports itself unhandled.
+  InputSnapshot open_local_mode(char trigger);
+  // None while no local mode is open. A frontend needs this to know that its digits are input for a
+  // Unicode code point rather than candidate numbers.
+  bool in_unicode_mode() const;
   InputSnapshot handle_candidate_key(char character);
   InputSnapshot handle_punctuation(char character);
   InputSnapshot handle_backspace();

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -31,6 +31,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (MetasequoiaInputSnapshot *)selectCandidateAtIndex:(NSUInteger)index;
 - (MetasequoiaInputSnapshot *)switchToShuangpin:(BOOL)usesShuangpin;
 
+/// Opens one of the engine's local input modes by its trigger letter. The engine keys these off a
+/// capital delivered with a shift-only modifier, which this keyboard has no way to produce, so the
+/// mode is named instead. A mode that is switched off, or a letter that names none, leaves the
+/// session untouched and reports itself unhandled.
+- (MetasequoiaInputSnapshot *)openLocalMode:(NSString *)trigger;
+
+/// YES while the Unicode local mode is open, when the digits are input for a code point rather than
+/// candidate numbers.
+@property(nonatomic, readonly, getter=isInUnicodeMode) BOOL inUnicodeMode;
+
 /// Per-key double-pinyin hints for the scheme the session is actually running, keyed by uppercase
 /// letter. Empty in full pinyin. Derived from the engine's own profile so a frontend never hardcodes
 /// a keymap that can drift from the scheme.

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -202,6 +202,18 @@ void ConfigureDataDirectory() {
   return [self snapshotFrom:_adapter->switch_to_shuangpin(usesShuangpin)];
 }
 
+- (MetasequoiaInputSnapshot *)openLocalMode:(NSString *)trigger {
+  const char *utf8 = trigger.UTF8String;
+  if (utf8 == nullptr || utf8[0] == '\0' || utf8[1] != '\0') {
+    return [self snapshotFrom:_adapter->open_local_mode('\0')];
+  }
+  return [self snapshotFrom:_adapter->open_local_mode(utf8[0])];
+}
+
+- (BOOL)isInUnicodeMode {
+  return _adapter->in_unicode_mode() ? YES : NO;
+}
+
 - (NSDictionary<NSString *, NSString *> *)shuangpinKeyHints {
   const auto hints =
       metasequoia::apple::shuangpin_key_hints(_adapter->uses_shuangpin());


### PR DESCRIPTION
macOS reached the engine's local input modes in #250. The iOS keyboard still could not open one.

Every trigger is a capital delivered with the engine's `shift_only` flag, and this keyboard has no shift key in Chinese mode to deliver it with. The frontend names the mode instead, and `InputSessionAdapter::open_local_mode` turns the name back into the keystroke the engine expects — refusing when a composition is live, which is the same guard the engine puts on every trigger.

## Which modes, and why only those

| mode | offered | why |
|---|---|---|
| Unicode | yes | parses its own input |
| date and time | yes | built-in provider |
| super jianpin | yes | queries the pinyin tables |
| quick phrase | no | needs `quick_parases` |
| temporary Japanese | no | needs `dict_japanese.dat` |
| emoji, kaomoji | no | need `others.db` |
| temporary English | no | needs `english.db` |

I started out intending to carry `quick_parases` into the compact dictionary, and backed that out: since #248 the compaction is MSIME-Dict's own `build_profile.py`, vendored as a submodule, and its mobile product is declared `features: ['pinyin']`. Which tables the mobile dictionary carries is that project's decision, not something to patch from here.

## The way in

The strip's own name. While nothing is being composed it is dead space, so it carries the menu; during a composition it shows the preedit again and the menu is withdrawn — which also matches the engine refusing to open a mode on top of a composition.

Withdrawing the menu rather than disabling the button matters, and I only found that by looking: a disabled `UIButton` dims its title, and that title is the preedit, so composing text turned grey. Caught on the simulator, fixed, and pinned with an assertion.

Unicode mode reads a hexadecimal code point, so while it is open the digits are input rather than candidate numbers — the same split the macOS controller makes.

## Verification

On an iPhone 17 Simulator with the keyboard enabled, through Orca, on this branch's build:

- the strip's name exposes 本地输入模式, and tapping it lists Unicode 码点 / 日期时间 / 超级简拼 — and nothing else
- picking 日期时间 opens the mode: the preedit becomes `T`, typing `rq` gives 2026年9月6日 and 2026-09-06, and selecting the first commits **2026年9月6日** into the field
- after the fix, composing `s` shows the preedit in its normal colour with candidates and the page control beside it

Plus `MetasequoiaAppleInputSessionAdapterTests`: a capital typed as a key is still not a trigger; the three serviceable modes open when named and Cancel closes them; Unicode reports itself for digit routing and takes a hex digit; the five unserviceable modes stay shut even when named; and no mode opens on top of a live composition. `ProjectConfigurationTests` — 38 tests.
