### PR TITLE
fix(release): resolve iOS artifact output path before zipping

### DIFF
--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -16,6 +16,12 @@ project_root=$(cd "$project_root" && pwd)
 
 tag_name=${1:-}
 output_dir=${2:-$project_root/dist}
+# The IPA is created from inside its staged Payload directory below. Resolve caller-supplied
+# relative paths before entering that directory, otherwise `dist/foo.ipa` is looked up under the
+# staging tree instead of the repository checkout.
+if [[ "$output_dir" != /* ]]; then
+    output_dir="$(pwd)/$output_dir"
+fi
 
 if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     printf '%s\n' "Tag must use the vMAJOR.MINOR.PATCH format." >&2

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -331,6 +331,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
         # tools expect, and it needs no signing identity to produce.
         self.assertIn("Payload", archive_script)
         self.assertIn("unzip -tqq", archive_script)
+        # The script zips from inside a staged Payload directory, so the workflow's relative dist
+        # argument must be resolved before that directory change.
+        self.assertIn('output_dir="$(pwd)/$output_dir"', archive_script)
         self.assertNotIn("generated", (package["pull-request-header"] + package["pull-request-footer"]).lower())
         self.assertTrue(package["draft"])
         self.assertTrue(package["force-tag-creation"])


### PR DESCRIPTION
## Summary

Fixes the release failure in the unsigned iOS IPA packaging step. The workflow passes `dist` as a relative output directory, but the script changes into the staged Payload directory before invoking `zip`; the IPA was therefore written to a nonexistent staging-relative path and exited with code 15.

This resolves relative output paths before the directory change and adds a regression assertion.

## Verification

- Local iOS archive and unsigned IPA packaging succeeded.
- SHA-256 manifests and IPA ZIP integrity passed.
- `python3 -m unittest platforms.macos.tests.ReleaseConfigurationTests platforms.ios.tests.ProjectConfigurationTests` — 56 passed.
- `bash -n platforms/ios/scripts/package_ios_archive.sh` and `git diff --check` passed.