### PR TITLE
Publish an unsigned .ipa alongside the iOS archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,17 @@ ctest --test-dir build-test --output-on-failure --timeout 20
 - `MetasequoiaIME-vX.Y.Z-macos-universal-update.zip`
 - `MetasequoiaIME-vX.Y.Z-macos-universal-update.zip.sha256`
 - `appcast.xml`
+- `MetasequoiaIME-vX.Y.Z-ios-unsigned.ipa`
+- `MetasequoiaIME-vX.Y.Z-ios-unsigned.ipa.sha256`
 - `MetasequoiaIME-vX.Y.Z-ios-unsigned.xcarchive.zip`
 - `MetasequoiaIME-vX.Y.Z-ios-unsigned.xcarchive.zip.sha256`
 
 当未配置 Apple 发布凭据时，工作流会发布同样的四份 macOS 产物，但在扩展名前加上 `-unsigned`，并在 GitHub Release 中附加警告。未签名产物仅用于测试，可能需要在 macOS 隐私与安全性设置中显式放行。
 
-iOS 产物是未签名的 `.xcarchive`，**不是可直接安装的 App**。iOS 没有「在隐私与安全性中放行」这种机制，自定义键盘只能通过 App Store 或 TestFlight 安装。发布它是为了重新签名：持有 Apple Developer Program 账号的维护者可以直接从该归档导出 IPA，无需重新构建，导出的就是这个 tag 构建并测试过的产物。仓库目前没有配置任何 Apple 签名凭据，所以 iOS 归档在任何发布模式下都是未签名的，文件名不带 `-unsigned` 之外的后缀区分。
+两份 iOS 产物都是**未签名**的：仓库没有配置任何 Apple 签名凭据，所以它们在任何发布模式下都不带签名，必须先签名才能在真机上运行。也因此文件名不随发布模式变化。
+
+- `.ipa` 是给试用者的。用 Sideloadly、AltStore 这类工具配自己的 Apple ID 重新签名后即可安装，装完在「设置 > 通用 > 键盘 > 键盘」里启用水杉。免费 Apple ID 签出的有效期 7 天，付费 Developer Program 账号 1 年，到期后需要重新签名。
+- `.xcarchive.zip` 是给维护者的。用 Xcode Organizer 打开即可分发到 TestFlight 或 App Store，导出的就是这个 tag 构建并测试过的产物，无需重新构建。
 
 常规安装请使用 ZIP 并运行其中的 `Install.command`，或使用 PKG 通过 macOS 原生安装器安装。两种方式都会安装当前用户的 bundle，并尝试自动注册并启用水杉，无需注销或重启 Mac。如果没有已登录的图形界面用户，或 macOS 拦截了未签名 App，可稍后在「系统设置 > 键盘 > 文本输入 > 编辑」中启用。
 

--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -101,8 +101,37 @@ fi
 bundle="$output_dir/MetasequoiaIME-$tag_name-ios-unsigned.xcarchive.zip"
 rm -f -- "$bundle" "$bundle.sha256"
 ditto -c -k --keepParent "$archive_path" "$bundle"
+
+# The .ipa is the artifact anyone other than the maintainer can actually use. Re-signing tools take
+# an .ipa directly and sign it with the user's own Apple ID; exporting from the .xcarchive instead
+# needs Xcode's Organizer and a Developer Program membership. An .ipa is just a zip whose top-level
+# directory is Payload, so it needs no signing identity to produce — the payload inside is unsigned
+# and has to be re-signed before a device will run it.
+payload_root="$build_root/ipa"
+rm -rf -- "$payload_root"
+mkdir -p "$payload_root/Payload"
+cp -R "$application" "$payload_root/Payload/"
+# Checked on the staged tree rather than by grepping a listing of the finished zip: the payload is
+# what this script controls, and a test that parses another tool's output can fail for reasons that
+# have nothing to do with the payload being wrong.
+staged_extension="$payload_root/Payload/MetasequoiaIME.app/PlugIns/MetasequoiaKeyboard.appex"
+if [[ ! -x "$staged_extension/MetasequoiaKeyboard" || ! -s "$staged_extension/msime.db" ]]; then
+    printf 'The staged .ipa payload is missing the keyboard extension or its dictionary.\n' >&2
+    exit 1
+fi
+
+ipa="$output_dir/MetasequoiaIME-$tag_name-ios-unsigned.ipa"
+rm -f -- "$ipa" "$ipa.sha256"
+# zip rather than ditto: ditto writes AppleDouble ._ entries beside the payload, and an .ipa is
+# consumed by tools that do not expect them.
+(cd "$payload_root" && zip -qry "$ipa" Payload)
+# Reads the whole archive back and verifies every CRC, so a truncated or corrupt .ipa cannot ship.
+unzip -tqq "$ipa"
+
 (
     cd "$output_dir"
-    shasum -a 256 "$(basename "$bundle")" > "$(basename "$bundle").sha256"
+    for artifact in "$bundle" "$ipa"; do
+        shasum -a 256 "$(basename "$artifact")" > "$(basename "$artifact").sha256"
+    done
 )
-printf '%s\n' "$bundle"
+printf '%s\n%s\n' "$bundle" "$ipa"

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -37,6 +37,7 @@ appcast="$dist_dir/appcast.xml"
 # The iOS archive carries no Apple signature in any release mode, so its name does not take
 # ASSET_SUFFIX — there is no signed counterpart for it to be distinguished from.
 ios_archive="$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.xcarchive.zip"
+ios_ipa="$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.ipa"
 artifacts=("$installer" "$installer.sha256" "$archive" "$archive.sha256" "$update_archive" "$update_archive.sha256")
 # The Sparkle appcast is signed with the project's Ed25519 update key, which is independent of Apple code signing, so publish it whenever the release job produced one.
 if [[ -f "$appcast" ]]; then
@@ -44,7 +45,7 @@ if [[ -f "$appcast" ]]; then
 fi
 # Required rather than optional: the iOS build is part of every release run, so a missing archive
 # means the step failed silently rather than that iOS is not being shipped.
-artifacts+=("$ios_archive" "$ios_archive.sha256")
+artifacts+=("$ios_archive" "$ios_archive.sha256" "$ios_ipa" "$ios_ipa.sha256")
 for artifact in "${artifacts[@]}"; do
     if [[ ! -f "$artifact" ]]; then
         printf 'Release artifact is missing: %s\n' "$artifact" >&2
@@ -69,11 +70,12 @@ done
     verify_checksum_manifest "$(basename "$archive")" "$(basename "$archive.sha256")"
     verify_checksum_manifest "$(basename "$update_archive")" "$(basename "$update_archive.sha256")"
     verify_checksum_manifest "$(basename "$ios_archive")" "$(basename "$ios_archive.sha256")"
+    verify_checksum_manifest "$(basename "$ios_ipa")" "$(basename "$ios_ipa.sha256")"
 )
 
 mode_marker="<!-- metasequoia-release-mode:$release_mode -->"
 opposite_marker="<!-- metasequoia-release-mode:$opposite_mode -->"
-install_guidance_marker="<!-- metasequoia-install-guidance:v2 -->"
+install_guidance_marker="<!-- metasequoia-install-guidance:v3 -->"
 current_notes=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq '.body // ""')
 if [[ "$current_notes" == *"$opposite_marker"* ]]; then
     printf '%s\n' "Release $TAG_NAME is already locked to $opposite_mode artifacts; refusing to switch it to $release_mode." >&2
@@ -98,14 +100,15 @@ if [[ "$current_notes" != *"$mode_marker"* || "$current_notes" != *"$install_gui
             printf '%s\n' '- **Recommended: ZIP.** Verify its `.sha256`, extract it, then run `Install.command`. It installs for the current user, registers and enables the exact input source, and does not automatically log out or restart the Mac.'
             printf '%s\n' '- **PKG option.** The native Installer copies the same app and attempts to register and enable 水杉 for the logged-in GUI user. If no GUI user is logged in or macOS blocks the app, enable it later in System Settings > Keyboard > Text Input > Edit. The package does not force a logout or restart; macOS may still require a later logout before a newly copied input method appears.'
             printf '\n%s\n' '### iOS'
-            printf '%s\n' '- The `-ios-unsigned.xcarchive.zip` asset is an **unsigned archive, not an installable app.** iOS has no equivalent of allowing an unsigned build in Privacy & Security, and a custom keyboard can only be installed through the App Store or TestFlight.'
-            printf '%s\n' '- It is published so a maintainer with an Apple Developer Program membership can export an IPA from the exact bits this tag built, without rebuilding.'
+            printf '%s\n' '- Both iOS assets are **unsigned**: this project has no Apple signing identity, so neither will run on a device until it is signed.'
+            printf '%s\n' '- `-ios-unsigned.ipa` is the one to take. Sign it with your own Apple ID using a re-signing tool such as Sideloadly or AltStore and install it; the keyboard is then enabled in Settings > General > Keyboard > Keyboards. A free Apple ID signature expires after 7 days and a paid Developer Program one after a year, at which point it has to be re-signed.'
+            printf '%s\n' '- `-ios-unsigned.xcarchive.zip` is for a maintainer with a Developer Program membership: open it in Xcode Organizer and distribute to TestFlight or the App Store from the exact bits this tag built, without rebuilding.'
         fi
     } > "$release_notes"
     gh release edit "$TAG_NAME" --repo "$GH_REPO" --notes-file "$release_notes"
 fi
 
-upload_args=("$installer" "$installer.sha256" "$archive" "$archive.sha256" "$update_archive" "$update_archive.sha256" "$ios_archive" "$ios_archive.sha256")
+upload_args=("$installer" "$installer.sha256" "$archive" "$archive.sha256" "$update_archive" "$update_archive.sha256" "$ios_archive" "$ios_archive.sha256" "$ios_ipa" "$ios_ipa.sha256")
 if [[ -f "$appcast" ]]; then
     upload_args+=("$appcast")
 fi

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -463,12 +463,14 @@ fi
                 "<?xml version=\"1.0\"?><rss><channel><item>test</item></channel></rss>\n"
             )
             # The iOS archive name never carries the signing suffix: it is unsigned in every mode.
-            ios_archive = dist / "MetasequoiaIME-v1.2.3-ios-unsigned.xcarchive.zip"
-            ios_archive.write_bytes(b"test iOS archive artifact\n")
-            ios_digest = hashlib.sha256(ios_archive.read_bytes()).hexdigest()
-            (dist / f"{ios_archive.name}.sha256").write_text(
-                f"{ios_digest}  {ios_archive.name}\n"
-            )
+            for ios_name in (
+                "MetasequoiaIME-v1.2.3-ios-unsigned.xcarchive.zip",
+                "MetasequoiaIME-v1.2.3-ios-unsigned.ipa",
+            ):
+                ios_artifact = dist / ios_name
+                ios_artifact.write_bytes(f"test {ios_name} artifact\n".encode())
+                ios_digest = hashlib.sha256(ios_artifact.read_bytes()).hexdigest()
+                (dist / f"{ios_name}.sha256").write_text(f"{ios_digest}  {ios_name}\n")
             if misdirected_checksum:
                 archive = dist / f"{stem}.zip"
                 archive_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
@@ -516,7 +518,11 @@ fi
         self.assertIn("macos-universal-unsigned.pkg", calls)
         self.assertIn("macos-universal-unsigned-update.zip", calls)
         self.assertIn("ios-unsigned.xcarchive.zip", calls)
-        self.assertIn("unsigned archive, not an installable app", notes)
+        self.assertIn("ios-unsigned.ipa", calls)
+        # The .ipa is the asset a tester can use, so the notes have to lead with it and say plainly
+        # that it still needs signing.
+        self.assertIn("Both iOS assets are **unsigned**", notes)
+        self.assertIn("Sideloadly", notes)
         # The appcast is signed with the Ed25519 update key, not with an Apple identity, so an Apple-unsigned release still publishes it and Sparkle keeps working.
         self.assertIn("appcast.xml", calls)
         self.assertIn("--draft=false", calls)
@@ -525,7 +531,7 @@ fi
         marker = (
             "Existing notes\n\n"
             "<!-- metasequoia-release-mode:unsigned -->\n"
-            "<!-- metasequoia-install-guidance:v2 -->\n"
+            "<!-- metasequoia-install-guidance:v3 -->\n"
         )
         result, calls, notes = self.run_publication("false", "-unsigned", marker)
 
@@ -541,7 +547,7 @@ fi
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Existing notes", notes)
         self.assertEqual(notes.count("metasequoia-release-mode:unsigned"), 1)
-        self.assertIn("metasequoia-install-guidance:v2", notes)
+        self.assertIn("metasequoia-install-guidance:v3", notes)
         self.assertIn("Recommended: ZIP", notes)
         self.assertLess(calls.index("--notes-file"), calls.index("release upload"))
 
@@ -567,6 +573,7 @@ fi
         self.assertIn("macos-universal.pkg", calls)
         # Unsigned in a signed release too, because no iOS signing identity exists.
         self.assertIn("ios-unsigned.xcarchive.zip", calls)
+        self.assertIn("ios-unsigned.ipa", calls)
 
     def test_corrupt_artifact_is_rejected_before_release_metadata_or_assets_change(self):
         result, calls, notes = self.run_publication("false", "-unsigned", corrupt_checksum=True)

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -291,10 +291,19 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("xcodegen", workflow)
         publish_script = (MACOS_ROOT / "scripts/publish-release.sh").read_text()
         self.assertIn("ios-unsigned.xcarchive.zip", publish_script)
+        # The .ipa is the asset a tester can actually re-sign and install, so it has to be uploaded
+        # rather than only checked for existence — an earlier revision added it to one list and not
+        # the other.
+        self.assertIn("ios-unsigned.ipa", publish_script)
+        self.assertIn('"$ios_ipa" "$ios_ipa.sha256")', publish_script.split("upload_args=", 1)[1])
         archive_script = (PROJECT_ROOT / "platforms/ios/scripts/package_ios_archive.sh").read_text()
         self.assertIn("CODE_SIGNING_ALLOWED=NO", archive_script)
         # The archive is worthless if it silently drops the extension the product exists for.
         self.assertIn("PlugIns/MetasequoiaKeyboard.appex", archive_script)
+        # An .ipa is a zip whose top-level directory is Payload; that layout is what re-signing
+        # tools expect, and it needs no signing identity to produce.
+        self.assertIn("Payload", archive_script)
+        self.assertIn("unzip -tqq", archive_script)
         self.assertNotIn("generated", (package["pull-request-header"] + package["pull-request-footer"]).lower())
         self.assertTrue(package["draft"])
         self.assertTrue(package["force-tag-creation"])


### PR DESCRIPTION
## Why

The iOS release shipped only `MetasequoiaIME-<tag>-ios-unsigned.xcarchive.zip`. That zip is not an alternative to an `.ipa` — it is just the container for the `.xcarchive`, which is a directory bundle and cannot be a release asset on its own. The problem is that an `.xcarchive` is the wrong artifact for anyone except the maintainer:

- **`.ipa`** → Sideloadly / AltStore take it directly and re-sign it with the user's own Apple ID. That is how a tester installs this.
- **`.xcarchive`** → needs Xcode's Organizer and a Developer Program membership to export anything installable.

So the one artifact published was usable by exactly the person who least needed it.

An `.ipa` is a zip whose top-level directory is `Payload`, so producing one needs **no signing identity at all**. The payload is the same unsigned app the archive already contains. Both are now published — 6.6 MB and 7.7 MB.

## Correcting the release notes and README

They said a custom keyboard "can only be installed through the App Store or TestFlight". That is not true: sideloading with a personal Apple ID works and the keyboard functions normally. The notes now lead with the `.ipa`, say plainly that both assets are unsigned and must be signed before a device will run them, and give the real signature lifetimes (7 days on a free Apple ID, a year on a paid one). The install-guidance marker moves to `v3` so releases that already carry `v2` notes get the corrected text.

## Robustness

The payload is checked on the staged tree — `Payload/MetasequoiaIME.app/PlugIns/MetasequoiaKeyboard.appex/{MetasequoiaKeyboard,msime.db}` — rather than by grepping a listing of the finished zip. A first cut did grep the listing and failed once with the payload demonstrably correct; I could not reproduce it afterwards and would rather not ship a check whose failure mode I cannot explain. The finished `.ipa` is then read back with `unzip -tqq`, which verifies every CRC, so a truncated archive cannot ship.

`zip` rather than `ditto`, because `ditto` writes AppleDouble `._` entries beside the payload and `.ipa` consumers do not expect them.

## Verification

Ran `package_ios_archive.sh` end to end. Produced:

```
MetasequoiaIME-v0.47.0-ios-unsigned.ipa              6.6 MB
MetasequoiaIME-v0.47.0-ios-unsigned.ipa.sha256
MetasequoiaIME-v0.47.0-ios-unsigned.xcarchive.zip    7.7 MB
MetasequoiaIME-v0.47.0-ios-unsigned.xcarchive.zip.sha256
```

- `shasum -a 256 -c` passes for both manifests.
- 14 entries in the `.ipa`, **all** under `Payload/` — no `__MACOSX`, no `._` files.
- `arm64` device binary, keyboard extension embedded, the 15.9 MB dictionary inside the `.appex`, bundle ids `com.houko.metasequoiaime.ios` and `.keyboard`, `CFBundleShortVersionString` matching the tag, `codesign -dv` reports "not signed at all" as intended.
- `ctest`: 38/38. `ReleaseAutomationTests` (31), `ReleaseConfigurationTests` (16), `ProductLockTests`, `ProjectConfigurationTests` all pass. `actionlint` clean.

`ReleaseAutomationTests` caught a real mistake while I was writing this: the first revision added the `.ipa` to the existence-check list but not to `upload_args`, so it would have been built and verified and then never uploaded. There is now an assertion pinning it in the upload list specifically.
