### PR TITLE
refactor(session): migrate macOS to public Engine actions and snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,11 @@
 # MSIME-Apple
 
-组织职责见 [组织规范](https://github.com/metasequoiaime/.github/blob/main/AGENTS.md)。平台代码负责 InputMethodKit/UIKit、焦点和系统文本插入；输入算法来自固定 Engine。iOS bridge 使用 `<metasequoia/session.h>` 的动作与快照，macOS 暂用兼容 `InputSession`。新平台代码优先使用公共 Session 接口。
+组织职责见 [组织规范](https://github.com/metasequoiaime/.github/blob/main/AGENTS.md)。平台代码负责 InputMethodKit/UIKit、焦点和系统文本插入；输入算法来自固定 Engine。iOS bridge 与 macOS 控制器均使用 `<metasequoia/session.h>` 的动作与快照。平台保存界面选择和产品偏好，不复制输入组合状态机。
 
 辅助码按会话配置，macOS 候选提示使用控制器持有的同方案只读码表；不要调用全局选择器来切换活动会话，也不要在每次按键上重新加载码表。当前安装器仍提供原有数据目录，`RuntimePaths::legacy()` 在会话创建时捕获该布局；这不表示已接入新的完整资源包或资源代际切换。
 
 桌面词库使用 product-lock.json 的已发布数据及摘要。`vendor/MetasequoiaImeEngine` 同时提供输入引擎、`helpcode/helpcodes/` 和根 `build_profile.py` 移动构建入口；禁止另行检出 Dict/HelpCode 或在 Apple 复制数据算法。Engine gitlink 与已发布词库源提交仍分别记录，不能把构建器提交冒充下载数据的来源。词库格式验证器从固定 Engine 复制，CI 比较字节防止漂移。
+
+macOS 每次 Engine 动作完成后更新值快照；候选选择必须用当前快照校验索引与词条。
+活动组合继续使用创建时的偏好，组合结束后才按新的 SessionOptions 重建会话。
+高亮候选的自动提交调用 Session::finish(index)，剩余分段仍由 Engine 完成。

--- a/docs/apple-platform-architecture.md
+++ b/docs/apple-platform-architecture.md
@@ -19,8 +19,11 @@ This repository is named `MSIME-Apple` because it contains Apple-platform adapte
 The engine is the only authority for a composition and its candidates. A platform frontend translates native events into engine calls, renders the returned state, and inserts committed text through the platform API.
 
 The iOS bridge now uses the public `<metasequoia/session.h>` facade: editing actions return commits,
-and value snapshots supply preedit and candidates. macOS still uses the compatibility `InputSession`
-interface directly. Both consume the same pinned Engine. macOS configures helpcodes on each session
+and value snapshots supply preedit and candidates. macOS also uses the public `Session` interface. It caches value snapshots after editing
+actions and keeps the immutable creation options for preference comparisons. Active compositions
+retain their options; changed preferences rebuild an idle session. Candidate navigation validates
+its index and word against the current snapshot before selection, and automatic completion uses
+`finish(highlighted_index)` so Engine also commits remaining segments. Both consume the same pinned Engine. macOS configures helpcodes on each session
 and keeps a matching immutable keymap for candidate annotations; one controller cannot change another
 controller's live scheme. Keymaps are prepared when a session is created, not on each keystroke.
 

--- a/platforms/macos/src/CandidateDisplay.h
+++ b/platforms/macos/src/CandidateDisplay.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "common/helpcode_utils.h"
-#include "core/input_session.h"
+#include <metasequoia/session.h>
 #include "core/scheme_type.h"
 #include "core/word_item.h"
 

--- a/platforms/macos/src/CandidateSelectionState.h
+++ b/platforms/macos/src/CandidateSelectionState.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CandidatePageSize.h"
-#include "core/input_session.h"
+#include <metasequoia/session.h>
 
 #include <cstddef>
 #include <optional>
@@ -43,13 +43,13 @@ class CandidateSelectionState
     // A tracked index only means something while the candidate list still holds the same word at
     // it. The list is rebuilt on every keystroke, so an index kept across one is not the candidate
     // the user was looking at.
-    std::optional<size_t> live_selected_index(const InputSession &session) const
+    std::optional<size_t> live_selected_index(const SessionSnapshot &snapshot) const
     {
         if (!selected_candidate_.has_value())
         {
             return std::nullopt;
         }
-        const auto &candidates = session.candidates();
+        const auto &candidates = snapshot.candidates;
         if (selected_candidate_->index < candidates.size()
             && candidates[selected_candidate_->index].word == selected_candidate_->word)
         {
@@ -58,20 +58,20 @@ class CandidateSelectionState
         return std::nullopt;
     }
 
-    KeyResult commit(InputSession &session) const
+    KeyResult commit(Session &session) const
     {
-        if (const auto index = live_selected_index(session))
+        if (const auto index = live_selected_index(session.snapshot()))
         {
-            const KeyResult selected = session.select_candidate(*index);
+            const KeyResult selected = session.select(*index);
             if (selected.handled)
             {
                 return selected;
             }
         }
-        return session.handle_command(Command::CommitCandidate);
+        return session.command(Command::CommitCandidate);
     }
 
-    KeyResult commit_number(InputSession &session, char character, size_t pageSize = candidates_per_page) const
+    KeyResult commit_number(Session &session, char character, size_t pageSize = candidates_per_page) const
     {
         if (character < '1' || character > '9')
         {
@@ -85,15 +85,16 @@ class CandidateSelectionState
             return {};
         }
 
-        const auto &candidates = session.candidates();
+        const auto snapshot = session.snapshot();
+        const auto &candidates = snapshot.candidates;
         if (!selected_candidate_.has_value() || selected_candidate_->index >= candidates.size()
             || candidates[selected_candidate_->index].word != selected_candidate_->word)
         {
-            return session.handle_candidate_key(character);
+            return session.candidate_key(character);
         }
 
         const size_t pageStart = selected_candidate_->index / pageSize * pageSize;
-        return session.select_candidate(pageStart + candidateOffset);
+        return session.select(pageStart + candidateOffset);
     }
 
   private:

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -22,7 +22,7 @@
 #include "StringConversion.h"
 #include "CandidateSelectionState.h"
 #include "InputControllerKeyRouting.h"
-#include "core/input_session.h"
+#include <metasequoia/session.h>
 
 #import <Carbon/Carbon.h>
 
@@ -72,21 +72,21 @@ SessionPreferences ReadSessionPreferences()
     };
 }
 
-// helpcode_enabled() reports false for every scheme that has no helpcodes, so comparing it directly can never match a Wubi session built with the preference on, and the caller would rebuild the engine on every keystroke. Only the schemes that carry helpcodes can be compared on it.
+// Helpcode preferences only affect pinyin schemes; changing that preference must not rebuild a Wubi session.
 bool SchemeUsesHelpcodes(SchemeType scheme)
 {
     return scheme == SchemeType::Quanpin || scheme == SchemeType::Shuangpin;
 }
 
-bool SessionMatchesPreferences(const metasequoia::InputSession &session, const SessionPreferences &preferences)
+bool SessionMatchesPreferences(const metasequoia::SessionOptions &options, const SessionPreferences &preferences)
 {
     const bool helpcodeMatches = !SchemeUsesHelpcodes(preferences.scheme) ||
-                                 session.helpcode_enabled() == preferences.helpcodeEnabled;
-    return session.scheme_type() == preferences.scheme &&
-           session.quanpin_autocorrect_enabled() == preferences.autocorrectEnabled &&
+                                 options.helpcode == preferences.helpcodeEnabled;
+    return options.scheme == preferences.scheme &&
+           options.autocorrect == preferences.autocorrectEnabled &&
            helpcodeMatches &&
-           session.chinese_punctuation_enabled() == preferences.chinesePunctuationEnabled &&
-           session.candidate_learning_enabled() == preferences.candidateLearningEnabled;
+           options.chinese_punctuation == preferences.chinesePunctuationEnabled &&
+           options.learning == preferences.candidateLearningEnabled;
 }
 } // namespace
 
@@ -95,7 +95,9 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 
 @implementation MetasequoiaInputController
 {
-    std::unique_ptr<metasequoia::InputSession> _session;
+    std::unique_ptr<metasequoia::Session> _session;
+    metasequoia::SessionOptions _sessionOptions;
+    metasequoia::SessionSnapshot _sessionSnapshot;
     std::string _activeHelpcodeSchema;
     HelpcodeUtils::SharedKeymap _activeHelpcodeKeymap;
     metasequoia::mac::CandidateSelectionState _candidateSelection;
@@ -185,7 +187,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 {
     [self refreshFloatingToolbar];
     if ([notification.name isEqualToString:MetasequoiaTraditionalChineseOutputDidChangeNotification] &&
-        _serverActive && _session != nullptr && _session->has_composition())
+        _serverActive && _session != nullptr && !_sessionSnapshot.preedit.empty())
     {
         [self refreshCandidatePanelPreservingSelection];
     }
@@ -216,7 +218,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     {
         [_shuangpinKeymapPanel orderOut:nil];
     }
-    if (_session != nullptr && _session->has_composition())
+    if (_session != nullptr && !_sessionSnapshot.preedit.empty())
     {
         // Keep the scheme chosen when this composition began. Preferences from another
         // controller must not change the helpcodes of this live session.
@@ -231,22 +233,26 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     _wubiAutoCommitUniqueEnabled = preferences.wubiAutoCommitUniqueEnabled;
     const bool helpcodeSchemaMatches = _activeHelpcodeSchema == preferences.helpcodeSchema;
     _activeHelpcodeSchema = preferences.helpcodeSchema;
-    // Applied above the early return, like every other preference a live session can take. It used
-    // to be applied only to a freshly constructed session, and SessionMatchesPreferences does not
-    // compare it, so toggling 启用本地输入模式 changed nothing until something unrelated forced a
-    // rebuild. set_local_mode_options is a plain setter and is safe on a running session.
-    [self applyLocalInputModeOptions];
-    if (_session != nullptr && helpcodeSchemaMatches && SessionMatchesPreferences(*_session, preferences))
+    _localInputModesEnabled = [MetasequoiaPreferencesWindowController storedLocalInputModesEnabled];
+    if (_session != nullptr && helpcodeSchemaMatches && SessionMatchesPreferences(_sessionOptions, preferences) &&
+        _sessionOptions.local_modes.unicode == _localInputModesEnabled)
     {
         return;
     }
     const auto paths = metasequoia::RuntimePaths::legacy();
-    _session = std::make_unique<metasequoia::InputSession>(
-        preferences.scheme, preferences.autocorrectEnabled, preferences.helpcodeEnabled,
-        preferences.chinesePunctuationEnabled, preferences.candidateLearningEnabled, paths);
-    _session->set_helpcode_schema(preferences.helpcodeSchema);
+    metasequoia::SessionOptions options;
+    options.paths = paths;
+    options.scheme = preferences.scheme;
+    options.autocorrect = preferences.autocorrectEnabled;
+    options.helpcode = preferences.helpcodeEnabled;
+    options.helpcode_schema = preferences.helpcodeSchema;
+    options.chinese_punctuation = preferences.chinesePunctuationEnabled;
+    options.learning = preferences.candidateLearningEnabled;
+    options.local_modes = [self localInputModeOptions];
+    _session = std::make_unique<metasequoia::Session>(options);
+    _sessionOptions = options;
+    _sessionSnapshot = _session->snapshot();
     _activeHelpcodeKeymap = HelpcodeUtils::load_helpcode_keymap(paths.resources, preferences.helpcodeSchema);
-    [self applyLocalInputModeOptions];
     _candidateSelection.reset();
     _candidateHighlightedIndex = 0;
     _candidatePageStart = 0;
@@ -264,14 +270,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 // four need nothing beyond what is here: Unicode parses its own input, date and time has a built-in
 // provider, quick phrases live in msime.db's quick_parases table, and super jianpin uses the pinyin
 // tables. Turning the whole family off by preference keeps Shift+letter inserting a capital.
-- (void)applyLocalInputModeOptions
+- (metasequoia::LocalModeOptions)localInputModeOptions
 {
-    if (_session == nullptr)
-    {
-        return;
-    }
-
-    _localInputModesEnabled = [MetasequoiaPreferencesWindowController storedLocalInputModesEnabled];
     metasequoia::LocalModeOptions options;
     options.unicode = _localInputModesEnabled;
     options.date_time = _localInputModesEnabled;
@@ -281,7 +281,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     options.kaomoji = false;
     options.temporary_english = false;
     options.temporary_japanese = false;
-    _session->set_local_mode_options(options);
+    return options;
 }
 
 - (BOOL)prepareSessionIfNeeded
@@ -329,12 +329,12 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 
 - (void)trackCandidateAtIndex:(NSUInteger)index
 {
-    if (_session == nullptr || index >= _candidateData.count || index >= _session->candidates().size())
+    if (_session == nullptr || index >= _candidateData.count || index >= _sessionSnapshot.candidates.size())
     {
         return;
     }
 
-    _candidateSelection.update(static_cast<size_t>(index), _session->candidates()[index].word);
+    _candidateSelection.update(static_cast<size_t>(index), _sessionSnapshot.candidates[index].word);
     _candidateHighlightedIndex = index;
     _candidatePageStart = metasequoia::mac::CandidatePageStart(
         index, _candidateData.count, _candidatePageSize);
@@ -493,7 +493,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 
     // Captured before the key is dispatched: a commit clears the local mode, and applyResult still
     // needs to know which one produced the text it is inserting.
-    const metasequoia::LocalInputMode localModeForKey = _session->local_input_mode();
+    const metasequoia::LocalInputMode localModeForKey = _sessionSnapshot.local_mode;
     metasequoia::KeyResult result;
     const BOOL candidatePageShortcutModified =
         (modifiers & (NSEventModifierFlagShift | NSEventModifierFlagCommand | NSEventModifierFlagControl |
@@ -549,13 +549,13 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
                            pageStart:_candidatePageStart];
         return YES;
     case metasequoia::mac::ControllerKeyAction::Backspace:
-        result = _session->handle_command(metasequoia::Command::Backspace);
+        result = _session->command(metasequoia::Command::Backspace);
         break;
     case metasequoia::mac::ControllerKeyAction::CommitRaw:
-        result = _session->handle_command(metasequoia::Command::CommitRaw);
+        result = _session->command(metasequoia::Command::CommitRaw);
         break;
     case metasequoia::mac::ControllerKeyAction::Cancel:
-        result = _session->handle_command(metasequoia::Command::Cancel);
+        result = _session->command(metasequoia::Command::Cancel);
         break;
     case metasequoia::mac::ControllerKeyAction::CommitCandidate:
         result = _candidateSelection.commit(*_session);
@@ -577,29 +577,29 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
             // composition, and a capital that is not one of the triggers still comes back unhandled
             // so the application inserts it.
             else if (_localInputModesEnabled && character >= 'A' && character <= 'Z' &&
-                     !_session->has_composition() && (modifiers & NSEventModifierFlagShift) != 0 &&
+                     _sessionSnapshot.preedit.empty() && (modifiers & NSEventModifierFlagShift) != 0 &&
                      (modifiers & ~NSEventModifierFlagShift) == 0)
             {
-                result = _session->handle_character(static_cast<char>(character), true);
+                result = _session->character(static_cast<char>(character), true);
             }
-            else if (character == '\'' && _session->has_composition())
+            else if (character == '\'' && !_sessionSnapshot.preedit.empty())
             {
-                result = _session->handle_character(static_cast<char>(character));
+                result = _session->character(static_cast<char>(character));
             }
             // Unicode mode reads a hex code point, so while it is open its digits and its optional
             // "+" are input rather than candidate numbers. Every other local mode takes letters
             // only and leaves the digits to selection, which is what they already did.
             else if ((character >= '0' && character <= '9') || character == '+')
             {
-                if (_session->local_input_mode() == metasequoia::LocalInputMode::Unicode)
+                if (_sessionSnapshot.local_mode == metasequoia::LocalInputMode::Unicode)
                 {
-                    result = _session->handle_character(static_cast<char>(character));
+                    result = _session->character(static_cast<char>(character));
                 }
                 else if (character >= '1' && character <= '9')
                 {
                     result = _candidateSelection.commit_number(
                         *_session, static_cast<char>(character), _candidatePageSize);
-                    if (!result.handled && _session->has_composition())
+                    if (!result.handled && !_sessionSnapshot.preedit.empty())
                     {
                         return YES;
                     }
@@ -616,7 +616,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
                      character == '<' || character == '>' || character == '\\' ||
                      character == '`' || character == '$' || character == '^' || character == '_')
             {
-                result = _session->handle_punctuation(static_cast<char>(character));
+                result = _session->punctuation(static_cast<char>(character));
             }
         }
         break;
@@ -625,8 +625,9 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 
     if (!result.handled)
     {
+        _sessionSnapshot = _session->snapshot();
         [self commitLeadingCandidate:sender];
-        if (_session != nullptr && !_session->has_composition() &&
+        if (_session != nullptr && _sessionSnapshot.preedit.empty() &&
             [MetasequoiaPreferencesWindowController storedFullWidthInputEnabled] && event.characters.length == 1)
         {
             const unichar character = [event.characters characterAtIndex:0];
@@ -647,7 +648,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 - (void)commitLeadingCandidate:(id)sender
 {
     [self cancelVoiceInput];
-    if (_session == nullptr || !_session->has_composition())
+    if (_session == nullptr || _sessionSnapshot.preedit.empty())
     {
         return;
     }
@@ -657,9 +658,9 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
     // arrowed onto — type shi, press Down to highlight 时, click into another application, and 是
     // was committed. The rest of the composition still finishes from the engine's first candidate,
     // which is what the default argument means and what this path already did.
-    const metasequoia::LocalInputMode localMode = _session->local_input_mode();
+    const metasequoia::LocalInputMode localMode = _sessionSnapshot.local_mode;
     const auto result =
-        _session->finish_composition(_candidateSelection.live_selected_index(*_session).value_or(0));
+        _session->finish(_candidateSelection.live_selected_index(_sessionSnapshot).value_or(0));
     if (result.handled)
     {
         [self applyResult:result localMode:localMode client:sender];
@@ -669,7 +670,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 // Single source of truth for the traditional-output predicate so the candidate panel and the committed text can never disagree about which script the user sees.
 - (BOOL)traditionalChineseOutputActive
 {
-    return _session != nullptr && _session->scheme_type() != SchemeType::JapaneseRomaji &&
+    return _session != nullptr && _sessionSnapshot.scheme != SchemeType::JapaneseRomaji &&
            [MetasequoiaPreferencesWindowController storedTraditionalChineseOutputEnabled];
 }
 
@@ -693,6 +694,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
           localMode:(metasequoia::LocalInputMode)localMode
              client:(id)sender
 {
+    _sessionSnapshot = _session->snapshot();
     id<IMKTextInput> client = sender;
     const NSRange replacementRange = NSMakeRange(NSNotFound, NSNotFound);
     if (result.commit.has_value())
@@ -703,7 +705,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
                                                            traditionalOutput);
         [client insertText:commit replacementRange:replacementRange];
         _candidateSelection.reset();
-        if (!_session->has_composition())
+        if (_sessionSnapshot.preedit.empty())
         {
             [_candidatePanel hide];
             [_shuangpinKeymapPanel orderOut:nil];
@@ -711,7 +713,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         }
     }
 
-    NSString *preedit = MetasequoiaStringFromUtf8(_session->preedit());
+    NSString *preedit = MetasequoiaStringFromUtf8(_sessionSnapshot.preedit);
     [client setMarkedText:preedit selectionRange:NSMakeRange(preedit.length, 0) replacementRange:replacementRange];
     [self updateCandidatePanel];
     [self updateShuangpinKeymapPanelForClient:client];
@@ -719,8 +721,8 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 
 - (void)updateShuangpinKeymapPanelForClient:(id<IMKTextInput>)client
 {
-    const BOOL hasComposition = _session != nullptr && _session->has_composition();
-    const BOOL isShuangpin = _session != nullptr && _session->scheme_type() == SchemeType::Shuangpin;
+    const BOOL hasComposition = _session != nullptr && !_sessionSnapshot.preedit.empty();
+    const BOOL isShuangpin = _session != nullptr && _sessionSnapshot.scheme == SchemeType::Shuangpin;
     if (!MetasequoiaShouldShowShuangpinKeymap(isShuangpin, _shuangpinKeymapEnabled, hasComposition) ||
         client == nil)
     {
@@ -738,7 +740,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         return;
     }
 
-    NSString *preedit = MetasequoiaStringFromUtf8(_session->preedit());
+    NSString *preedit = MetasequoiaStringFromUtf8(_sessionSnapshot.preedit);
     NSString *highlightedKey = @"";
     if (preedit.length > 0)
     {
@@ -775,6 +777,7 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 
 - (void)rebuildCandidatePanelPreservingSelection:(BOOL)preserveSelection
 {
+    _sessionSnapshot = _session->snapshot();
     const std::optional<size_t> preservedSelection =
         preserveSelection ? _candidateSelection.selected_index() : std::nullopt;
     if (!preserveSelection)
@@ -784,23 +787,23 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
         _candidatePageStart = 0;
     }
     _candidateLineIdentifiersCollapsed = NO;
-    NSMutableArray *data = [NSMutableArray arrayWithCapacity:_session->candidates().size()];
-    const metasequoia::LocalInputMode localMode = _session->local_input_mode();
+    NSMutableArray *data = [NSMutableArray arrayWithCapacity:_sessionSnapshot.candidates.size()];
+    const metasequoia::LocalInputMode localMode = _sessionSnapshot.local_mode;
     const BOOL traditionalOutput = [self traditionalChineseOutputActive] &&
                                    metasequoia::mac::ScriptConversionAppliesToLocalMode(localMode);
     const bool annotateHelpcodes =
-        _session->helpcode_enabled() && metasequoia::mac::HelpcodesAnnotateLocalMode(localMode);
+        (_sessionOptions.helpcode && SchemeUsesHelpcodes(_sessionSnapshot.scheme)) && metasequoia::mac::HelpcodesAnnotateLocalMode(localMode);
     NSUInteger candidateIndex = 0;
-    for (const WordItem &candidate : _session->candidates())
+    for (const WordItem &candidate : _sessionSnapshot.candidates)
     {
         NSString *display = MetasequoiaStringFromUtf8(metasequoia::mac::CandidateDisplayText(
-            candidate, _session->scheme_type(), annotateHelpcodes, _activeHelpcodeKeymap.get()));
+            candidate, _sessionSnapshot.scheme, annotateHelpcodes, _activeHelpcodeKeymap.get()));
         NSString *convertedDisplay = MetasequoiaChineseOutputString(display, traditionalOutput);
         [data addObject:MetasequoiaIndexedCandidateString(convertedDisplay, candidateIndex)];
         ++candidateIndex;
     }
     _candidateData = [data copy];
-    if (_session->has_composition() && _candidateData.count > 0)
+    if (!_sessionSnapshot.preedit.empty() && _candidateData.count > 0)
     {
         const NSUInteger selectedIndex = preservedSelection.has_value() && preservedSelection.value() < _candidateData.count
                                              ? preservedSelection.value() : 0;
@@ -888,12 +891,12 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
             index = _candidatePageStart + static_cast<NSUInteger>(selectedLine);
         }
     }
-    if (index == NSNotFound || index >= _session->candidates().size())
+    if (index == NSNotFound || index >= _sessionSnapshot.candidates.size())
     {
         return;
     }
-    const metasequoia::LocalInputMode localMode = _session->local_input_mode();
-    const auto result = _session->select_candidate(static_cast<size_t>(index));
+    const metasequoia::LocalInputMode localMode = _sessionSnapshot.local_mode;
+    const auto result = _session->select(static_cast<size_t>(index));
     if (result.handled)
     {
         [self applyResult:result localMode:localMode client:self.client];
@@ -903,13 +906,13 @@ bool SessionMatchesPreferences(const metasequoia::InputSession &session, const S
 - (id)composedString:(id)sender
 {
     (void)sender;
-    return _session == nullptr ? @"" : MetasequoiaStringFromUtf8(_session->preedit());
+    return _session == nullptr ? @"" : MetasequoiaStringFromUtf8(_sessionSnapshot.preedit);
 }
 
 - (NSAttributedString *)originalString:(id)sender
 {
     (void)sender;
-    NSString *raw = _session == nullptr ? @"" : MetasequoiaStringFromUtf8(_session->preedit());
+    NSString *raw = _session == nullptr ? @"" : MetasequoiaStringFromUtf8(_sessionSnapshot.preedit);
     return [[NSAttributedString alloc] initWithString:raw];
 }
 

--- a/platforms/macos/src/WubiCommitPolicy.h
+++ b/platforms/macos/src/WubiCommitPolicy.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "core/input_session.h"
+#include <metasequoia/session.h>
 
 #include <cstddef>
 
@@ -12,14 +12,15 @@ inline bool ShouldAutoCommitUniqueWubiCandidate(bool enabled, SchemeType scheme,
     return enabled && scheme == SchemeType::Wubi && codeLength == 4 && candidateCount == 1;
 }
 
-inline KeyResult HandleCharacterWithWubiAutoCommit(InputSession &session, char character, bool enabled)
+inline KeyResult HandleCharacterWithWubiAutoCommit(Session &session, char character, bool enabled)
 {
-    KeyResult result = session.handle_character(character);
+    KeyResult result = session.character(character);
+    const auto snapshot = session.snapshot();
     if (result.handled &&
-        ShouldAutoCommitUniqueWubiCandidate(enabled, session.scheme_type(), session.preedit().size(),
-                                            session.candidates().size()))
+        ShouldAutoCommitUniqueWubiCandidate(enabled, snapshot.scheme, snapshot.preedit.size(),
+                                            snapshot.candidates.size()))
     {
-        result = session.handle_command(Command::CommitCandidate);
+        result = session.command(Command::CommitCandidate);
     }
     return result;
 }

--- a/platforms/macos/tests/CandidatePaginationTests.mm
+++ b/platforms/macos/tests/CandidatePaginationTests.mm
@@ -1,3 +1,4 @@
+#include "PublicSessionTestOptions.h"
 // Exercise the real controller with a recording window boundary. A headless
 // IMKCandidates cannot render without a registered input-method client.
 #include "../src/MetasequoiaInputController.mm"
@@ -79,9 +80,9 @@ static void Require(bool condition, const char *message)
 - (void)prepareTestPanel:(RecordingCandidatePanel *)panel
 {
     _candidatePanel = (MetasequoiaCandidatePanel *)panel;
-    _session = std::make_unique<metasequoia::InputSession>();
+    _session.reset();
     [self reloadSessionFromPreferences];
-    for (char character : std::string("nihao")) _session->handle_character(character);
+    for (char character : std::string("nihao")) _session->character(character);
     [self updateCandidatePanel];
 }
 // Leaves the session empty so a test can drive every keystroke through handleEvent:client: instead
@@ -92,26 +93,29 @@ static void Require(bool condition, const char *message)
     _session.reset();
     [self reloadSessionFromPreferences];
 }
-- (BOOL)testHasComposition { return _session != nullptr && _session->has_composition(); }
+- (BOOL)testHasComposition { return _session != nullptr && (!_session->snapshot().preedit.empty()); }
 - (void)prepareHelpcodeProbe
 {
-    for (char character : std::string("niA")) _session->handle_character(character);
+    for (char character : std::string("niA")) _session->character(character);
+    _sessionSnapshot = _session->snapshot();
 }
 - (void)refreshHelpcodeProbe
 {
     [self reloadSessionFromPreferences];
-    _session->handle_command(metasequoia::Command::Backspace);
-    _session->handle_character('A');
+    _session->command(metasequoia::Command::Backspace);
+    _session->character('A');
+    _sessionSnapshot = _session->snapshot();
 }
 - (void)preparePartialInput
 {
-    _session = std::make_unique<metasequoia::InputSession>(SchemeType::Quanpin, true, false, true, false);
-    for (char character : std::string("shui'lin")) _session->handle_character(character);
+    _sessionOptions = SessionTestOptions(SchemeType::Quanpin, false, false);
+    _session = std::make_unique<metasequoia::Session>(_sessionOptions);
+    for (char character : std::string("shui'lin")) _session->character(character);
     [self updateCandidatePanel];
 }
-- (NSUInteger)testCandidateCount { return _session->candidates().size(); }
+- (NSUInteger)testCandidateCount { return _session->snapshot().candidates.size(); }
 - (NSString *)testCandidateAtIndex:(NSUInteger)index
-{ return MetasequoiaStringFromUtf8(_session->candidates()[index].word); }
+{ return MetasequoiaStringFromUtf8(_session->snapshot().candidates[index].word); }
 @end
 
 @interface PaginationTestController : MetasequoiaInputController

--- a/platforms/macos/tests/CandidateSelectionStateTests.cpp
+++ b/platforms/macos/tests/CandidateSelectionStateTests.cpp
@@ -1,3 +1,4 @@
+#include "PublicSessionTestOptions.h"
 #include "../src/CandidateSelectionState.h"
 #include "../../../vendor/MetasequoiaImeEngine/core/data_path.h"
 #include "../../../vendor/MetasequoiaImeEngine/user_dictionary/user_dictionary_journal.h"
@@ -37,9 +38,9 @@ private:
   sqlite3 *database_ = nullptr;
 };
 
-void type(metasequoia::InputSession &session, const std::string &text) {
+void type(metasequoia::Session &session, const std::string &text) {
   for (const char character : text) {
-    if (!session.handle_character(character).handled) {
+    if (!session.character(character).handled) {
       throw std::runtime_error("A pinyin character was not handled.");
     }
   }
@@ -54,19 +55,19 @@ void require(bool condition, const char *message) {
 void run_tests() {
   metasequoia::mac::CandidateSelectionState candidate_selection;
 
-  metasequoia::InputSession unarmed_session;
+  metasequoia::Session unarmed_session(SessionTestOptions());
   type(unarmed_session, "nihao");
   const std::string leading_candidate =
-      unarmed_session.candidates().front().word;
-  candidate_selection.update(1, unarmed_session.candidates()[1].word);
+      unarmed_session.snapshot().candidates.front().word;
+  candidate_selection.update(1, unarmed_session.snapshot().candidates[1].word);
   const auto unarmed = candidate_selection.commit(unarmed_session);
   require(unarmed.handled && unarmed.commit == leading_candidate,
           "An unsolicited panel callback replaced the leading candidate.");
 
-  metasequoia::InputSession highlighted_session;
+  metasequoia::Session highlighted_session(SessionTestOptions());
   type(highlighted_session, "nihao");
   const std::string highlighted_candidate =
-      highlighted_session.candidates()[1].word;
+      highlighted_session.snapshot().candidates[1].word;
   candidate_selection.begin_navigation();
   candidate_selection.update(1, highlighted_candidate);
   require(candidate_selection.selected_index() == 1,
@@ -76,12 +77,12 @@ void run_tests() {
       highlighted.handled && highlighted.commit == highlighted_candidate,
       "Space did not commit the candidate highlighted by the native panel.");
 
-  metasequoia::InputSession reset_session;
+  metasequoia::Session reset_session(SessionTestOptions());
   type(reset_session, "nihao");
   const std::string reset_leading_candidate =
-      reset_session.candidates().front().word;
+      reset_session.snapshot().candidates.front().word;
   candidate_selection.begin_navigation();
-  candidate_selection.update(1, reset_session.candidates()[1].word);
+  candidate_selection.update(1, reset_session.snapshot().candidates[1].word);
   candidate_selection.reset();
   require(!candidate_selection.selected_index().has_value(),
           "Reset retained a stale engine index.");
@@ -90,9 +91,9 @@ void run_tests() {
       reset.handled && reset.commit == reset_leading_candidate,
       "Clearing the native highlight did not restore the leading candidate.");
 
-  metasequoia::InputSession stale_session;
+  metasequoia::Session stale_session(SessionTestOptions());
   type(stale_session, "nihao");
-  const std::string stale_fallback = stale_session.candidates().front().word;
+  const std::string stale_fallback = stale_session.snapshot().candidates.front().word;
   candidate_selection.begin_navigation();
   candidate_selection.update(1, "candidate-from-an-old-composition");
   const auto stale = candidate_selection.commit(stale_session);
@@ -103,55 +104,55 @@ void run_tests() {
   // Every automatic commit — losing focus, a modifier, a key the session does not take — finishes
   // the composition, and it has to finish it from the candidate the user arrowed onto rather than
   // from the engine's own first one.
-  metasequoia::InputSession flush_session;
+  metasequoia::Session flush_session(SessionTestOptions());
   type(flush_session, "nihao");
-  const std::string flush_highlighted = flush_session.candidates()[1].word;
+  const std::string flush_highlighted = flush_session.snapshot().candidates[1].word;
   candidate_selection.begin_navigation();
   candidate_selection.update(1, flush_highlighted);
-  require(candidate_selection.live_selected_index(flush_session) == 1,
+  require(candidate_selection.live_selected_index(flush_session.snapshot()) == 1,
           "A live highlight was not offered to the automatic commit.");
-  const auto flushed = flush_session.finish_composition(
-      candidate_selection.live_selected_index(flush_session).value_or(0));
+  const auto flushed = flush_session.finish(
+      candidate_selection.live_selected_index(flush_session.snapshot()).value_or(0));
   require(flushed.handled && flushed.commit == flush_highlighted,
           "An automatic commit discarded the highlighted candidate.");
 
   // With nothing highlighted, and with a highlight that no longer names the same word, the index
   // has to come back empty so the automatic commit keeps its previous behaviour.
-  metasequoia::InputSession flush_default_session;
+  metasequoia::Session flush_default_session(SessionTestOptions());
   type(flush_default_session, "nihao");
   const std::string flush_default_leading =
-      flush_default_session.candidates().front().word;
+      flush_default_session.snapshot().candidates.front().word;
   candidate_selection.reset();
-  require(!candidate_selection.live_selected_index(flush_default_session).has_value(),
+  require(!candidate_selection.live_selected_index(flush_default_session.snapshot()).has_value(),
           "A cleared highlight still offered an index to the automatic commit.");
   candidate_selection.begin_navigation();
   candidate_selection.update(1, "candidate-from-an-old-composition");
-  require(!candidate_selection.live_selected_index(flush_default_session).has_value(),
+  require(!candidate_selection.live_selected_index(flush_default_session.snapshot()).has_value(),
           "A stale highlight still offered an index to the automatic commit.");
-  const auto flushed_default = flush_default_session.finish_composition(
-      candidate_selection.live_selected_index(flush_default_session).value_or(0));
+  const auto flushed_default = flush_default_session.finish(
+      candidate_selection.live_selected_index(flush_default_session.snapshot()).value_or(0));
   require(flushed_default.handled && flushed_default.commit == flush_default_leading,
           "An automatic commit without a highlight did not take the leading candidate.");
 
-  metasequoia::InputSession paged_session;
+  metasequoia::Session paged_session(SessionTestOptions());
   type(paged_session, "nihao");
-  require(paged_session.candidates().size() >= 11,
+  require(paged_session.snapshot().candidates.size() >= 11,
           "The paging fixture did not return enough candidates.");
-  const std::string second_page_candidate = paged_session.candidates()[9].word;
+  const std::string second_page_candidate = paged_session.snapshot().candidates[9].word;
   candidate_selection.begin_navigation();
   candidate_selection.update(9, second_page_candidate);
   const auto unavailable_digit =
       candidate_selection.commit_number(paged_session, '9');
-  require(!unavailable_digit.handled && paged_session.has_composition(),
+  require(!unavailable_digit.handled && (!paged_session.snapshot().preedit.empty()),
           "An unavailable number on the current page changed composition.");
   const auto page_digit = candidate_selection.commit_number(paged_session, '1');
   require(page_digit.handled && page_digit.commit == second_page_candidate,
           "The 1 key did not commit the first candidate on the visible page.");
 
-  metasequoia::InputSession compact_page_session;
+  metasequoia::Session compact_page_session(SessionTestOptions());
   type(compact_page_session, "nihao");
   const std::string compact_page_candidate =
-      compact_page_session.candidates()[5].word;
+      compact_page_session.snapshot().candidates[5].word;
   candidate_selection.begin_navigation();
   candidate_selection.update(5, compact_page_candidate);
   const auto compact_page_digit =

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -1,3 +1,4 @@
+#include "PublicSessionTestOptions.h"
 #include "../src/InputControllerKeyRouting.h"
 #include "../src/CandidatePanelStyle.h"
 #include "../src/CandidatePageSize.h"
@@ -166,7 +167,7 @@ int main()
                          "('aaaa', '候选二', 90)");
     }
     {
-        metasequoia::InputSession enabledSession(SchemeType::Wubi, true, true, true, false);
+        metasequoia::Session enabledSession(SessionTestOptions(SchemeType::Wubi, true, false));
         for (const char character : std::string("abc"))
         {
             const auto result = metasequoia::mac::HandleCharacterWithWubiAutoCommit(enabledSession, character, true);
@@ -174,27 +175,27 @@ int main()
                     "Wubi auto-commit fired before the fourth code.");
         }
         const auto uniqueResult = metasequoia::mac::HandleCharacterWithWubiAutoCommit(enabledSession, 'd', true);
-        require(uniqueResult.handled && uniqueResult.commit == "唯一候选" && !enabledSession.has_composition(),
+        require(uniqueResult.handled && uniqueResult.commit == "唯一候选" && !(!enabledSession.snapshot().preedit.empty()),
                 "The fourth Wubi code did not commit its unique refreshed candidate.");
 
-        metasequoia::InputSession disabledSession(SchemeType::Wubi, true, true, true, false);
+        metasequoia::Session disabledSession(SessionTestOptions(SchemeType::Wubi, true, false));
         for (const char character : std::string("abcd"))
         {
             const auto result = metasequoia::mac::HandleCharacterWithWubiAutoCommit(disabledSession, character, false);
             require(result.handled && !result.commit.has_value(),
                     "Disabled Wubi auto-commit unexpectedly committed a candidate.");
         }
-        require(disabledSession.preedit() == "abcd",
+        require(disabledSession.snapshot().preedit == "abcd",
                 "Disabled Wubi auto-commit did not preserve the four-code composition.");
 
-        metasequoia::InputSession multipleSession(SchemeType::Wubi, true, true, true, false);
+        metasequoia::Session multipleSession(SessionTestOptions(SchemeType::Wubi, true, false));
         for (const char character : std::string("aaaa"))
         {
             const auto result = metasequoia::mac::HandleCharacterWithWubiAutoCommit(multipleSession, character, true);
             require(result.handled && !result.commit.has_value(),
                     "Wubi auto-commit committed a code with multiple candidates.");
         }
-        require(multipleSession.preedit() == "aaaa" && multipleSession.candidates().size() == 2,
+        require(multipleSession.snapshot().preedit == "aaaa" && multipleSession.snapshot().candidates.size() == 2,
                 "The multiple-candidate Wubi fixture did not remain available for selection.");
     }
     std::filesystem::remove_all(dictionaryDirectory);

--- a/platforms/macos/tests/LocalInputModeTests.cpp
+++ b/platforms/macos/tests/LocalInputModeTests.cpp
@@ -1,8 +1,9 @@
+#include "PublicSessionTestOptions.h"
 // The controller only forwards a capital to the session when nothing is being composed and Shift is
 // the only modifier. These tests pin the engine side of that arrangement: which capitals open a
 // mode, that the rest stay unhandled so the application still inserts them, and that a disabled
 // mode gives its trigger letter back.
-#include "core/input_session.h"
+#include <metasequoia/session.h>
 
 #include <chrono>
 #include <cstdio>
@@ -44,68 +45,72 @@ int RunTest() {
   }
 
   {
-    metasequoia::InputSession session;
-    session.set_local_mode_options(AppleOptions(true));
+    auto options = SessionTestOptions();
+    options.local_modes = AppleOptions(true);
+    metasequoia::Session session(options);
 
-    const auto unicode = session.handle_character('U', true);
-    Require(unicode.handled && session.preedit() == "U",
+    const auto unicode = session.character('U', true);
+    Require(unicode.handled && session.snapshot().preedit == "U",
             "Shift+U did not open the Unicode mode.");
-    Require(session.local_input_mode() == metasequoia::LocalInputMode::Unicode,
+    Require(session.snapshot().local_mode == metasequoia::LocalInputMode::Unicode,
             "Shift+U did not report the Unicode mode.");
 
     // The code point is hexadecimal, so the mode has to take digits as input. The controller routes
     // them here only while this mode is open; every other mode leaves digits to candidate numbers.
-    Require(session.handle_character('4').handled && session.preedit() == "U4",
+    Require(session.character('4').handled && session.snapshot().preedit == "U4",
             "The Unicode mode rejected a hexadecimal digit.");
-    Require(session.handle_command(metasequoia::Command::Cancel).handled,
+    Require(session.command(metasequoia::Command::Cancel).handled,
             "Cancel did not close the Unicode mode.");
-    Require(session.local_input_mode() == metasequoia::LocalInputMode::None,
+    Require(session.snapshot().local_mode == metasequoia::LocalInputMode::None,
             "Cancel left a local mode open.");
   }
 
   {
-    metasequoia::InputSession session;
-    session.set_local_mode_options(AppleOptions(true));
+    auto options = SessionTestOptions();
+    options.local_modes = AppleOptions(true);
+    metasequoia::Session session(options);
 
     // A capital that opens nothing has to come back unhandled, or the keyboard would swallow it
     // instead of letting the application insert it.
-    const auto passthrough = session.handle_character('Z', true);
+    const auto passthrough = session.character('Z', true);
     Require(!passthrough.handled,
             "A capital that opens no mode was swallowed by the session.");
-    Require(session.local_input_mode() == metasequoia::LocalInputMode::None,
+    Require(session.snapshot().local_mode == metasequoia::LocalInputMode::None,
             "A capital that opens no mode still changed the local mode.");
 
     // The four modes whose data this bundle does not ship must not open at all.
     for (const char trigger : {'E', 'M', 'Y', 'R'}) {
-      const auto result = session.handle_character(trigger, true);
+      const auto result = session.character(trigger, true);
       Require(!result.handled,
               "A local mode without packaged data was opened by its trigger.");
-      Require(session.local_input_mode() == metasequoia::LocalInputMode::None,
+      Require(session.snapshot().local_mode == metasequoia::LocalInputMode::None,
               "A local mode without packaged data reported itself as open.");
     }
   }
 
   {
-    metasequoia::InputSession session;
-    session.set_local_mode_options(AppleOptions(false));
+    auto options = SessionTestOptions();
+    options.local_modes = AppleOptions(false);
+    metasequoia::Session session(options);
 
     // With the preference off the trigger is an ordinary capital again.
-    const auto disabled = session.handle_character('U', true);
+    const auto disabled = session.character('U', true);
     Require(!disabled.handled,
             "Shift+U opened the Unicode mode while local modes were disabled.");
-    Require(session.local_input_mode() == metasequoia::LocalInputMode::None,
+    Require(session.snapshot().local_mode == metasequoia::LocalInputMode::None,
             "A disabled local mode still opened.");
   }
 
   {
-    metasequoia::InputSession session;
-    session.set_local_mode_options(AppleOptions(true));
+    auto options = SessionTestOptions();
+    options.local_modes = AppleOptions(true);
+    metasequoia::Session session(options);
 
     // The engine guards every trigger on there being no composition, which is the same condition
     // the controller checks before forwarding a capital at all.
-    Require(session.handle_character('n').handled, "The guard fixture did not start a composition.");
-    const auto duringComposition = session.handle_character('U', true);
-    Require(session.local_input_mode() == metasequoia::LocalInputMode::None,
+    Require(session.character('n').handled, "The guard fixture did not start a composition.");
+    const auto duringComposition = session.character('U', true);
+    Require(session.snapshot().local_mode == metasequoia::LocalInputMode::None,
             "A trigger opened a local mode on top of a live composition.");
     (void)duringComposition;
   }

--- a/platforms/macos/tests/PublicSessionTestOptions.h
+++ b/platforms/macos/tests/PublicSessionTestOptions.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <metasequoia/session.h>
+
+inline metasequoia::SessionOptions SessionTestOptions(SchemeType scheme = SchemeType::Quanpin,
+                                                     bool helpcode = true, bool learning = true)
+{
+    metasequoia::SessionOptions options;
+    options.paths = metasequoia::RuntimePaths::legacy();
+    options.scheme = scheme;
+    options.helpcode = helpcode;
+    options.learning = learning;
+    return options;
+}

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -32,7 +32,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         )[0]
         self.assertLess(
             reload_session.index("storedShuangpinKeymapEnabled"),
-            reload_session.index("_session->has_composition()"),
+            reload_session.index("!_sessionSnapshot.preedit.empty()"),
         )
         self.assertIn("ShuangpinKeymapPanel.mm", cmake)
         self.assertIn("ShuangpinKeymapPanelTests.mm", cmake)
@@ -115,7 +115,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
     def test_input_controller_survives_the_engine_helpcode_semantics(self):
         controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
 
-        # InputSession::helpcode_enabled() reports false for schemes without helpcodes, so an unguarded comparison never matches a Wubi session and rebuilds the engine on every keystroke.
+        # Non-pinyin schemes ignore helpcode preference changes when comparing immutable session options.
         matches = controller.split("bool SessionMatchesPreferences(", 1)[1].split("\n}", 1)[0]
         self.assertIn("SchemeUsesHelpcodes(preferences.scheme)", matches)
         self.assertNotIn("session.helpcode_enabled() == preferences.helpcodeEnabled &&", matches)
@@ -139,10 +139,10 @@ class ReleaseConfigurationTests(unittest.TestCase):
             "uppercase reaches the session from more than one place in the key-routing branch",
         )
         uppercase_branch = character_branch.split("character <= 'Z'", 1)[1].split("}", 1)[0]
-        self.assertIn("!_session->has_composition()", uppercase_branch)
+        self.assertIn("_sessionSnapshot.preedit.empty()", uppercase_branch)
         self.assertIn("_localInputModesEnabled", character_branch)
         self.assertIn("NSEventModifierFlagShift", uppercase_branch)
-        self.assertIn("handle_character(static_cast<char>(character), true)", uppercase_branch)
+        self.assertIn("character(static_cast<char>(character), true)", uppercase_branch)
 
     def test_engine_english_learning_stays_unreachable_from_macos(self):
         controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
@@ -155,14 +155,14 @@ class ReleaseConfigurationTests(unittest.TestCase):
         # orphan learned English words in a file no macOS code reads, migrates or clears.
         self.assertIn("msime_english.db", installer)
         for switch in (
-            "set_dedicated_english_mode",
+            "set_dedicated_english",
             "set_english_input_options",
             "set_frequency_adjustment",
             "set_mixed_expressive_options",
         ):
             self.assertNotIn(switch, controller, f"{switch} reaches the engine's english.db path; reconcile the filename with msime_english.db first")
         # handle_character's second parameter is what routes Shift+letter into the English and local modes.
-        self.assertIn("_session->handle_character(static_cast<char>(character))", controller)
+        self.assertIn("_session->character(static_cast<char>(character))", controller)
 
     def test_input_controller_owns_a_native_floating_status_toolbar(self):
         cmake = (PROJECT_ROOT / "CMakeLists.txt").read_text()
@@ -551,7 +551,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         reload_session = input_controller.split("- (void)reloadSessionFromPreferences", 1)[1].split(
             "- (BOOL)prepareSessionIfNeeded", 1
         )[0]
-        self.assertLess(reload_session.index("_session->has_composition()"), reload_session.index("ReadSessionPreferences()"))
+        self.assertLess(reload_session.index("!_sessionSnapshot.preedit.empty()"), reload_session.index("ReadSessionPreferences()"))
         self.assertIn("_candidateSelection.reset();", reload_session)
         self.assertIn("[_candidatePanel hide];", reload_session)
         controller_initialization = input_controller.split("- (instancetype)initWithServer:", 1)[1].split(


### PR DESCRIPTION
macOS now uses Engine's public Session interface, matching the iOS bridge. Pin the producer to merged main commit 020e906abe5a6af78cec70a1dced8789812eac52 and migrate controller actions, candidate navigation and Wubi auto-commit away from the compatibility InputSession API.

The controller saves value snapshots after mutations and compares immutable creation options when preferences change. Active compositions retain their original options; idle sessions adopt changed preferences. Candidate selection validates both index and word, while finish(highlighted_index) preserves the selected candidate and commits remaining segments through Engine.

Validation on this producer pin: Release universal arm64/x86_64 build, all 38 CTest targets, codesign verification and lipo architecture verification pass locally. Tests cover real-controller pagination/isolation, local-mode preference changes, Wubi behavior, bridge, installer and release packaging. Updated native CI is required for this exact PR. No installed user input source was changed.

This keeps the existing dictionary profile and installation layout. Full resource/user generation migration and physical-device/real-host acceptance remain pending.

Related: metasequoiaime/MSIME-Engine#37 (merged), metasequoiaime/MSIME-Linux#84, metasequoiaime/MSIME-Docs#8. Follows #272.
