### PR TITLE
Tell a missing engine submodule apart from a drifted dictionary validator

### DIFF
--- a/scripts/check-dictionary-contract.py
+++ b/scripts/check-dictionary-contract.py
@@ -3,6 +3,10 @@
 from pathlib import Path
 root = Path(__file__).resolve().parents[1]
 source = root / 'vendor/MetasequoiaImeEngine/contracts/dictionary/product.py'
-if not source.is_file() or source.read_bytes() != (root / 'scripts/dictionary_product.py').read_bytes():
+# An engine submodule that was never checked out is not a validator that drifted. Reporting both as
+# "differs" sends whoever reads it looking for a content change that is not there.
+if not source.is_file():
+    raise SystemExit(f'{source.relative_to(root)} is missing; run git submodule update --init')
+if source.read_bytes() != (root / 'scripts/dictionary_product.py').read_bytes():
     raise SystemExit('Dictionary validator differs from the pinned Engine contract')
 print('Dictionary product validator matches the pinned Engine contract')


### PR DESCRIPTION
## What

`scripts/check-dictionary-contract.py` folds two different failures into one condition:

```python
if not source.is_file() or source.read_bytes() != (root / 'scripts/dictionary_product.py').read_bytes():
    raise SystemExit('Dictionary validator differs from the pinned Engine contract')
```

A checkout that has never run `git submodule update --init` has no `vendor/MetasequoiaImeEngine/contracts/dictionary/product.py` at all, and gets told the vendored validator *differs from the pinned contract* — sending the reader looking for a content change that is not there. The two cases need different answers: one is "check out the submodule", the other is "someone edited a file that must stay byte-identical to the engine contract".

MSIME-Windows already carries the corrected version of this exact file. This adopts it verbatim. The three frontends keep byte-identical copies of `dictionary_product.py` and use this script to enforce that, so the script doing the enforcing should not itself differ between them.

MSIME-Linux picks up the same change in metasequoiaime/MSIME-Linux#82.

## Verification

Both directions, locally:

- with the submodule checked out at the pinned engine commit (`cc21e42`): `Dictionary product validator matches the pinned Engine contract`, exit 0
- with no submodule: `vendor/MetasequoiaImeEngine/contracts/dictionary/product.py is missing; run git submodule update --init`, exit 1

CI runs this script in the `Validate the product lock` step, where the submodule is always checked out, so the passing path is the one CI exercises and it is unchanged.
