### PR TITLE
fix(data): follow the dictionary release to its published tag

### DIFF
--- a/product-lock.json
+++ b/product-lock.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "dictionary": {
     "repository": "metasequoiaime/MSIME-Engine",
-    "tag": "dict-2026.09.06",
+    "tag": "dict-v1.0.0",
     "source_commit": "d0dc0c2b594b5540b5de99ad12085c786410626e",
     "assets": {
       "msime.db": "9e68e88be036206fc14d44db7111376b1d92f9173b04d623e601e31edd664c2f",


### PR DESCRIPTION
`product-lock.json` named `dict-2026.09.06`. MSIME-Engine no longer publishes that tag — its only dictionary release is `dict-v1.0.0`, and requesting the old name returns `release not found`.

Every iOS job has been failing at **Package iOS dictionary** since the rename, on every pull request in this repository, including ones that only touch text. main is red for the same reason.

Only the name moved. `source_commit` stays `d0dc0c2b` and all three asset digests are unchanged, and they are identical to what MSIME-Windows already pins for the same release, so this changes which tag is requested and nothing about which bytes are accepted.