### PR TITLE
Record that macOS voice has no streaming path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ brew install cmake boost fmt spdlog nlohmann-json
 
 macOS 产品直接链接 Engine 的 `Voice`、`VoiceCapture` 和 `VoiceWhisper` 目标。平台层负责权限、钥匙串、录音提示和 IMK 上屏。iOS 目前只接入公共输入引擎与词库构建器，尚未提供语音入口。
 
+macOS 用的是公共 `voice/` 模块，走 HTTP 一次性上传：录完整段再识别，不能边说边出字。Windows 端在合仓时另外积累了 Doubao provider 与 WebSocket 流式识别，这些能力没有回流到公共模块（见 Engine 的 [合仓说明](https://github.com/metasequoiaime/MSIME-Engine/blob/main/docs/consolidation.md)），所以 macOS 与 Linux 在语音上结构性地落后 Windows 一档。这不是配置问题，配置里也没有可以打开的开关。
+
 ## 开发测试
 
 ```sh


### PR DESCRIPTION
## What

The README describes macOS voice input without saying what it cannot do. It uses the shared `voice/` module, which uploads the whole recording over HTTP and recognises it in one shot — `http_client.cpp` drives a single `curl_easy_perform`, so there is no incremental transcription while the user is still speaking.

Windows accumulated a Doubao provider and WebSocket streaming in its own server before the consolidation, and Engine's [consolidation notes](https://github.com/metasequoiaime/MSIME-Engine/blob/main/docs/consolidation.md) state plainly that those capabilities were not brought back into the shared module:

> 当前 Server 的 Doubao/WebSocket 等新增能力没有回退到旧 VoiceInput，也未在本变更中迁移。

So macOS and Linux are structurally a generation behind Windows here, and no setting exposes the difference. Today someone comparing the platforms — or hunting for a streaming switch that does not exist — has to read another repository's migration notes to find that out.

## Scope

Documentation only. Whether the streaming path should be brought into the shared module, and therefore reach macOS and Linux, is a product decision this does not make; it only stops the gap being invisible from this repository.
