### PR TITLE
feat(release): separate the automatic build channel from the release channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,4 +310,6 @@ jobs:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           ASSET_SUFFIX: ${{ steps.signing.outputs.asset_suffix }}
           SIGNING_ENABLED: ${{ steps.signing.outputs.signing_enabled }}
+          # Decides which channel the release is published into: push is an automatic per-merge build, workflow_dispatch is one somebody asked for.
+          RELEASE_TRIGGER: ${{ github.event_name }}
         run: exec "$RUNNER_TEMP/publish-release.sh"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ ctest --test-dir build-test --output-on-failure --timeout 20
 
 ## 发布
 
+Release 分两个频道，由触发方式决定：
+
+| 频道 | 触发 | 页面上的样子 | Sparkle 自动更新 |
+|---|---|---|---|
+| 发布 | 手动触发 `Release` workflow | 正常发布，最新的一个带 **Latest** 徽章 | **跟随这个频道** |
+| 自动构建 | 合并到 `main` 后自动 | 标记 **Pre-release**，标题带「（自动构建）」 | 不参与 |
+
+GitHub 没有自定义频道，只有 Latest / Pre-release / Draft 三种状态，所以这里用 `prerelease` 标志承载「自动、未经挑选」，而不是承载「内测」——两个频道当前都还是内测阶段。
+
+自动更新之所以只跟随发布频道，是因为 `Info.plist` 里的 Sparkle feed 指向 `releases/latest/download/appcast.xml`，而 Pre-release 不会成为 Latest，它的 appcast 取不到。想装自动构建的用户需要自己去 Releases 页面下载。
+
 合并到 `main` 会根据 conventional commit 历史更新 Release Please 的 pull request。合并该发布 PR 会更新 `version.txt`、`CMakeLists.txt` 和 `CHANGELOG.md`，创建对应的 `vX.Y.Z` 标签，构建并测试通用架构的输入法 bundle，然后发布带有以下产物的 GitHub Release：
 
 - `MetasequoiaIME-vX.Y.Z-macos-universal.pkg`

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 : "${GH_REPO:?GH_REPO is required}"
 : "${TAG_NAME:?TAG_NAME is required}"
 : "${SIGNING_ENABLED:?SIGNING_ENABLED is required}"
+# push means an automatic per-merge build, anything else means somebody asked for this one. GitHub has no channel concept, so the two states it does have carry the two channels: automatic builds are prereleases, deliberate ones are ordinary releases and the newest of those takes the Latest badge. Before this the two were indistinguishable and the badge simply followed whatever merged last. Kept in step with MSIME-Windows#167.
+: "${RELEASE_TRIGGER:?RELEASE_TRIGGER is required}"
 if [[ ${ASSET_SUFFIX+x} != x ]]; then
     printf '%s\n' "ASSET_SUFFIX is required." >&2
     exit 1
@@ -76,17 +78,35 @@ done
 mode_marker="<!-- metasequoia-release-mode:$release_mode -->"
 opposite_marker="<!-- metasequoia-release-mode:$opposite_mode -->"
 install_guidance_marker="<!-- metasequoia-install-guidance:v3 -->"
+build_channel_marker="<!-- metasequoia-build-channel:v1 -->"
+if [[ "$RELEASE_TRIGGER" == push ]]; then
+    # Braces are required: bash takes the full-width bracket that follows as part of the name otherwise.
+    release_title="${TAG_NAME}（自动构建）"
+    channel=(--prerelease)
+    needs_channel_note=true
+else
+    release_title="$TAG_NAME"
+    channel=(--prerelease=false --latest)
+    needs_channel_note=false
+fi
 current_notes=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq '.body // ""')
+if [[ "$needs_channel_note" == true && "$current_notes" == *"$build_channel_marker"* ]]; then
+    needs_channel_note=false
+fi
 if [[ "$current_notes" == *"$opposite_marker"* ]]; then
     printf '%s\n' "Release $TAG_NAME is already locked to $opposite_mode artifacts; refusing to switch it to $release_mode." >&2
     exit 1
 fi
 
-if [[ "$current_notes" != *"$mode_marker"* || "$current_notes" != *"$install_guidance_marker"* ]]; then
+if [[ "$current_notes" != *"$mode_marker"* || "$current_notes" != *"$install_guidance_marker"* || "$needs_channel_note" == true ]]; then
     release_notes=${RUNNER_TEMP:-${TMPDIR:-/tmp}}/metasequoia-release-notes.md
     {
         if [[ -n "$current_notes" ]]; then
             printf '%s\n\n' "$current_notes"
+        fi
+        if [[ "$needs_channel_note" == true ]]; then
+            printf '%s\n' "$build_channel_marker"
+            printf '%s\n\n' '> 本版本由 CI 在合并到 `main` 后自动构建发布，未经人工挑选，标记为 Pre-release。想要经过挑选的版本，请下载页面上带 Latest 徽章的那个。'
         fi
         if [[ "$current_notes" != *"$mode_marker"* ]]; then
             printf '%s\n' "$mode_marker"
@@ -113,4 +133,4 @@ if [[ -f "$appcast" ]]; then
     upload_args+=("$appcast")
 fi
 gh release upload "$TAG_NAME" --repo "$GH_REPO" "${upload_args[@]}" --clobber
-gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false
+gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false "${channel[@]}" --title "$release_title"

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -417,6 +417,7 @@ class ReleasePublicationTests(unittest.TestCase):
         existing_notes="",
         corrupt_checksum=False,
         misdirected_checksum=False,
+        release_trigger="workflow_dispatch",
     ):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary = Path(temporary_directory)
@@ -483,6 +484,7 @@ fi
                     "TAG_NAME": "v1.2.3",
                     "ASSET_SUFFIX": asset_suffix,
                     "SIGNING_ENABLED": signing_enabled,
+                    "RELEASE_TRIGGER": release_trigger,
                     "DIST_DIR": str(dist),
                     "RUNNER_TEMP": str(temporary),
                     "FAKE_GH_LOG": str(log),
@@ -587,6 +589,49 @@ fi
         result, calls, notes = self.run_publication("false", "-unsigned", misdirected_checksum=True)
 
         self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(calls, "")
+        self.assertEqual(notes, "")
+
+    def test_push_publishes_into_the_build_channel(self):
+        result, calls, notes = self.run_publication(
+            "true", "", existing_notes="Existing notes", release_trigger="push"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--prerelease", calls)
+        self.assertNotIn("--latest", calls)
+        self.assertIn("（自动构建）", calls)
+        self.assertIn("metasequoia-build-channel:v1", notes)
+        self.assertIn("未经人工挑选", notes)
+
+    def test_dispatch_publishes_into_the_release_channel(self):
+        result, calls, notes = self.run_publication(
+            "true", "", existing_notes="Existing notes", release_trigger="workflow_dispatch"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--prerelease=false", calls)
+        self.assertIn("--latest", calls)
+        self.assertNotIn("（自动构建）", calls)
+        self.assertNotIn("metasequoia-build-channel", notes)
+
+    def test_build_channel_note_is_not_repeated_on_a_retry(self):
+        _, _, notes = self.run_publication(
+            "true",
+            "",
+            existing_notes="Existing notes <!-- metasequoia-build-channel:v1 --> 未经人工挑选",
+            release_trigger="push",
+        )
+
+        self.assertLessEqual(notes.count("metasequoia-build-channel:v1"), 1)
+
+    def test_publication_requires_knowing_which_channel_it_is_publishing_into(self):
+        # Defaulting would silently pick a channel, and picking the release channel by accident
+        # puts an uncurated build behind the Latest badge, which is what Sparkle follows.
+        result, calls, notes = self.run_publication("true", "", release_trigger="")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("RELEASE_TRIGGER", result.stderr)
         self.assertEqual(calls, "")
         self.assertEqual(notes, "")
 


### PR DESCRIPTION
Keeps this repository in step with the channel split being made in MSIME-Windows (metasequoiaime/MSIME-Windows#167).

## The change

| Channel | Trigger | State | Title |
| --- | --- | --- | --- |
| 自动构建 | `push` | `--prerelease` | `v<version>（自动构建）`, with a note in the body |
| 发布 | `workflow_dispatch` | `--prerelease=false --latest` | `v<version>` |

Until now every release was published with a bare `--draft=false`, so the newest one always took the Latest badge regardless of whether anyone had looked at it.

`prerelease` carries "automatic and uncurated" here, not "beta". Both channels are still 内测; that is a claim for prose to make, and the flag cannot make it while also being the only thing separating the channels.

## This settles Sparkle too, which matters more here than elsewhere

`platforms/macos/resources/Info.plist` points the feed at:

```
https://github.com/metasequoiaime/MSIME-Apple/releases/latest/download/appcast.xml
```

The feed follows the Latest badge. A prerelease never takes that badge, so its `appcast.xml` is never served, and Sparkle stops offering per-merge builds to everyone running the input method. Automatic updates now follow the release channel, and installing an automatic build becomes a deliberate download. Without this, the split would be cosmetic on macOS: users would still be auto-updated onto uncurated builds.

**Worth being explicit about the transition.** Until the first `workflow_dispatch` after this lands, Latest stays on the release published before it, so Sparkle keeps offering that version and automatic updates deliver nothing new in the meantime.

## Verification

- The channel decision extracted and exercised in isolation:
  - `push`, marker absent → `--prerelease`, title `v0.47.0（自动构建）`, note written
  - `push`, marker already present → `--prerelease`, note **not** written again
  - `workflow_dispatch` → `--prerelease=false --latest`, bare title, no note
- The note reuses the `<!-- metasequoia-... -->` marker idiom already used for release mode and install guidance, so it is idempotent the same way they are.
- `shellcheck -S warning` clean on `publish-release.sh`; `actionlint` with `SHELLCHECK_OPTS=--severity=warning` clean on `release.yml`.
- `gh release edit` accepts `--prerelease=false`; its own help documents the `--draft=false` form.

`README.md` gains a table describing both channels and stating that automatic updates follow only the release channel.
