### PR TITLE
chore(ci): adopt the develop branch model

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,37 @@
+name: Branch guard
+
+# main is the release branch: it only moves when develop is promoted for a release, or when
+# release-please lands the version commit it generates on top of that promotion. Everything else
+# targets develop.
+#
+# This is a check rather than a ruleset rule because GitHub rulesets can protect a base branch but
+# cannot say which head branches may target it. Add it to main's required status checks so a pull
+# request opened against the wrong base cannot be merged.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  base:
+    name: Base branch
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check the head branch may target main
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            develop | release/* | release-please--*)
+              echo "$HEAD_REF may target main."
+              ;;
+            *)
+              echo "::error::'$HEAD_REF' cannot target main. Day-to-day changes are merged into develop; main only receives develop promotions and release-please version branches. Retarget this pull request at develop."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
   workflow_dispatch:
@@ -16,7 +17,7 @@ on:
   merge_group:
 
 concurrency:
-  # Keyed by event as well as branch: the release scripts dispatch this workflow and wait on that exact run, so a pull_request run on the same branch must not cancel it. Feature branches only ever get the pull_request run (push is restricted to main), so this still collapses superseded runs of the same kind.
+  # Keyed by event as well as branch: the release scripts dispatch this workflow and wait on that exact run, so a pull_request run on the same branch must not cancel it. Feature branches only ever get the pull_request run (push is restricted to develop and main), so this still collapses superseded runs of the same kind.
   group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
   pull_request:
   schedule:
     - cron: '47 3 * * 1'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # This job must not skip. It is one of main's required status checks, and a required check that reports "skipped" blocks a merge instead of passing it. Guarding it on the pull_request event leaves the release pull request unmergeable by its own automation: the release workflow dispatches ci.yml on the release branch, so this job sees workflow_dispatch and skips, and the merge is refused with "the base branch policy prohibits the merge" after everything else comes back green. MSIME-Windows hit exactly that and fixed it the same way.
+      # This job must not skip. It is one of the required status checks on main and develop, and a required check that reports "skipped" blocks a merge instead of passing it. Guarding it on the pull_request event leaves the release pull request unmergeable by its own automation: the release workflow dispatches ci.yml on the release branch, so this job sees workflow_dispatch and skips, and the merge is refused with "the base branch policy prohibits the merge" after everything else comes back green. MSIME-Windows hit exactly that and fixed it the same way.
       #
       # A pull_request event supplies both refs on its own. Every other trigger has to be told what to compare, and comparing the default branch against the checked-out commit is the same question the pull request asks.
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 组织职责见 [组织规范](https://github.com/metasequoiaime/.github/blob/main/AGENTS.md)。平台代码负责 InputMethodKit/UIKit、焦点和系统文本插入；输入算法来自固定 Engine。iOS bridge 与 macOS 控制器均使用 `<metasequoia/session.h>` 的动作与快照。平台保存界面选择和产品偏好，不复制输入组合状态机。
 
+本仓默认分支是 `develop`，日常改动从 `develop` 切分支并合回 `develop`；`main` 是发布分支，只在发版时由维护者从 `develop` 合入，`release.yml` 也只监听 `main`。特性分支直接提到 `main` 会被 `Branch guard` 拦下。规则见[组织 AGENTS.md 的分支模型](https://github.com/metasequoiaime/.github/blob/main/AGENTS.md#分支模型)。
+
 辅助码按会话配置，macOS 候选提示使用控制器持有的同方案只读码表；不要调用全局选择器来切换活动会话，也不要在每次按键上重新加载码表。当前安装器仍提供原有数据目录，`RuntimePaths::legacy()` 在会话创建时捕获该布局；这不表示已接入新的完整资源包或资源代际切换。
 
 桌面词库使用 product-lock.json 的已发布数据及摘要。`vendor/MetasequoiaImeEngine` 同时提供输入引擎、`helpcode/helpcodes/` 和根 `build_profile.py` 移动构建入口；禁止另行检出 Dict/HelpCode 或在 Apple 复制数据算法。Engine gitlink 与已发布词库源提交仍分别记录，不能把构建器提交冒充下载数据的来源。词库格式验证器从固定 Engine 复制，CI 比较字节防止漂移。

--- a/README.en.md
+++ b/README.en.md
@@ -3,8 +3,8 @@
 [中文 README](README.md) · [Website](https://msime.app) · [Docs](https://msime.app/docs/) · [Privacy](PRIVACY.md)
 
 <!-- badges:start -->
-[![CI](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/ci.yml?branch=main&label=CI)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/ci.yml)
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/codeql.yml?branch=main&label=CodeQL)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/codeql.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/ci.yml?branch=develop&label=CI)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/ci.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/codeql.yml?branch=develop&label=CodeQL)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/codeql.yml)
 [![Release](https://img.shields.io/github/v/release/metasequoiaime/MSIME-Apple?include_prereleases&label=release)](https://github.com/metasequoiaime/MSIME-Apple/releases)
 [![License](https://img.shields.io/github/license/metasequoiaime/MSIME-Apple)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/metasequoiaime/MSIME-Apple?style=flat)](https://github.com/metasequoiaime/MSIME-Apple/stargazers)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [官网](https://msime.app) · [用户文档](https://msime.app/docs/) · [隐私说明](PRIVACY.md) · [English README](README.en.md)
 
 <!-- badges:start -->
-[![CI](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/ci.yml?branch=main&label=CI)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/ci.yml)
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/codeql.yml?branch=main&label=CodeQL)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/codeql.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/ci.yml?branch=develop&label=CI)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/ci.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/codeql.yml?branch=develop&label=CodeQL)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/codeql.yml)
 [![Release](https://img.shields.io/github/v/release/metasequoiaime/MSIME-Apple?include_prereleases&label=release)](https://github.com/metasequoiaime/MSIME-Apple/releases)
 [![Downloads](https://img.shields.io/github/downloads/metasequoiaime/MSIME-Apple/total?label=downloads)](https://github.com/metasequoiaime/MSIME-Apple/releases)
 [![License](https://img.shields.io/github/license/metasequoiaime/MSIME-Apple)](LICENSE)
@@ -77,7 +77,7 @@ brew install cmake boost fmt spdlog nlohmann-json
 
 macOS 产品直接链接 Engine 的 `Voice`、`VoiceCapture` 和 `VoiceWhisper` 目标。平台层负责权限、钥匙串、录音提示和 IMK 上屏。iOS 目前只接入公共输入引擎与词库构建器，尚未提供语音入口。
 
-macOS 用的是公共 `voice/` 模块，走 HTTP 一次性上传：录完整段再识别，不能边说边出字。Windows 端在合仓时另外积累了 Doubao provider 与 WebSocket 流式识别，这些能力没有回流到公共模块（见 Engine 的 [合仓说明](https://github.com/metasequoiaime/MSIME-Engine/blob/main/docs/consolidation.md)），所以 macOS 与 Linux 在语音上结构性地落后 Windows 一档。这不是配置问题，配置里也没有可以打开的开关。
+macOS 用的是公共 `voice/` 模块，走 HTTP 一次性上传：录完整段再识别，不能边说边出字。Windows 端在合仓时另外积累了 Doubao provider 与 WebSocket 流式识别，这些能力没有回流到公共模块（见 Engine 的 [合仓说明](https://github.com/metasequoiaime/MSIME-Engine/blob/develop/docs/consolidation.md)），所以 macOS 与 Linux 在语音上结构性地落后 Windows 一档。这不是配置问题，配置里也没有可以打开的开关。
 
 ## 开发测试
 

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -53,7 +53,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("cancel-in-progress: true", workflow)
         # merge-release-pr.sh dispatches ci.yml and waits on that run with --exit-status, so a pull_request run on the same branch must land in a different concurrency group or it cancels the release.
         self.assertIn("${{ github.event_name }}", workflow.split("concurrency:", 1)[1].split("permissions:", 1)[0])
-        self.assertIn("on:\n  push:\n    branches:\n      - main\n  pull_request:\n", workflow)
+        self.assertIn("on:\n  push:\n    branches:\n      - develop\n      - main\n  pull_request:\n", workflow)
 
     def test_current_repository_links_use_the_canonical_apple_repository(self):
         canonical_repository = "https://github.com/metasequoiaime/MSIME-Apple"
@@ -345,10 +345,15 @@ class ReleaseConfigurationTests(unittest.TestCase):
             "github/codeql-action/analyze",
         }
         used_actions = set()
-        for workflow_path in (PROJECT_ROOT / ".github/workflows").glob("*.yml"):
+        # The guard against a broken glob or parse counts the whole tree rather than each file:
+        # branch-guard.yml is a shell-only check and legitimately uses no action at all.
+        workflow_paths = sorted((PROJECT_ROOT / ".github/workflows").glob("*.yml"))
+        self.assertGreater(len(workflow_paths), 0)
+        parsed_uses = 0
+        for workflow_path in workflow_paths:
             uses_lines = [line.strip().removeprefix("- ") for line in workflow_path.read_text().splitlines()
                           if line.strip().removeprefix("- ").startswith("uses:")]
-            self.assertGreater(len(uses_lines), 0)
+            parsed_uses += len(uses_lines)
             for uses_line in uses_lines:
                 action_reference = uses_line.removeprefix("uses:").strip().split()[0]
                 if action_reference.startswith("./"):
@@ -361,6 +366,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 self.assertIn(action, allowed_actions)
                 self.assertRegex(revision, r"^[0-9a-f]{40}$")
                 used_actions.add(action)
+        self.assertGreater(parsed_uses, 0)
         self.assertEqual(used_actions, allowed_actions)
         self.assertIn("steps.release.outputs.release_created", workflow)
         self.assertIn("run: bash platforms/macos/scripts/merge-release-pr.sh", workflow)


### PR DESCRIPTION
Adopts the develop branch model in this repository.

`develop` is now the default branch: day-to-day work branches off `develop` and merges back into it. `main` is the release branch and only moves when a maintainer promotes `develop` for a release, after which release-please lands the version commit and tag on top of that promotion.

## Changes

- `branch-guard.yml`: fails a pull request whose base is `main` unless the head is `develop`, `release/*`, or a `release-please--branches--main--*` branch. This is a check rather than a ruleset rule because rulesets can protect a base branch but cannot say which head branches may target it. It should be added to `main`'s required status checks once it has run once.
- Functional CI and CodeQL now also run on pushes to `develop`; pull request triggers were never branch-filtered, so a pull request against `develop` runs exactly the checks it used to run against `main`.
- `release.yml` is unchanged and still listens only to `main` pushes. Merging into `develop` produces no version and consumes no signing quota.
- AGENTS.md, contributing docs and README badges describe the new model.

## Repository settings already applied

- Default branch switched to `develop`.
- The branch ruleset condition changed from `~DEFAULT_BRANCH` to an explicit `refs/heads/main` + `refs/heads/develop`, so both branches keep deletion, force-push, pull request and required check protection. Leaving the placeholder in place would have dropped `main` out of protection the moment the default branch changed.

Organization-wide rules live in [.github#分支模型](https://github.com/metasequoiaime/.github/blob/main/AGENTS.md).

## Verification

- `SHELLCHECK_OPTS=--severity=warning actionlint` clean in this repository.


## Test updates this required

`platforms/macos/tests/ReleaseConfigurationTests.py` asserts on the workflow files themselves, and two assertions encoded the old model:

- The `on:` block assertion pinned `push` to `main` alone; it now expects `develop` and `main`.
- Every workflow file had to contain at least one `uses:` line. `branch-guard.yml` is a shell-only check with no action at all, so the guard against a broken glob or parse now counts the whole tree instead of each file.
