### PR TITLE
Guard the punctuation whitelist against engine table drift

### DIFF
--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -263,6 +263,33 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual((PROJECT_ROOT / "version.txt").read_text().strip(), match.group(1))
         self.assertIn("x-release-please-version", project_line)
 
+    def test_punctuation_dispatch_matches_the_pinned_engine_table(self):
+        # The controller forwards a hardcoded set of characters to the engine's punctuation policy.
+        # When the engine's table grew ` $ ^ _ alongside < >, only the latter pair was picked up
+        # here, so with 中文标点 on Shift+4 kept inserting $ instead of ￥ and nothing noticed —
+        # neither repository has a test that compares the two, and the engine bump that introduced
+        # the divergence merged normally. Compare them directly instead.
+        def literals(pattern, text):
+            escapes = {"\\\\": "\\", "\\'": "'", '\\"': '"'}
+            return {escapes.get(match, match) for match in re.findall(pattern, text)}
+
+        policy = (
+            PROJECT_ROOT / "vendor/MetasequoiaImeEngine/core/punctuation_policy.cpp"
+        ).read_text()
+        engine_characters = literals(r"case '(\\.|[^'])':", policy)
+
+        controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
+        # The branch that reaches the engine, not the full-width or candidate-number branches.
+        branch = controller.split("_session->punctuation(", 1)[0].rsplit("else if (", 1)[1]
+        dispatched = literals(r"character == '(\\.|[^'])'", branch)
+
+        self.assertGreater(len(engine_characters), 10, "the engine punctuation table was not parsed")
+        self.assertEqual(
+            dispatched,
+            engine_characters,
+            "the controller's punctuation whitelist and the pinned engine's table disagree",
+        )
+
     def test_release_automation_bumps_tags_and_uploads_installable_assets(self):
         config = json.loads((PROJECT_ROOT / "release-please-config.json").read_text())
         package = config["packages"]["."]


### PR DESCRIPTION
## Why

`MetasequoiaInputController.mm` forwards a hardcoded set of characters to the engine's punctuation policy. When that policy's table grew `` ` `` `$` `^` `_` alongside `<` `>`, only the latter pair was picked up here — so with 中文标点 on, Shift+4 kept inserting `$` instead of `￥`, and `` ` `` `^` `_` likewise missed `·` `……` `——`.

Nothing caught it. Neither repository compares the two lists, and the engine bump that introduced the divergence was a routine source change that classified as "needs review" and merged normally. The whitelist was corrected in #269; this is the guard that would have caught it, and will catch the next one.

## What it does

Parses the `case` labels out of the pinned engine's `core/punctuation_policy.cpp` and the `character == '…'` comparisons out of the controller's dispatch branch, then requires the two sets to be equal. The engine keeps this table in one small single-purpose file, so the parse is not fragile.

Both sides are 19 characters today: ``! " $ ' ( ) , . : ; < > ? [ \ ] ^ _ ` ``

The branch is located by splitting on `_session->punctuation(`, so it cannot accidentally pick up the full-width or candidate-number branches, which also compare characters.

## Verification

- `ctest`: 38/38, including `release_configuration` which now carries this case.
- Mutation-checked: deleting `character == '$'` from the controller fails the test with `'$' : the controller's punctuation whitelist and the pinned engine's table disagree`. Restoring it passes.
- The test reads the submodule, which CI checks out with `submodules: recursive`.

iOS needs no equivalent: `handleSymbol` forwards every symbol to the session unfiltered, so there is no whitelist there to drift.

## Context

This is the consumer-side half of a broader gap — MSIME-Engine owns contracts for three frontends but has no mechanism to verify or notify them when a contract changes. Deciding what that mechanism should be is a design question; this guards the one case that has already bitten, in the repository that has to react to it.


---

## Verified afterwards: macOS is the only frontend that mirrors this table

I checked the other three consumers to see whether they need the same guard. They do not, and the reason matters:

- **Linux** classifies by ASCII range — `is_ascii_punctuation` in `src/IBusKeyMapper.cpp` accepts `!`–`/`, `:`–`@`, `[`–`` ` ``, `{`–`~` — and forwards the character to the session. The engine's `translate()` returns null for anything it does not map, and the frontend treats that as unhandled.
- **iOS** `handleSymbol` forwards every symbol to the session unfiltered.
- **The Windows server** does not mirror the table at all; grepping its `server/src` for a character whitelist turns up only skin-catalog, SVG-path and URL-encoding code.

So all three forward a superset and let the engine decide, while macOS enumerates the engine's exact set by hand. That is precisely why macOS was the one that drifted when the table grew — and it means this guard completes the consumer side rather than being the first of three.

Removing the mirror entirely would be structurally better than guarding it, but on macOS `[`, `]` and `'` carry paging and composition meaning ahead of this branch, so reworking the dispatch is a change to the input hot path with real regression risk. The guard removes the harm — silent divergence — without touching behaviour.
