### PR TITLE
fix(mac): stop annotating and converting local-mode candidates

### DIFF
--- a/platforms/macos/src/CandidateDisplay.h
+++ b/platforms/macos/src/CandidateDisplay.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/helpcode_utils.h"
+#include "core/input_session.h"
 #include "core/scheme_type.h"
 #include "core/word_item.h"
 
@@ -8,6 +9,24 @@
 
 namespace metasequoia::mac
 {
+// A helpcode says how to reach a word through pinyin. A local input mode that synthesises its
+// candidates has no such word to annotate: a date, a code point, a quick phrase or a kaomoji was
+// never typed in pinyin, and compute_helpcodes still finds Han characters in "2026年9月6日" and
+// appends the letters for 年 and 日 to it. Super jianpin is the exception — it is pinyin initials
+// over the same dictionary, so its candidates are ordinary words with real helpcodes.
+inline bool HelpcodesAnnotateLocalMode(LocalInputMode mode)
+{
+    return mode == LocalInputMode::None || mode == LocalInputMode::SuperJianpin;
+}
+
+// Traditional output rewrites the script of a Chinese candidate, which is a choice about how to
+// render a word. A Unicode code point is not that: the user named one exact character, and handing
+// back its traditional counterpart is handing back a different character than the one requested.
+inline bool ScriptConversionAppliesToLocalMode(LocalInputMode mode)
+{
+    return mode != LocalInputMode::Unicode;
+}
+
 inline std::string CandidateDisplayText(const WordItem &candidate, SchemeType scheme, bool helpcodeEnabled)
 {
     if (!helpcodeEnabled || (scheme != SchemeType::Quanpin && scheme != SchemeType::Shuangpin))

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -463,6 +463,9 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         return NO;
     }
 
+    // Captured before the key is dispatched: a commit clears the local mode, and applyResult still
+    // needs to know which one produced the text it is inserting.
+    const metasequoia::LocalInputMode localModeForKey = _session->local_input_mode();
     metasequoia::KeyResult result;
     const BOOL candidatePageShortcutModified =
         (modifiers & (NSEventModifierFlagShift | NSEventModifierFlagCommand | NSEventModifierFlagControl |
@@ -603,7 +606,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         }
         return NO;
     }
-    [self applyResult:result client:sender];
+    [self applyResult:result localMode:localModeForKey client:sender];
     return YES;
 }
 
@@ -619,11 +622,12 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     // arrowed onto — type shi, press Down to highlight 时, click into another application, and 是
     // was committed. The rest of the composition still finishes from the engine's first candidate,
     // which is what the default argument means and what this path already did.
+    const metasequoia::LocalInputMode localMode = _session->local_input_mode();
     const auto result =
         _session->finish_composition(_candidateSelection.live_selected_index(*_session).value_or(0));
     if (result.handled)
     {
-        [self applyResult:result client:sender];
+        [self applyResult:result localMode:localMode client:sender];
     }
 }
 
@@ -634,13 +638,20 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
            [MetasequoiaPreferencesWindowController storedTraditionalChineseOutputEnabled];
 }
 
-- (void)applyResult:(const metasequoia::KeyResult &)result client:(id)sender
+// The local input mode is taken as an argument rather than read from the session, because
+// committing resets it: by the time a result arrives here the session has already forgotten that a
+// Unicode code point is what produced it, and converting that to traditional would hand back a
+// different character than the one the user named.
+- (void)applyResult:(const metasequoia::KeyResult &)result
+          localMode:(metasequoia::LocalInputMode)localMode
+             client:(id)sender
 {
     id<IMKTextInput> client = sender;
     const NSRange replacementRange = NSMakeRange(NSNotFound, NSNotFound);
     if (result.commit.has_value())
     {
-        const BOOL traditionalOutput = [self traditionalChineseOutputActive];
+        const BOOL traditionalOutput = [self traditionalChineseOutputActive] &&
+                                       metasequoia::mac::ScriptConversionAppliesToLocalMode(localMode);
         NSString *commit = MetasequoiaChineseOutputString(MetasequoiaStringFromUtf8(*result.commit),
                                                            traditionalOutput);
         [client insertText:commit replacementRange:replacementRange];
@@ -727,12 +738,16 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     }
     _candidateLineIdentifiersCollapsed = NO;
     NSMutableArray *data = [NSMutableArray arrayWithCapacity:_session->candidates().size()];
-    const BOOL traditionalOutput = [self traditionalChineseOutputActive];
+    const metasequoia::LocalInputMode localMode = _session->local_input_mode();
+    const BOOL traditionalOutput = [self traditionalChineseOutputActive] &&
+                                   metasequoia::mac::ScriptConversionAppliesToLocalMode(localMode);
+    const bool annotateHelpcodes =
+        _session->helpcode_enabled() && metasequoia::mac::HelpcodesAnnotateLocalMode(localMode);
     NSUInteger candidateIndex = 0;
     for (const WordItem &candidate : _session->candidates())
     {
         NSString *display = MetasequoiaStringFromUtf8(metasequoia::mac::CandidateDisplayText(
-            candidate, _session->scheme_type(), _session->helpcode_enabled()));
+            candidate, _session->scheme_type(), annotateHelpcodes));
         NSString *convertedDisplay = MetasequoiaChineseOutputString(display, traditionalOutput);
         [data addObject:MetasequoiaIndexedCandidateString(convertedDisplay, candidateIndex)];
         ++candidateIndex;
@@ -830,10 +845,11 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     {
         return;
     }
+    const metasequoia::LocalInputMode localMode = _session->local_input_mode();
     const auto result = _session->select_candidate(static_cast<size_t>(index));
     if (result.handled)
     {
-        [self applyResult:result client:self.client];
+        [self applyResult:result localMode:localMode client:self.client];
     }
 }
 

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -116,6 +116,38 @@ int main()
     require(CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true) == "你(rX)" &&
                 CandidateDisplayText(WordItem{"nimen", "你们", 1}, SchemeType::Shuangpin, true) == "你们(rR)",
             "Pinyin candidate display did not append the configured auxiliary code.");
+    // A helpcode annotates a word the user could have typed in pinyin. compute_helpcodes still
+    // finds Han characters in a synthesised candidate and appends letters for them, so "2026年9月6日"
+    // came back carrying the codes for 年 and 日. Only the modes whose candidates are dictionary
+    // words keep the annotation.
+    using metasequoia::LocalInputMode;
+    using metasequoia::mac::HelpcodesAnnotateLocalMode;
+    require(HelpcodesAnnotateLocalMode(LocalInputMode::None) &&
+                HelpcodesAnnotateLocalMode(LocalInputMode::SuperJianpin),
+            "Ordinary and super-jianpin candidates lost their helpcode annotation.");
+    require(!HelpcodesAnnotateLocalMode(LocalInputMode::DateTime) &&
+                !HelpcodesAnnotateLocalMode(LocalInputMode::Unicode) &&
+                !HelpcodesAnnotateLocalMode(LocalInputMode::QuickPhrase) &&
+                !HelpcodesAnnotateLocalMode(LocalInputMode::Emoji) &&
+                !HelpcodesAnnotateLocalMode(LocalInputMode::Kaomoji),
+            "A synthesised local-mode candidate was annotated with a helpcode.");
+    require(CandidateDisplayText(WordItem{"T", "2026年9月6日", 1}, SchemeType::Quanpin, false) ==
+                "2026年9月6日",
+            "A date candidate did not come back unannotated.");
+    require(CandidateDisplayText(WordItem{"T", "2026年9月6日", 1}, SchemeType::Quanpin, true) !=
+                "2026年9月6日",
+            "The annotation this rule exists to suppress no longer happens, so the rule is dead.");
+
+    // Traditional output chooses how to render a word. A Unicode code point is one exact character,
+    // and its traditional counterpart is a different one than the user named.
+    using metasequoia::mac::ScriptConversionAppliesToLocalMode;
+    require(ScriptConversionAppliesToLocalMode(LocalInputMode::None) &&
+                ScriptConversionAppliesToLocalMode(LocalInputMode::DateTime) &&
+                ScriptConversionAppliesToLocalMode(LocalInputMode::QuickPhrase),
+            "Traditional output stopped applying to candidates that are words.");
+    require(!ScriptConversionAppliesToLocalMode(LocalInputMode::Unicode),
+            "A Unicode code point was handed to the traditional-output conversion.");
+
     require(CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, false) == "你" &&
                 CandidateDisplayText(WordItem{"abcd", "你", 1}, SchemeType::Wubi, true) == "你",
             "Candidate display exposed auxiliary codes when the feature or scheme did not allow them.");


### PR DESCRIPTION
Making the local input modes reachable in #250 pointed two existing rules at candidates they were never written for. Both are visible the moment someone turns the feature on.

## A helpcode on a date

The candidate panel appends a helpcode to every candidate while helpcodes are on, and `compute_helpcodes` does not care where the candidate came from — it looks for Han characters and annotates them. `2026年9月6日` has three, so the date came back carrying the codes for 年 and 日 stuck on the end.

A helpcode says how to reach a word through pinyin. A date, a code point, a quick phrase or a kaomoji was never typed in pinyin and has none to describe. The annotation now applies outside a local mode and in super jianpin — that one is pinyin initials over the same dictionary, so its candidates are ordinary words with real helpcodes.

## Traditional output rewriting a code point

Traditional output rewrites the script of a Chinese candidate, which is a choice about how to render a word. A Unicode code point is not a word in that sense: ask for U+4E1C with traditional output on and 東 came back — a different character than the one named. It is now left alone.

That one could not be fixed on the display side only, because a mismatch between what the panel shows and what gets inserted would be worse than the bug. Committing resets the local mode, so by the time a result reaches `applyResult` the session has forgotten what produced it. The mode is now passed in, captured at all three call sites before the session call that clears it.

## Verification

- 33 ctest targets pass
- `InputControllerKeyRoutingTests` gained the rules directly: which modes keep the helpcode annotation and which do not, that a date comes back unannotated, that a code point is not handed to the script conversion — plus an assertion that a date *would* still be annotated without the rule, so the test fails if the underlying behaviour ever changes and the rule quietly becomes dead

Not exercised by typing into a live input source: that means registering and selecting a real input method on this machine. Both rules are pure functions and are tested as such, and the call sites that consume them are covered by the suite.
