### PR TITLE
fix(consolidation): align data notices and release checks with Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ brew install cmake boost fmt spdlog nlohmann-json
 
 构建脚本会下载 `product-lock.json` 锁定的 MSIME-Engine 词库 release，逐个校验 SHA256，再放到 `vendor/MetasequoiaImeDict/out/msime.db`。该数据库文件有意不纳入版本库。Windows 和 Linux 取的是同一份产物，所以三个平台分发的 `msime.db` 逐字节一致。
 
-换用新的词库版本：`python3 scripts/product_lock.py refresh --dictionary-tag dict-YYYY.MM.DD`，然后 review 产生的 diff。
+换用新的词库版本：`python3 scripts/product_lock.py refresh --dictionary-tag dict-vMAJOR.MINOR.PATCH`，然后 review 产生的 diff。
 
 公共词库源数据、构建器、辅助码与语音模块现在统一来自固定的 [MSIME-Engine](https://github.com/metasequoiaime/MSIME-Engine) submodule。桌面端继续下载锁定的已发布词库；iOS 打包通过同一 Engine 中的 `build_profile.py` 构建移动词库。现有 MSIME-Dict release 的来源和摘要保持不变，不能用新的构建器提交替代它们。
 

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -39,14 +39,14 @@ Dictionary and helpcode data
 
 The application installs data built from these repositories:
 
-  MSIME-Dict       https://github.com/metasequoiaime/MSIME-Dict
-  MSIME-HelpCode   https://github.com/metasequoiaime/MSIME-HelpCode
+  MSIME-Engine/dictionary  https://github.com/metasequoiaime/MSIME-Engine/tree/main/dictionary
+  (imported from MSIME-HelpCode and MSIME-Dict, both now archived; the upstream attribution below is retained)
 
-Installed as msime.db and helpcodes/*.txt in the application's Resources directory. The database is the one MSIME-Dict publishes as a release asset; product-lock.json in this repository names the release and records the SHA256 of every file taken from it.
+Installed as msime.db and helpcodes/*.txt in the application's Resources directory. The database is the one MSIME-Engine publishes as a release asset; product-lock.json in this repository names the release and records the SHA256 of every file taken from it. Releases published by the archived MSIME-Dict remain available as immutable historical artefacts.
 
-Neither repository declares a license of its own, because most of their content is not their own work. They aggregate word lists and code tables from upstream projects. The upstream terms, which travel with the data, are as follows.
+The sources do not declare a license of their own, because most of their content is not their own work. They aggregate word lists and code tables from upstream projects. The upstream terms, which travel with the data, are as follows.
 
-Sources of msime.db, via MSIME-Dict:
+Sources of msime.db:
 
   rime-ice                GPL-3.0    https://github.com/iDvel/rime-ice
   CustomPinyinDictionary  none       https://github.com/wuhgit/CustomPinyinDictionary
@@ -56,7 +56,7 @@ Sources of msime.db, via MSIME-Dict:
 
 The Chinese tables that msime.db is built from (cn/BaseDictAllV1Part1.txt and cn/BaseDictAllV1Part2.txt) merge rime-ice with CustomPinyinDictionary. rime-ice is licensed under the GNU General Public License version 3, which is the same license this application is distributed under, so its terms are satisfied by the distribution as a whole; this notice serves as its attribution, and its source remains available at the URL above. The quick phrase table is written by the Metasequoia IME maintainers and is covered by that same license.
 
-Sources of helpcodes/*.txt, now packaged from MSIME-Engine/helpcode (history imported from MSIME-HelpCode):
+Sources of helpcodes/*.txt, packaged from MSIME-Engine/helpcode (history imported from the archived MSIME-HelpCode):
 
   helpcode.txt                    lantian      蓝天小雨点 helpcode scheme
   zrm_helpcode_big_unique.txt     ziranma      自然码, derived from

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -40,6 +40,7 @@ Dictionary and helpcode data
 The application installs data built from these repositories:
 
   MSIME-Engine/dictionary  https://github.com/metasequoiaime/MSIME-Engine/tree/main/dictionary
+  MSIME-Engine/helpcode    https://github.com/metasequoiaime/MSIME-Engine/tree/main/helpcode
   (imported from MSIME-HelpCode and MSIME-Dict, both now archived; the upstream attribution below is retained)
 
 Installed as msime.db and helpcodes/*.txt in the application's Resources directory. The database is the one MSIME-Engine publishes as a release asset; product-lock.json in this repository names the release and records the SHA256 of every file taken from it. Releases published by the archived MSIME-Dict remain available as immutable historical artefacts.

--- a/docs/apple-platform-architecture.md
+++ b/docs/apple-platform-architecture.md
@@ -60,7 +60,7 @@ MSIME-Apple/
 │       └── tests/
 ├── vendor/
 │   ├── MetasequoiaImeEngine/
-│   └── MetasequoiaImeDict/out/   # 从 MSIME-Dict release 下载，非 submodule
+│   └── MetasequoiaImeDict/out/   # 从 MSIME-Engine release 下载，非 submodule
 ├── cmake/
 ├── docs/
 └── CMakeLists.txt

--- a/platforms/macos/scripts/build.sh
+++ b/platforms/macos/scripts/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 project_root=${0:A:h:h:h:h}
-# Take the released database rather than rebuilding it, so a local build ships what a release ships. Changing dictionary sources happens in MSIME-Dict, which is where build_all.py lives.
+# Take the released database rather than rebuilding it, so a local build ships what a release ships. Dictionary sources and the public build_profile.py entry point live in MSIME-Engine.
 python3 "$project_root/scripts/fetch_dictionary.py"
 cmake -S "$project_root" -B "$project_root/build" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
 cmake --build "$project_root/build" --parallel

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -674,7 +674,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
 
         self.assertFalse((MACOS_ROOT / "scripts/build_dictionary.py").exists())
         # A branch or a bare "latest" would make two builds of the same commit ship different data.
-        self.assertRegex(lock["tag"], r"\Adict-\d{4}\.\d{2}\.\d{2}\Z")
+        self.assertRegex(lock["tag"], r"\Adict-v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\Z")
         self.assertEqual(lock["repository"], "metasequoiaime/MSIME-Engine")
         # Not read from a gitlink: MSIME-Linux#47 found its dict pin attesting to 55bd649 while the
         # shipped bytes came from 0c7368c, because nothing moves that pin when the tag does.

--- a/scripts/fetch_dictionary.py
+++ b/scripts/fetch_dictionary.py
@@ -5,7 +5,7 @@ This used to be built here, by platforms/macos/scripts/build_dictionary.py, whic
 
 MSIME-Engine publishes msime.db and SHA256SUMS.txt as release assets and both other platforms already take them from there, so take them here too. That is what makes the claim in MSIME-Linux/scripts/fetch_dictionary.py true: all three platforms ship a byte-identical msime.db.
 
-The release tag cannot be overridden from the command line. product-lock.json names it and records the SHA256 of every asset, so a retagged release or a replaced database fails the build instead of shipping: rewriting the upstream SHA256SUMS.txt along with the data does not help, because that file is verified against a committed digest too. Move to a new release with `python3 scripts/product_lock.py refresh --dictionary-tag dict-YYYY.MM.DD` and review the resulting diff.
+The release tag cannot be overridden from the command line. product-lock.json names it and records the SHA256 of every asset, so a retagged release or a replaced database fails the build instead of shipping: rewriting the upstream SHA256SUMS.txt along with the data does not help, because that file is verified against a committed digest too. Move to a new release with `python3 scripts/product_lock.py refresh --dictionary-tag dict-vMAJOR.MINOR.PATCH` and review the resulting diff.
 
     python3 scripts/fetch_dictionary.py
 """

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -10,7 +10,7 @@ public:
   explicit Impl(SchemeType scheme = SchemeType::Quanpin)
       : session{scheme, true, true, true, false} {
     // Only the modes this frontend can answer are offered, and that is decided by the dictionary
-    // product it ships. MSIME-Dict's mobile profile is compact pinyin — its manifest declares
+    // product it ships. Engine's mobile dictionary profile is compact pinyin — its manifest declares
     // features ['pinyin'] — so quick phrases have no quick_parases table here, and temporary
     // Japanese no dict_japanese.dat; emoji and kaomoji read others.db and temporary English reads
     // english.db, neither of which is fetched on Apple at all. What is left needs nothing beyond


### PR DESCRIPTION
产品锁已使用 dict-v1.0.0，但发布配置测试仍只接受日期标签，导致 macOS CI 失败。测试改为检查当前语义化标签，README 和下载脚本的更新示例同步修正。保持产品锁中的数据来源和摘要。

架构文档、构建注释和随包声明统一指向 Engine 的 dictionary/helpcode 目录，保留历史 Releases 与上游许可。

验证：在当前默认分支同样复现日期标签断言失败；修正后 ReleaseConfigurationTests 全部 16 项通过，重新配置并构建 arm64/x86_64 通用架构后全部 38 项 CTest 通过。原生 CI 覆盖 macOS 双架构与 iOS，未启动麦克风或调用云服务。
