### PR TITLE
ci: 补齐仓库验证与自动安全维护

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ permissions:
   contents: read
 
 jobs:
+  quality:
+    uses: ./.github/workflows/quality.yml
+
   macos:
     name: macOS 15 ${{ matrix.architecture }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
         type: boolean
         default: false
 
+  merge_group:
+
 concurrency:
   # Keyed by event as well as branch: the release scripts dispatch this workflow and wait on that exact run, so a pull_request run on the same branch must not cancel it. Feature branches only ever get the pull_request run (push is restricted to main), so this still collapses superseded runs of the same kind.
   group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -33,6 +35,7 @@ jobs:
           - runner: macos-15-intel
             architecture: x86_64
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -65,7 +68,7 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
       - name: Test
-        run: ctest --test-dir build --output-on-failure --timeout 20
+        run: ctest --no-tests=error --test-dir build --output-on-failure --timeout 20
       - name: Verify input method bundle
         run: |
           codesign --verify --deep --strict --verbose=2 build/MetasequoiaIME.app
@@ -79,6 +82,7 @@ jobs:
     name: iOS Simulator
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_only != true }}
     runs-on: macos-15
+    timeout-minutes: 60
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '47 3 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: codeql-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  analyze:
+    name: CodeQL / ${{ matrix.language }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, c-cpp, python]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: ${{ matrix.language }}
+          # C/C++ source analysis complements, rather than replaces, native build CI.
+          build-mode: none
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: '/language:${{ matrix.language }}'
+
+  swift:
+    name: CodeQL / Swift
+    runs-on: macos-15
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - name: Install dependencies and Xcode generator
+        run: brew install boost fmt spdlog nlohmann-json xcodegen
+      - name: Prepare the same dictionary as simulator CI
+        run: python3 platforms/ios/scripts/prepare_dictionary.py
+      - name: Generate Xcode project
+        run: |
+          mkdir -p build/ios
+          xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: swift
+          build-mode: manual
+      - name: Build the app and keyboard for analysis
+        run: >-
+          xcodebuild -project build/ios/MetasequoiaImeIOS.xcodeproj
+          -scheme MetasequoiaImeIOS -configuration Debug -sdk iphonesimulator
+          -destination 'generic/platform=iOS Simulator'
+          -derivedDataPath build/codeql-ios CODE_SIGNING_ALLOWED=NO build
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: '/language:swift'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,44 @@
+name: Repository quality
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: quality-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  workflows:
+    name: Workflow validation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: '1.26'
+          cache: false
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Validate workflows and embedded shell scripts
+        env:
+          # Ignore style suggestions, but fail on shell correctness warnings and errors.
+          SHELLCHECK_OPTS: --severity=warning
+        run: actionlint -color
+  dependencies:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,15 +1,9 @@
 name: Repository quality
+# Called by CI so release-please's workflow_dispatch receives these checks too.
 on:
-  push:
-    branches: [main]
-  pull_request:
-  merge_group:
-  workflow_dispatch:
+  workflow_call:
 permissions:
   contents: read
-concurrency:
-  group: quality-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   workflows:
     name: Workflow validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
   prepare:
     name: Prepare release metadata
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       actions: write
       contents: write

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -281,13 +281,23 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertTrue(package["force-tag-creation"])
         self.assertFalse(package.get("include-component-in-tag", True))
         ci_workflow = (PROJECT_ROOT / ".github/workflows/ci.yml").read_text()
-        allowed_actions = {"actions/checkout", "googleapis/release-please-action"}
+        allowed_actions = {
+            "actions/checkout", "googleapis/release-please-action", "actions/setup-go",
+            "actions/dependency-review-action", "github/codeql-action/init",
+            "github/codeql-action/analyze",
+        }
         used_actions = set()
-        for workflow_source in (workflow, ci_workflow):
-            uses_lines = [line.strip() for line in workflow_source.splitlines() if line.strip().startswith("uses:")]
+        for workflow_path in (PROJECT_ROOT / ".github/workflows").glob("*.yml"):
+            uses_lines = [line.strip().removeprefix("- ") for line in workflow_path.read_text().splitlines()
+                          if line.strip().removeprefix("- ").startswith("uses:")]
             self.assertGreater(len(uses_lines), 0)
             for uses_line in uses_lines:
                 action_reference = uses_line.removeprefix("uses:").strip().split()[0]
+                if action_reference.startswith("./"):
+                    # Local reusable workflows are pinned by the caller's own commit.
+                    self.assertEqual(action_reference, "./.github/workflows/quality.yml")
+                    self.assertTrue((PROJECT_ROOT / action_reference).is_file())
+                    continue
                 action, separator, revision = action_reference.partition("@")
                 self.assertEqual(separator, "@")
                 self.assertIn(action, allowed_actions)


### PR DESCRIPTION
Apple 产品 CI 增加 actionlint、依赖审查和定期 CodeQL，并以未签名 iOS 模拟器构建执行 Swift 分析。质量检查随手动 CI 一起运行；配置回归区分仓内复用工作流和远程 Action，扩展到所有工作流并继续严格要求远程引用使用完整 SHA。

验证：本 PR 最新提交的全部适用 GitHub 检查通过，包括 quality / Workflow validation、CodeQL / actions、CodeQL / c-cpp、CodeQL / python、quality / Dependency review、CodeQL / Swift、macOS 15 arm64、macOS 15 x86_64、iOS Simulator、CodeQL。本地 actionlint、git diff --check 通过。

保留既有产品锁、语义化版本和发布规则；没有执行正式发布或证书签名。
