### PR TITLE
Explain why this lock does not copy the engine commit

### DIFF
--- a/scripts/product_lock.py
+++ b/scripts/product_lock.py
@@ -3,7 +3,7 @@
 
 This mirrors MSIME-Linux/scripts/product_lock.py deliberately, so the two can be diffed. The only intended difference is the asset set: the macOS bundle installs msime.db and nothing else, so others.db and english.db are not locked here. Add them here and to CMakeLists.txt together if the bundle ever ships them.
 
-Engine, helpcodes and the mobile builder share one Engine gitlink. Git already makes those immutable and shows every move in a pull request diff, so they are not copied into this lock: doing that would only give the submodule pin a second home to drift from.
+Engine, helpcodes and the mobile builder share one Engine gitlink, and this lock does not copy that commit. Nothing here reads it: the manifest resolves gitlinks directly, and this repository has no release gate that refuses an engine commit nobody merged. MSIME-Windows does record it, because its packaging manifest and release gate both consume it, and `product_lock.py verify-contracts` keeps that copy honest against the gitlink. Either is fine with a checker; a second copy with no reader and no checker is not.
 
 The dictionary the bundle actually *ships* is the one input git does not pin. It is a release asset behind a tag that upstream can retag, and the SHA256SUMS.txt published beside it is exactly as mutable as the data. So product-lock.json holds the tag and the SHA256 of every asset, and the build verifies those committed digests instead.
 


### PR DESCRIPTION
## What

The `product_lock.py` docstring said recording the engine commit in the lock "would only give the submodule pin a second home to drift from". MSIME-Windows *does* record it — `product-lock.json` there carries a `repositories.engine` block — so as written the sentence says a sibling repository is doing it wrong, rather than explaining a local choice.

Both choices are defensible and the difference is deliberate:

- **Here**: nothing reads the field. The manifest resolves gitlinks directly, and this repository has no release gate that refuses an engine commit nobody merged. A copy would be write-only, and a write-only copy is exactly the "second home to drift from" the old sentence worried about.
- **MSIME-Windows**: its packaging manifest and its release gate both consume it, and `product_lock.py verify-contracts` requires the lock and the gitlink to agree — that checker is what makes the second copy safe, and `engine-bump-triage.yml` runs it before it will enable auto-merge.

The rewritten paragraph says that, so the next person comparing the three frontends finds a reason instead of a contradiction.

## Scope

Documentation only. The lock format, `validate()`, `verify_assets()` and every digest check are untouched.

## What I did not add

I started to add a guard requiring the lock's database set to equal `DATABASES`, on the theory that a database added to the lock but not to the constant would skip the product validator while still having its digest checked. **That cannot happen** — `validate()` already requires `set(assets)` to equal exactly `DATABASES + SHA256SUMS.txt + dictionary-manifest.json`, `load()` always calls `validate()`, and CI runs `product_lock.py validate`. Verified by injecting an extra database into the parsed lock: `validate()` rejects it with "Dictionary lock must cover every shipped database and the checksum file". The guard was redundant, so it is not in this PR.

`python3 scripts/product_lock.py validate` and `ProductLockTests` (15) pass.
