### PR TITLE
refactor(session): 接入公共会话并隔离辅助码与候选提示

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # MSIME-Apple
 
-组织职责见 [组织规范](https://github.com/metasequoiaime/.github/blob/main/AGENTS.md)。平台代码负责 InputMethodKit/UIKit、焦点和系统文本插入；输入算法使用固定 Engine InputSession。
+组织职责见 [组织规范](https://github.com/metasequoiaime/.github/blob/main/AGENTS.md)。平台代码负责 InputMethodKit/UIKit、焦点和系统文本插入；输入算法来自固定 Engine。iOS bridge 使用 `<metasequoia/session.h>` 的动作与快照，macOS 暂用兼容 `InputSession`。新平台代码优先使用公共 Session 接口。
+
+辅助码按会话配置，macOS 候选提示使用控制器持有的同方案只读码表；不要调用全局选择器来切换活动会话，也不要在每次按键上重新加载码表。当前安装器仍提供原有数据目录，`RuntimePaths::legacy()` 在会话创建时捕获该布局；这不表示已接入新的完整资源包或资源代际切换。
 
 桌面词库使用 product-lock.json 的已发布数据及摘要。`vendor/MetasequoiaImeEngine` 同时提供输入引擎、`helpcode/helpcodes/` 和根 `build_profile.py` 移动构建入口；禁止另行检出 Dict/HelpCode 或在 Apple 复制数据算法。Engine gitlink 与已发布词库源提交仍分别记录，不能把构建器提交冒充下载数据的来源。词库格式验证器从固定 Engine 复制，CI 比较字节防止漂移。

--- a/docs/apple-platform-architecture.md
+++ b/docs/apple-platform-architecture.md
@@ -18,6 +18,17 @@ This repository is named `MSIME-Apple` because it contains Apple-platform adapte
 
 The engine is the only authority for a composition and its candidates. A platform frontend translates native events into engine calls, renders the returned state, and inserts committed text through the platform API.
 
+The iOS bridge now uses the public `<metasequoia/session.h>` facade: editing actions return commits,
+and value snapshots supply preedit and candidates. macOS still uses the compatibility `InputSession`
+interface directly. Both consume the same pinned Engine. macOS configures helpcodes on each session
+and keeps a matching immutable keymap for candidate annotations; one controller cannot change another
+controller's live scheme. Keymaps are prepared when a session is created, not on each keystroke.
+
+The existing installers and dictionary profiles remain in use. `RuntimePaths::legacy()` captures
+their directory layout when a session is created. Separate immutable resource generations and the
+complete desktop resource ZIP are follow-up migrations; the facade change does not enable extra
+local modes or require desktop dictionaries in the mobile keyboard.
+
 ```text
 MetasequoiaImeEngine (C++17)
           |

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -73,6 +73,7 @@ targets:
           - $(inherited)
           - $(PROJECT_DIR)/../../shared/apple-bridge
           - $(PROJECT_DIR)/../../vendor/MetasequoiaImeEngine
+          - $(PROJECT_DIR)/../../vendor/MetasequoiaImeEngine/include
           - $(PROJECT_DIR)/../../vendor/MetasequoiaImeEngine/utfcpp/source
           - $(BREW_PREFIX)/include
         SKIP_INSTALL: YES

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -275,15 +275,12 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("InputSnapshot open_local_mode(char trigger);", adapter_header)
         self.assertIn("openLocalMode:", bridge_header)
 
-        # A mode cannot open on top of a composition, and the engine guards every trigger on that,
-        # so the bridge has to refuse rather than hand the capital over as helpcode.
-        opener = adapter.split("InputSessionAdapter::open_local_mode", 1)[1].split("\n}", 1)[0]
-        self.assertIn("impl_->session.has_composition()", opener)
-        self.assertIn("handle_character(trigger, true)", opener)
+        # InputSessionAdapterTests exercises idle and in-composition mode triggers through the
+        # real adapter. Do not couple this packaging check to the engine facade's method names.
 
         # Only the four this frontend can answer. The rest read others.db, english.db or
         # dict_japanese.dat, none of which are packaged.
-        options = adapter.split("LocalModeOptions options;", 1)[1].split("set_local_mode_options", 1)[0]
+        options = adapter.split("LocalModeOptions options;", 1)[1].split("return session_options", 1)[0]
         for enabled in ("unicode", "date_time", "super_jianpin"):
             self.assertIn(f"options.{enabled} = true;", options)
         # quick_phrase reads quick_parases and temporary_japanese reads dict_japanese.dat, neither of

--- a/platforms/macos/src/CandidateDisplay.h
+++ b/platforms/macos/src/CandidateDisplay.h
@@ -27,12 +27,13 @@ inline bool ScriptConversionAppliesToLocalMode(LocalInputMode mode)
     return mode != LocalInputMode::Unicode;
 }
 
-inline std::string CandidateDisplayText(const WordItem &candidate, SchemeType scheme, bool helpcodeEnabled)
+inline std::string CandidateDisplayText(const WordItem &candidate, SchemeType scheme, bool helpcodeEnabled,
+                                        const HelpcodeUtils::Keymap *keymap = nullptr)
 {
-    if (!helpcodeEnabled || (scheme != SchemeType::Quanpin && scheme != SchemeType::Shuangpin))
+    if (!helpcodeEnabled || keymap == nullptr || (scheme != SchemeType::Quanpin && scheme != SchemeType::Shuangpin))
     {
         return candidate.word;
     }
-    return candidate.word + HelpcodeUtils::compute_helpcodes(candidate.word);
+    return candidate.word + HelpcodeUtils::compute_helpcodes(candidate.word, false, keymap);
 }
 } // namespace metasequoia::mac

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -23,7 +23,6 @@
 #include "CandidateSelectionState.h"
 #include "InputControllerKeyRouting.h"
 #include "core/input_session.h"
-#include "common/helpcode_utils.h"
 
 #import <Carbon/Carbon.h>
 
@@ -98,6 +97,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 {
     std::unique_ptr<metasequoia::InputSession> _session;
     std::string _activeHelpcodeSchema;
+    HelpcodeUtils::SharedKeymap _activeHelpcodeKeymap;
     metasequoia::mac::CandidateSelectionState _candidateSelection;
     MetasequoiaCandidatePanel *_candidatePanel;
     MetasequoiaFloatingToolbarPanel *_floatingToolbarPanel;
@@ -218,7 +218,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     }
     if (_session != nullptr && _session->has_composition())
     {
-        HelpcodeUtils::select_helpcode_schema(_activeHelpcodeSchema);
+        // Keep the scheme chosen when this composition began. Preferences from another
+        // controller must not change the helpcodes of this live session.
         return;
     }
 
@@ -229,7 +230,6 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     [_candidatePanel setAttributes:metasequoia::mac::CandidatePanelAttributes(preferences.candidateFontSize)];
     _wubiAutoCommitUniqueEnabled = preferences.wubiAutoCommitUniqueEnabled;
     const bool helpcodeSchemaMatches = _activeHelpcodeSchema == preferences.helpcodeSchema;
-    HelpcodeUtils::select_helpcode_schema(preferences.helpcodeSchema);
     _activeHelpcodeSchema = preferences.helpcodeSchema;
     // Applied above the early return, like every other preference a live session can take. It used
     // to be applied only to a freshly constructed session, and SessionMatchesPreferences does not
@@ -240,9 +240,12 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     {
         return;
     }
+    const auto paths = metasequoia::RuntimePaths::legacy();
     _session = std::make_unique<metasequoia::InputSession>(
         preferences.scheme, preferences.autocorrectEnabled, preferences.helpcodeEnabled,
-        preferences.chinesePunctuationEnabled, preferences.candidateLearningEnabled);
+        preferences.chinesePunctuationEnabled, preferences.candidateLearningEnabled, paths);
+    _session->set_helpcode_schema(preferences.helpcodeSchema);
+    _activeHelpcodeKeymap = HelpcodeUtils::load_helpcode_keymap(paths.resources, preferences.helpcodeSchema);
     [self applyLocalInputModeOptions];
     _candidateSelection.reset();
     _candidateHighlightedIndex = 0;
@@ -791,7 +794,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     for (const WordItem &candidate : _session->candidates())
     {
         NSString *display = MetasequoiaStringFromUtf8(metasequoia::mac::CandidateDisplayText(
-            candidate, _session->scheme_type(), annotateHelpcodes));
+            candidate, _session->scheme_type(), annotateHelpcodes, _activeHelpcodeKeymap.get()));
         NSString *convertedDisplay = MetasequoiaChineseOutputString(display, traditionalOutput);
         [data addObject:MetasequoiaIndexedCandidateString(convertedDisplay, candidateIndex)];
         ++candidateIndex;

--- a/platforms/macos/tests/CandidatePaginationTests.mm
+++ b/platforms/macos/tests/CandidatePaginationTests.mm
@@ -72,6 +72,8 @@ static void Require(bool condition, const char *message)
 - (void)preparePartialInput;
 - (NSString *)testCandidateAtIndex:(NSUInteger)index;
 - (BOOL)testHasComposition;
+- (void)prepareHelpcodeProbe;
+- (void)refreshHelpcodeProbe;
 @end
 @implementation MetasequoiaInputController (PaginationTestFixture)
 - (void)prepareTestPanel:(RecordingCandidatePanel *)panel
@@ -91,6 +93,16 @@ static void Require(bool condition, const char *message)
     [self reloadSessionFromPreferences];
 }
 - (BOOL)testHasComposition { return _session != nullptr && _session->has_composition(); }
+- (void)prepareHelpcodeProbe
+{
+    for (char character : std::string("niA")) _session->handle_character(character);
+}
+- (void)refreshHelpcodeProbe
+{
+    [self reloadSessionFromPreferences];
+    _session->handle_command(metasequoia::Command::Backspace);
+    _session->handle_character('A');
+}
 - (void)preparePartialInput
 {
     _session = std::make_unique<metasequoia::InputSession>(SchemeType::Quanpin, true, false, true, false);
@@ -445,6 +457,53 @@ static void RunChinesePunctuationTests()
     [defaults setVolatileDomain:@{} forName:NSArgumentDomain];
 }
 
+static void RunHelpcodeIsolationTests(NSString *directory)
+{
+    // Add these candidates after the pagination fixtures, whose expected list has 12 entries.
+    sqlite3 *database = nullptr;
+    Require(sqlite3_open([directory stringByAppendingPathComponent:@"msime.db"].fileSystemRepresentation,
+                         &database) == SQLITE_OK, "Cannot open helpcode fixture.");
+    const int result = sqlite3_exec(database,
+        "CREATE TABLE tbl_1_n(key TEXT,jp TEXT,value TEXT,weight INTEGER);"
+        "INSERT INTO tbl_1_n VALUES('ni','n','你',100),('ni','n','妮',90)", nullptr, nullptr, nullptr);
+    sqlite3_close(database);
+    Require(result == SQLITE_OK, "Cannot create helpcode fixture.");
+    NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+    NSMutableDictionary *preferences = [@{
+        @"MetasequoiaImeInputScheme": @0,
+        @"MetasequoiaImeHelpcodeEnabled": @YES,
+        @"MetasequoiaImeCandidateLearning": @NO,
+        @"MetasequoiaImeQuanpinHelpcodeSchema": @0,
+    } mutableCopy];
+    [defaults setVolatileDomain:preferences forName:NSArgumentDomain];
+    PaginationTestController *first = [[PaginationTestController alloc] init];
+    [first prepareEmptyTestPanel:[[RecordingCandidatePanel alloc] init]];
+    [first prepareHelpcodeProbe];
+    Require([first testCandidateCount] > 0 && [[first testCandidateAtIndex:0] isEqualToString:@"你"],
+            "The first controller did not apply its Lantian helpcodes.");
+
+    preferences[@"MetasequoiaImeQuanpinHelpcodeSchema"] = @1;
+    [defaults setVolatileDomain:preferences forName:NSArgumentDomain];
+    PaginationTestController *second = [[PaginationTestController alloc] init];
+    [second prepareEmptyTestPanel:[[RecordingCandidatePanel alloc] init]];
+    [second prepareHelpcodeProbe];
+    Require([second testCandidateCount] > 0 && [[second testCandidateAtIndex:0] isEqualToString:@"妮"],
+            "The second controller did not apply its Ziranma helpcodes.");
+
+    [first refreshHelpcodeProbe];
+    Require([[first testCandidateAtIndex:0] isEqualToString:@"你"],
+            "Reloading preferences changed the first controller's live composition schema.");
+    [second refreshHelpcodeProbe];
+    Require([[second testCandidateAtIndex:0] isEqualToString:@"妮"],
+            "Another controller changed this session's helpcodes.");
+
+    [first prepareEmptyTestPanel:[[RecordingCandidatePanel alloc] init]];
+    [first prepareHelpcodeProbe];
+    Require([[first testCandidateAtIndex:0] isEqualToString:@"妮"],
+            "A new composition did not pick up the updated schema preference.");
+    [defaults setVolatileDomain:@{} forName:NSArgumentDomain];
+}
+
 int main()
 {
     @autoreleasepool
@@ -453,6 +512,12 @@ int main()
         NSString *directory = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
         std::filesystem::create_directories(directory.fileSystemRepresentation);
         setenv("METASEQUOIA_IME_DATA_DIR", directory.fileSystemRepresentation, 1);
+        NSString *helpcodeDirectory = [directory stringByAppendingPathComponent:@"helpcodes"];
+        std::filesystem::create_directories(helpcodeDirectory.fileSystemRepresentation);
+        Require([@"你=ab\n妮=cd\n" writeToFile:[helpcodeDirectory stringByAppendingPathComponent:@"helpcode.txt"]
+                                   atomically:YES encoding:NSUTF8StringEncoding error:nil], "Cannot write Lantian fixture.");
+        Require([@"你=cb\n妮=ad\n" writeToFile:[helpcodeDirectory stringByAppendingPathComponent:@"zrm_helpcode_big_unique.txt"]
+                                   atomically:YES encoding:NSUTF8StringEncoding error:nil], "Cannot write Ziranma fixture.");
         sqlite3 *database = nullptr;
         Require(sqlite3_open([directory stringByAppendingPathComponent:@"msime.db"].fileSystemRepresentation, &database) == SQLITE_OK, "Cannot create fixture.");
         Require(sqlite3_exec(database, "CREATE TABLE tbl_2_n(key TEXT,jp TEXT,value TEXT,weight INTEGER)", nullptr, nullptr, nullptr) == SQLITE_OK, "Cannot create table.");
@@ -469,7 +534,7 @@ int main()
             "CREATE TABLE tbl_2_s(key TEXT,jp TEXT,value TEXT,weight INTEGER)",
             nullptr, nullptr, nullptr) == SQLITE_OK, "Cannot create partial-selection fixture.");
         sqlite3_close(database);
-        try { RunTests(); RunVoiceTests(); RunFullWidthAndLocalModeTests(); RunChinesePunctuationTests(); }
+        try { RunTests(); RunVoiceTests(); RunFullWidthAndLocalModeTests(); RunChinesePunctuationTests(); RunHelpcodeIsolationTests(directory); }
         catch (const std::exception &error)
         {
             fprintf(stderr, "%s\n", error.what());

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -101,20 +101,18 @@ int main()
 
     const std::filesystem::path helpcodeDataDirectory =
         std::filesystem::path(__FILE__).parent_path() / "../../../vendor/MetasequoiaImeEngine/helpcode";
-    require(setenv("METASEQUOIA_IME_DATA_DIR", helpcodeDataDirectory.lexically_normal().c_str(), 1) == 0,
-            "The candidate display test could not select its helpcode data.");
-    require(HelpcodeUtils::select_helpcode_schema(metasequoia::mac::HelpcodeSchemaIdentifier(1)) &&
-                CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true) == "你(rE)" &&
-                HelpcodeUtils::select_helpcode_schema(metasequoia::mac::HelpcodeSchemaIdentifier(2)) &&
-                CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true) == "你(rP)" &&
-                HelpcodeUtils::select_helpcode_schema(metasequoia::mac::HelpcodeSchemaIdentifier(3)) &&
-                CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true) == "你(rG)" &&
-                HelpcodeUtils::select_helpcode_schema(metasequoia::mac::HelpcodeSchemaIdentifier(4)) &&
-                CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true) == "你(rX)" &&
-                HelpcodeUtils::select_helpcode_schema(metasequoia::mac::HelpcodeSchemaIdentifier(0)),
-            "A configured helpcode scheme did not select its packaged engine table.");
-    require(CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true) == "你(rX)" &&
-                CandidateDisplayText(WordItem{"nimen", "你们", 1}, SchemeType::Shuangpin, true) == "你们(rR)",
+    const char *expected[] = {"你(rX)", "你(rE)", "你(rP)", "你(rG)", "你(rX)"};
+    const auto lantian = HelpcodeUtils::load_helpcode_keymap(helpcodeDataDirectory, "lantian");
+    for (int schema = 0; schema < 5; ++schema)
+    {
+        const auto table = HelpcodeUtils::load_helpcode_keymap(
+            helpcodeDataDirectory, metasequoia::mac::HelpcodeSchemaIdentifier(schema));
+        require(CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true, table.get()) == expected[schema],
+                "A configured helpcode scheme did not select its packaged engine table.");
+        require(CandidateDisplayText(WordItem{"ni", "你", 1}, SchemeType::Quanpin, true, lantian.get()) == "你(rX)",
+                "Loading another display keymap changed an existing one.");
+    }
+    require(CandidateDisplayText(WordItem{"nimen", "你们", 1}, SchemeType::Shuangpin, true, lantian.get()) == "你们(rR)",
             "Pinyin candidate display did not append the configured auxiliary code.");
     // A helpcode annotates a word the user could have typed in pinyin. compute_helpcodes still
     // finds Han characters in a synthesised candidate and appends letters for them, so "2026年9月6日"
@@ -134,7 +132,7 @@ int main()
     require(CandidateDisplayText(WordItem{"T", "2026年9月6日", 1}, SchemeType::Quanpin, false) ==
                 "2026年9月6日",
             "A date candidate did not come back unannotated.");
-    require(CandidateDisplayText(WordItem{"T", "2026年9月6日", 1}, SchemeType::Quanpin, true) !=
+    require(CandidateDisplayText(WordItem{"T", "2026年9月6日", 1}, SchemeType::Quanpin, true, lantian.get()) !=
                 "2026年9月6日",
             "The annotation this rule exists to suppress no longer happens, so the rule is dead.");
 

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -501,8 +501,8 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertNotIn("Schema", helpcode_enabled_setter)
         self.assertIn("全拼辅助码方案", preferences_controller)
         self.assertIn("双拼辅助码方案", preferences_controller)
-        input_controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
-        self.assertIn("HelpcodeUtils::select_helpcode_schema", input_controller)
+        # Runtime schema selection and isolation are exercised by CandidatePaginationTests;
+        # do not require the retired process-global selector's spelling in the controller.
         self.assertIn("storedChinesePunctuationEnabled", preferences_controller)
         self.assertIn("setChinesePunctuationEnabled", preferences_controller)
         self.assertIn("使用中文标点", preferences_controller)

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -1,6 +1,6 @@
 #include "InputSessionAdapter.h"
 
-#include "core/input_session.h"
+#include <metasequoia/session.h>
 
 #include <utility>
 
@@ -8,7 +8,16 @@ namespace metasequoia::apple {
 class InputSessionAdapter::Impl {
 public:
   explicit Impl(SchemeType scheme = SchemeType::Quanpin)
-      : session{scheme, true, true, true, false} {
+      : session{MakeOptions(scheme)} {}
+
+  static SessionOptions MakeOptions(SchemeType scheme) {
+    SessionOptions session_options;
+    // The iOS installer still supplies the existing writable dictionary layout. Capture it
+    // once per session; moving installation to separate resource generations is independent
+    // of routing editing actions through the public facade.
+    session_options.paths = RuntimePaths::legacy();
+    session_options.scheme = scheme;
+    session_options.learning = false;
     // Only the modes this frontend can answer are offered, and that is decided by the dictionary
     // product it ships. Engine's mobile dictionary profile is compact pinyin — its manifest declares
     // features ['pinyin'] — so quick phrases have no quick_parases table here, and temporary
@@ -25,21 +34,23 @@ public:
     options.kaomoji = false;
     options.temporary_english = false;
     options.temporary_japanese = false;
-    session.set_local_mode_options(options);
+    session_options.local_modes = options;
+    return session_options;
   }
 
-  InputSession session;
+  Session session;
 };
 
 namespace {
-InputSnapshot MakeSnapshot(const InputSession &session, KeyResult result) {
+InputSnapshot MakeSnapshot(const Session &session, KeyResult result) {
   InputSnapshot snapshot;
   snapshot.handled = result.handled;
   snapshot.commit = std::move(result.commit);
   snapshot.diagnostic = std::move(result.diagnostic);
-  snapshot.preedit = session.preedit();
-  snapshot.candidates.reserve(session.candidates().size());
-  for (const auto &candidate : session.candidates()) {
+  const auto view = session.snapshot();
+  snapshot.preedit = view.preedit;
+  snapshot.candidates.reserve(view.candidates.size());
+  for (const auto &candidate : view.candidates) {
     snapshot.candidates.push_back(candidate.word);
   }
   return snapshot;
@@ -51,14 +62,14 @@ InputSessionAdapter::InputSessionAdapter() : impl_(std::make_unique<Impl>()) {}
 InputSessionAdapter::~InputSessionAdapter() = default;
 
 InputSnapshot InputSessionAdapter::handle_character(char character) {
-  // The engine accepts A-Z during a composition as helpcode input, which no Apple frontend offers.
+  // The engine accepts A-Z during a composition as helpcode input, which this keyboard does not offer.
   // Reject it here so an uppercase letter stays unhandled and the frontend passes it to the client,
-  // matching what core/input_session.h still documents and what the macOS controller does.
+  // preserving the keyboard's existing uppercase passthrough behavior.
   if (character >= 'A' && character <= 'Z') {
     return MakeSnapshot(impl_->session, KeyResult{});
   }
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_character(character));
+                      impl_->session.character(character));
 }
 
 InputSnapshot InputSessionAdapter::open_local_mode(char trigger) {
@@ -66,60 +77,60 @@ InputSnapshot InputSessionAdapter::open_local_mode(char trigger) {
   // would be a mode the user did not ask for. handle_character rejects A-Z outright, which is right
   // for a keystroke and wrong here, so the session is called directly with the shift_only flag the
   // triggers are keyed off.
-  if (trigger < 'A' || trigger > 'Z' || impl_->session.has_composition()) {
+  if (trigger < 'A' || trigger > 'Z' || !impl_->session.snapshot().preedit.empty()) {
     return MakeSnapshot(impl_->session, KeyResult{});
   }
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_character(trigger, true));
+                      impl_->session.character(trigger, true));
 }
 
 bool InputSessionAdapter::in_unicode_mode() const {
-  return impl_->session.local_input_mode() == LocalInputMode::Unicode;
+  return impl_->session.snapshot().local_mode == LocalInputMode::Unicode;
 }
 
 InputSnapshot InputSessionAdapter::handle_candidate_key(char character) {
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_candidate_key(character));
+                      impl_->session.candidate_key(character));
 }
 
 InputSnapshot InputSessionAdapter::handle_punctuation(char character) {
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_punctuation(character));
+                      impl_->session.punctuation(character));
 }
 
 InputSnapshot InputSessionAdapter::handle_backspace() {
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_command(Command::Backspace));
+                      impl_->session.command(Command::Backspace));
 }
 
 InputSnapshot InputSessionAdapter::commit_candidate() {
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_command(Command::CommitCandidate));
+                      impl_->session.command(Command::CommitCandidate));
 }
 
 InputSnapshot InputSessionAdapter::finish_composition() {
-  return MakeSnapshot(impl_->session, impl_->session.finish_composition());
+  return MakeSnapshot(impl_->session, impl_->session.finish());
 }
 
 InputSnapshot InputSessionAdapter::commit_raw() {
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_command(Command::CommitRaw));
+                      impl_->session.command(Command::CommitRaw));
 }
 
 InputSnapshot InputSessionAdapter::cancel() {
   return MakeSnapshot(impl_->session,
-                      impl_->session.handle_command(Command::Cancel));
+                      impl_->session.command(Command::Cancel));
 }
 
 InputSnapshot InputSessionAdapter::select_candidate(std::size_t index) {
-  return MakeSnapshot(impl_->session, impl_->session.select_candidate(index));
+  return MakeSnapshot(impl_->session, impl_->session.select(index));
 }
 
 InputSnapshot InputSessionAdapter::switch_to_shuangpin(bool uses_shuangpin) {
   if (uses_shuangpin == this->uses_shuangpin()) {
     return MakeSnapshot(impl_->session, {});
   }
-  const auto result = impl_->session.finish_composition();
+  const auto result = impl_->session.finish();
   auto snapshot = MakeSnapshot(impl_->session, result);
   const auto scheme =
       uses_shuangpin ? SchemeType::Shuangpin : SchemeType::Quanpin;
@@ -128,6 +139,6 @@ InputSnapshot InputSessionAdapter::switch_to_shuangpin(bool uses_shuangpin) {
 }
 
 bool InputSessionAdapter::uses_shuangpin() const {
-  return impl_->session.scheme_type() == SchemeType::Shuangpin;
+  return impl_->session.snapshot().scheme == SchemeType::Shuangpin;
 }
 } // namespace metasequoia::apple


### PR DESCRIPTION
Engine 的公共 Session 和会话隔离已合入。Apple 仍通过内部 InputSession 驱动 iOS，macOS 的候选提示依赖进程全局辅助码表，会把会话隔离的输入层和全局显示层混在一起。

固定到已合入的 Engine c63ba774；iOS bridge 改用 Session 动作和快照并更新 Xcode 公共头路径。macOS 对每个会话配置辅助码，并为候选提示持有匹配的只读码表；另一控制器不能改变正在输入的方案，每次按键也不再加载码表。新增真实 macOS 控制器的双方案交替回归，保留词库规格、学习开关和输入行为。

验证：
- macOS 26.6.2：arm64/x86_64 通用构建、签名和双架构校验通过，全部 38 个 CTest 通过。
- 原有 iOS bridge 回归通过；39 项 iOS 工程配置测试、移动词库打包检查通过，真实锁定的词库下载/校验和 mobile profile 生成通过。
- iOS 26.5 / iPhone 17 专用模拟器：宿主与键盘扩展构建通过，现有引导页 XCTest 1 项通过，测试模拟器已清理。
- 产品锁与 Engine 词库契约副本校验通过。
- 删除两处只断言旧方法名的静态检查；相同行为由原有 bridge 回归和新增控制器运行时回归覆盖。

现有安装目录仍由 RuntimePaths::legacy 在会话创建时捕获，完整资源包/代际目录以及 macOS Session facade 尚未迁移。没有执行真机内存测量、用户系统安装或产品发布。

对应接入矩阵：metasequoiaime/MSIME-Docs#8；Linux 同步兼容迁移：metasequoiaime/MSIME-Linux#84。
