### PR TITLE
feat(ios): let the tryout field put the keyboard away

### DIFF
--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct OnboardingView: View {
   @State private var sampleText = ""
+  @FocusState private var tryoutFocused: Bool
   @State private var usesShuangpin = InputSchemePreference.usesShuangpin
   @State private var usesTraditionalOutput = ChineseOutputPreference.usesTraditional
 
@@ -114,10 +115,22 @@ struct OnboardingView: View {
         }
 
         VStack(alignment: .leading, spacing: 10) {
-          Text("启用后试一试")
-            .font(.headline)
-            .foregroundStyle(MetasequoiaTheme.ink)
+          HStack {
+            Text("启用后试一试")
+              .font(.headline)
+              .foregroundStyle(MetasequoiaTheme.ink)
+            Spacer(minLength: 8)
+            // The field had no way to put the keyboard away, which also meant the keyboard never
+            // saw a dismissal while this app stayed in front.
+            if tryoutFocused {
+              Button("收起键盘") { tryoutFocused = false }
+                .font(.subheadline)
+                .foregroundStyle(MetasequoiaTheme.forest)
+                .accessibilityIdentifier("dismissKeyboardButton")
+            }
+          }
           TextField("在这里试试水杉键盘", text: $sampleText)
+            .focused($tryoutFocused)
             .textFieldStyle(.plain)
             .padding(.horizontal, 16)
             .frame(minHeight: 52)

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -31,5 +31,14 @@ final class OnboardingUITests: XCTestCase {
     wait(for: [focused], timeout: 10)
     tryoutField.typeText("test")
     XCTAssertEqual(tryoutField.value as? String, "test")
+
+    // The field had no way to put the keyboard away without leaving the app.
+    let dismissButton = app.buttons["dismissKeyboardButton"]
+    XCTAssertTrue(dismissButton.waitForExistence(timeout: 5))
+    dismissButton.tap()
+    let unfocused = expectation(
+      for: NSPredicate(format: "hasKeyboardFocus == false"), evaluatedWith: tryoutField)
+    wait(for: [unfocused], timeout: 10)
+    XCTAssertEqual(tryoutField.value as? String, "test")
   }
 }

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -339,6 +339,11 @@ class ProjectConfigurationTests(unittest.TestCase):
 
         self.assertIn('TextField("在这里试试水杉键盘"', onboarding)
         self.assertIn('.accessibilityIdentifier("keyboardTryoutField")', onboarding)
+        # Without this the keyboard could not be put away without leaving the app.
+        self.assertIn("@FocusState private var tryoutFocused: Bool", onboarding)
+        self.assertIn(".focused($tryoutFocused)", onboarding)
+        self.assertIn('Button("收起键盘") { tryoutFocused = false }', onboarding)
+        self.assertIn('.accessibilityIdentifier("dismissKeyboardButton")', onboarding)
 
     def test_host_app_exposes_the_shared_input_scheme_setting(self):
         onboarding = (IOS_ROOT / "App/Sources/OnboardingView.swift").read_text()


### PR DESCRIPTION
Once the keyboard came up over the tryout field there was no way to put it away without leaving the app: the field has no return action of its own, and tapping elsewhere does not resign a SwiftUI focus. It now carries a 收起键盘 button while it holds focus.

## What I was actually chasing, and what I found

macOS commits a half-typed composition when focus moves away — the README calls it out. iOS discards it: `textWillChange` cancels, and a keyboard that simply disappears takes the composition with it. Someone who types `ni` and puts the keyboard away loses the typing entirely.

I tried the obvious fix, committing through `finishComposition` in `viewWillDisappear`, and backed it out because **it does not work**. Measured on a simulator with the keyboard enabled, driven through Orca:

- typed `ni`, candidate strip showing 你 / 尼 / 妮, field empty
- pressed 收起键盘 — app still in front, so the document is still there and the proxy should still be valid
- the field stayed empty
- re-focusing showed no preedit and no candidates

So `viewWillDisappear` did run and `finishComposition` did commit — the composition is gone — but `textDocumentProxy.insertText` no longer reached the document at that point. The text was produced and dropped on the floor. Backgrounding the app instead gave the same result.

That leaves the discarded-composition gap open, and I would rather leave it open than ship a change that quietly produces text nothing receives. It needs a hook that still owns the document — most likely `textWillChange` before the resign — and that path carries its own risk, since at focus-change time the proxy may already point at the field the user moved *to*. Worth doing deliberately, with a two-field fixture to prove where the text lands, rather than folded into this.

What survives is the affordance itself, which is a real gap on its own: the sample field could not put the keyboard away.

## Verification

- `run_ui_tests.sh` — the onboarding test now dismisses the keyboard through the button, waits for the field to lose focus, and checks the typed text is still there
- `ProjectConfigurationTests` — 38 tests, including the focus binding and the button
- `xcodebuild ... -sdk iphonesimulator build`
