### PR TITLE
refactor(data): consume the consolidated Engine dictionary release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install cmake boost fmt spdlog nlohmann-json
 ./platforms/macos/scripts/build.sh
 ```
 
-构建脚本会下载 `product-lock.json` 锁定的那个 MSIME-Dict release，逐个校验 SHA256，再放到 `vendor/MetasequoiaImeDict/out/msime.db`。该数据库文件有意不纳入版本库。Windows 和 Linux 取的是同一份产物，所以三个平台分发的 `msime.db` 逐字节一致。
+构建脚本会下载 `product-lock.json` 锁定的 MSIME-Engine 词库 release，逐个校验 SHA256，再放到 `vendor/MetasequoiaImeDict/out/msime.db`。该数据库文件有意不纳入版本库。Windows 和 Linux 取的是同一份产物，所以三个平台分发的 `msime.db` 逐字节一致。
 
 换用新的词库版本：`python3 scripts/product_lock.py refresh --dictionary-tag dict-YYYY.MM.DD`，然后 review 产生的 diff。
 

--- a/platforms/macos/tests/ProductLockTests.py
+++ b/platforms/macos/tests/ProductLockTests.py
@@ -30,6 +30,8 @@ class ProductLockTests(unittest.TestCase):
 
     def test_modern_dictionary_requires_a_compatible_locked_manifest(self):
         self.data['dictionary']['tag'] = 'dict-2026.09.06'
+        self.data['dictionary']['repository'] = lock.DICTIONARY_REPOSITORY
+        self.data['dictionary']['assets'].pop(lock.PRODUCT_MANIFEST, None)
         with self.assertRaises(ValueError):
             lock.validate(self.data)
         with tempfile.TemporaryDirectory() as temporary:
@@ -38,6 +40,7 @@ class ProductLockTests(unittest.TestCase):
             for name in lock._product.DESKTOP_FILES:
                 (directory / name).write_bytes(b'MSJPDT1\0fixture' if name == 'dict_japanese.dat' else b'fixture')
             product = {'manifest_version': 1, 'format_version': 1, 'profile': 'desktop',
+                       'source': {'repository': self.data['dictionary']['repository'], 'commit': self.data['dictionary']['source_commit'], 'dirty': False},
                        'engine_compatibility': {'dictionary_format': 1, 'japanese_model_magic': 'MSJPDT1'},
                        'files': {name: {'sha256': lock.sha256(directory / name), 'size': (directory / name).stat().st_size}
                                  for name in lock._product.DESKTOP_FILES}}
@@ -47,6 +50,13 @@ class ProductLockTests(unittest.TestCase):
                 self.data['dictionary']['assets'][name] = lock.sha256(directory / name)
             lock.validate(self.data)
             lock.verify_assets(directory, self.data)
+            original_commit = product['source']['commit']
+            product['source']['commit'] = 'f' * 40
+            manifest_path.write_text(json.dumps(product))
+            self.data['dictionary']['assets'][lock.PRODUCT_MANIFEST] = lock.sha256(manifest_path)
+            with self.assertRaises(ValueError):
+                lock.verify_assets(directory, self.data)
+            product['source']['commit'] = original_commit
             # Even a deliberately updated digest cannot declare an unsupported format compatible.
             product['format_version'] = 2
             manifest_path.write_text(json.dumps(product))
@@ -59,6 +69,23 @@ class ProductLockTests(unittest.TestCase):
             value = (name + " fixture").encode()
             (directory / name).write_bytes(value)
             self.data["dictionary"]["assets"][name] = hashlib.sha256(value).hexdigest()
+
+        if lock.PRODUCT_MANIFEST in self.data['dictionary']['assets']:
+            for name in lock._product.DESKTOP_FILES:
+                path = directory / name
+                if not path.exists():
+                    path.write_bytes(b'fixture')
+                if name == 'dict_japanese.dat':
+                    path.write_bytes(b'MSJPDT1\0fixture')
+            product = {'manifest_version': 1, 'format_version': 1, 'profile': 'desktop',
+                       'source': {'repository': self.data['dictionary']['repository'],
+                                  'commit': self.data['dictionary']['source_commit'], 'dirty': False},
+                       'engine_compatibility': {'dictionary_format': 1, 'japanese_model_magic': 'MSJPDT1'},
+                       'files': {name: {'sha256': lock.sha256(directory / name), 'size': (directory / name).stat().st_size}
+                                 for name in lock._product.DESKTOP_FILES}}
+            (directory / lock.PRODUCT_MANIFEST).write_text(json.dumps(product))
+            for name in self.data['dictionary']['assets']:
+                self.data['dictionary']['assets'][name] = lock.sha256(directory / name)
 
     def test_mutable_dictionary_tags_are_rejected(self):
         for tag in ("latest", "main", "../dict-test", "dict-test\n", ""):

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -671,13 +671,13 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertFalse((MACOS_ROOT / "scripts/build_dictionary.py").exists())
         # A branch or a bare "latest" would make two builds of the same commit ship different data.
         self.assertRegex(lock["tag"], r"\Adict-\d{4}\.\d{2}\.\d{2}\Z")
-        self.assertEqual(lock["repository"], "metasequoiaime/MSIME-Dict")
+        self.assertEqual(lock["repository"], "metasequoiaime/MSIME-Engine")
         # Not read from a gitlink: MSIME-Linux#47 found its dict pin attesting to 55bd649 while the
         # shipped bytes came from 0c7368c, because nothing moves that pin when the tag does.
         self.assertRegex(lock["source_commit"], r"\A[0-9a-f]{40}\Z")
         # The digests are committed rather than taken from the SHA256SUMS.txt that travels with the
         # data, so a retagged release fails the build instead of shipping.
-        for name in ("msime.db", "SHA256SUMS.txt"):
+        for name in ("msime.db", "SHA256SUMS.txt", "dictionary-manifest.json"):
             self.assertRegex(lock["assets"][name], r"\A[0-9a-f]{64}\Z")
         self.assertIn("product_lock.verify_assets", source)
         # The probe that would have caught the old build: quick_parases comes from a stage the

--- a/product-lock.json
+++ b/product-lock.json
@@ -1,12 +1,13 @@
 {
   "schema_version": 1,
   "dictionary": {
-    "repository": "metasequoiaime/MSIME-Dict",
-    "tag": "dict-2026.09.05",
-    "source_commit": "0c7368cc46020b4f6c8ac7f9bf62b68ff0b303cd",
+    "repository": "metasequoiaime/MSIME-Engine",
+    "tag": "dict-2026.09.06",
+    "source_commit": "d0dc0c2b594b5540b5de99ad12085c786410626e",
     "assets": {
       "msime.db": "9e68e88be036206fc14d44db7111376b1d92f9173b04d623e601e31edd664c2f",
-      "SHA256SUMS.txt": "32a9a5272926573c98ba9c81dd50b81ec24410fa2cc3716e6a832bf547a87f41"
+      "SHA256SUMS.txt": "2d1bd6f9b89feaa59d677504cdb49646071d609b3a4fa80201cdb976b05e0c05",
+      "dictionary-manifest.json": "bc992419a3923ea3e75f35539b0c0a61932c13cedee92d3a7323f984db6ca9cd"
     }
   }
 }

--- a/scripts/fetch_dictionary.py
+++ b/scripts/fetch_dictionary.py
@@ -3,7 +3,7 @@
 
 This used to be built here, by platforms/macos/scripts/build_dictionary.py, which ran two of the four MSIME-Dict stages that write into msime.db. The bundle therefore shipped a database without the quick-phrase and Japanese lexicon tables that MSIME-Windows and MSIME-Linux ship, from a submodule pin that was five commits behind the released tag, with no digest to catch either. Nothing reported it, because a smaller database is still a valid one.
 
-MSIME-Dict publishes msime.db and SHA256SUMS.txt as release assets and both other platforms already take them from there, so take them here too. That is what makes the claim in MSIME-Linux/scripts/fetch_dictionary.py true: all three platforms ship a byte-identical msime.db.
+MSIME-Engine publishes msime.db and SHA256SUMS.txt as release assets and both other platforms already take them from there, so take them here too. That is what makes the claim in MSIME-Linux/scripts/fetch_dictionary.py true: all three platforms ship a byte-identical msime.db.
 
 The release tag cannot be overridden from the command line. product-lock.json names it and records the SHA256 of every asset, so a retagged release or a replaced database fails the build instead of shipping: rewriting the upstream SHA256SUMS.txt along with the data does not help, because that file is verified against a committed digest too. Move to a new release with `python3 scripts/product_lock.py refresh --dictionary-tag dict-YYYY.MM.DD` and review the resulting diff.
 
@@ -71,7 +71,7 @@ def main() -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(dir=OUTPUT_DIR) as temporary:
         incoming = Path(temporary)
-        product_lock.download_assets(tag, incoming)
+        product_lock.download_assets(tag, incoming, data["dictionary"]["repository"])
         product_lock.verify_assets(incoming, data)
         print(f"verified {len(data["dictionary"]["assets"])} assets against product-lock.json")
         verify_contents(incoming)

--- a/scripts/product_lock.py
+++ b/scripts/product_lock.py
@@ -34,7 +34,7 @@ LEGACY_DICTIONARY_TAG = "dict-2026.09.05"
 
 
 REPOSITORY = "metasequoiaime/MSIME-Apple"
-DICTIONARY_REPOSITORY = "metasequoiaime/MSIME-Dict"
+DICTIONARY_REPOSITORY = "metasequoiaime/MSIME-Engine"
 DICTIONARY_URL = f"https://github.com/{DICTIONARY_REPOSITORY}.git"
 
 # Every gitlink this repository builds from. The manifest reads their commits here rather than from
@@ -57,7 +57,9 @@ def validate(data: dict) -> dict:
     if data.get("schema_version") != 1:
         raise ValueError("Unsupported product lock schema_version")
     dictionary = data.get("dictionary", {})
-    if dictionary.get("repository") != DICTIONARY_REPOSITORY:
+    if dictionary.get("repository") != DICTIONARY_REPOSITORY and not (
+        dictionary.get("repository") == "metasequoiaime/MSIME-Dict" and dictionary.get("tag") == LEGACY_DICTIONARY_TAG
+    ):
         raise ValueError("Unexpected dictionary repository")
     if not TAG.fullmatch(dictionary.get("tag", "")):
         raise ValueError("Dictionary tag must be an explicit dict-* release, never latest")
@@ -101,20 +103,26 @@ def verify_assets(directory: Path, data: dict) -> None:
             raise ValueError(f"{name} does not match the product lock: expected {expected}, got {actual}")
 
     if PRODUCT_MANIFEST in data["dictionary"]["assets"]:
-        _product.verify_product(directory, "desktop", DATABASES)
+        manifest = _product.verify_product(directory, "desktop", DATABASES)
+        source = manifest.get("source", {})
+        if (source.get("repository") != data["dictionary"]["repository"] or
+                source.get("commit") != data["dictionary"]["source_commit"] or source.get("dirty") is not False):
+            raise ValueError("Dictionary manifest provenance does not match the reviewed source commit")
 
 
-def download_assets(tag: str, destination: Path) -> None:
+def download_assets(tag: str, destination: Path, repository: str = DICTIONARY_REPOSITORY) -> None:
     """Plain HTTPS rather than the GitHub CLI or the API.
 
     The release assets of a public repository are served unauthenticated from a CDN, so this needs no credentials and stays off the API and its rate limits.
     """
     if not TAG.fullmatch(tag):
         raise ValueError("Refusing to download from a tag that is not an explicit dict-* release")
+    if repository not in (DICTIONARY_REPOSITORY, "metasequoiaime/MSIME-Dict"):
+        raise ValueError("Unexpected dictionary repository")
     destination.mkdir(parents=True, exist_ok=True)
     names = ASSETS if tag == LEGACY_DICTIONARY_TAG else (*ASSETS, PRODUCT_MANIFEST)
     for name in names:
-        url = f"https://github.com/{DICTIONARY_REPOSITORY}/releases/download/{tag}/{name}"
+        url = f"https://github.com/{repository}/releases/download/{tag}/{name}"
         target = destination / name
         last_error: Exception | None = None
         for attempt in range(1, 4):


### PR DESCRIPTION
Apple now consumes the Engine dict-2026.09.06 release, including its format/source manifest. Downloads use the repository recorded in the lock; source repository, immutable commit and clean build state must agree with the locked release. The Engine tool gitlink stays independent of the published data's source commit.

The shipped msime.db SHA256 is unchanged. Product-lock rejection tests (including a rehashed manifest claiming another source), release configuration tests, a real verified release download and iOS mobile packaging pass. All published files were compared byte-for-byte with the successful Engine workflow artifact before locking. Historical MSIME-Dict release metadata remains supported only for the explicit legacy tag.
