### PR TITLE
fix(ci): separate automatic and manual release locks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Keep automatic release metadata refreshes from blocking manually dispatched release builds.