### PR TITLE
feat(ios): publish signed builds to TestFlight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,7 @@ jobs:
             platforms/macos/scripts/package_release.sh
             platforms/macos/scripts/generate-sparkle-appcast.sh
             platforms/macos/scripts/publish-release.sh
+            platforms/ios/scripts/package_ios_testflight.sh
           persist-credentials: false
       - name: Stage trusted release automation
         run: |
@@ -160,6 +161,7 @@ jobs:
           install -m 0755 .release-automation/platforms/macos/scripts/package_release.sh "$RUNNER_TEMP/package-release.sh"
           install -m 0755 .release-automation/platforms/macos/scripts/generate-sparkle-appcast.sh "$RUNNER_TEMP/generate-sparkle-appcast.sh"
           install -m 0755 .release-automation/platforms/macos/scripts/publish-release.sh "$RUNNER_TEMP/publish-release.sh"
+          install -m 0755 .release-automation/platforms/ios/scripts/package_ios_testflight.sh "$RUNNER_TEMP/package-ios-testflight.sh"
       - name: Determine release signing mode
         id: signing
         env:
@@ -246,16 +248,52 @@ jobs:
           METASEQUOIA_RELEASE_POSTINSTALL_SCRIPT: ${{ runner.temp }}/pkg-postinstall.sh
           METASEQUOIA_INSTALLER_DISTRIBUTION: ${{ runner.temp }}/InstallerDistribution.xml.in
         run: exec "$RUNNER_TEMP/package-release.sh" "$TAG_NAME" build/MetasequoiaIME.app dist
-      # The iOS artifact is an unsigned .xcarchive, because no Apple signing identity is configured
-      # for this repository. It is not installable on its own — a custom keyboard reaches users only
-      # through the App Store or TestFlight — but it lets a maintainer with a Developer Program
-      # membership export an IPA from the exact bits this tag built, without a rebuild.
+      # The public iOS artifacts stay unsigned and reproducible. When App Store Connect API key
+      # secrets are configured, the separate TestFlight step below builds an automatically signed upload from the
+      # same tag and sends it to App Store Connect.
       - name: Package the iOS dictionary
         run: python3 platforms/ios/scripts/prepare_dictionary.py
       - name: Build the unsigned iOS archive
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
         run: exec platforms/ios/scripts/package_ios_archive.sh "$TAG_NAME" dist
+      - name: Prepare App Store Connect API key for TestFlight
+        id: testflight_credentials
+        env:
+          IOS_API_KEY_BASE64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_BASE64 }}
+          IOS_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
+          IOS_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${IOS_API_KEY_BASE64:-}" && -z "${IOS_API_KEY_ID:-}" && -z "${IOS_API_KEY_ISSUER_ID:-}" ]]; then
+            printf 'enabled=false\n' >> "$GITHUB_OUTPUT"
+            echo 'TestFlight upload skipped: App Store Connect API Key secrets are not configured.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [[ -z "${IOS_API_KEY_BASE64:-}" || -z "${IOS_API_KEY_ID:-}" || -z "${IOS_API_KEY_ISSUER_ID:-}" ]]; then
+            echo 'TestFlight upload requires IOS_APP_STORE_CONNECT_API_KEY_BASE64, IOS_APP_STORE_CONNECT_API_KEY_ID, and IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID.' >&2
+            exit 1
+          fi
+          key_path="$RUNNER_TEMP/AuthKey_${IOS_API_KEY_ID}.p8"
+          printf '%s' "$IOS_API_KEY_BASE64" | base64 -D > "$key_path"
+          chmod 600 "$key_path"
+          printf 'enabled=true\nkey_path=%s\n' "$key_path" >> "$GITHUB_OUTPUT"
+      - name: Upload iOS build to TestFlight
+        if: ${{ steps.testflight_credentials.outputs.enabled == 'true' }}
+        env:
+          TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+          IOS_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          IOS_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
+          IOS_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          IOS_API_KEY_PATH: ${{ steps.testflight_credentials.outputs.key_path }}
+          METASEQUOIA_PROJECT_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          export METASEQUOIA_IOS_TEAM_ID="$IOS_TEAM_ID"
+          export METASEQUOIA_IOS_AUTH_KEY_ID="$IOS_API_KEY_ID"
+          export METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID="$IOS_API_KEY_ISSUER_ID"
+          export METASEQUOIA_IOS_AUTH_KEY_PATH="$IOS_API_KEY_PATH"
+          exec "$RUNNER_TEMP/package-ios-testflight.sh" "$TAG_NAME"
       - name: Detect the Sparkle update key
         id: sparkle
         env:

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -30,3 +30,22 @@ The host app exposes the same input-scheme setting as a native segmented control
 The host app also exposes a simplified/traditional output setting, shared through the same App Group and defaulting to simplified. The engine and the packaged dictionary keep their original simplified strings; only the candidates shown in the keyboard and the text it commits are converted, through Core Foundation's `Simplified-Traditional` transform. Candidate selection continues to use engine indexes, and the preedit is left alone because it carries pinyin rather than Chinese output.
 
 `prepare_dictionary.py` first builds the canonical database, then retains all single-syllable entries and common multi-syllable entries with weight 2000 or greater. The generated database and its SHA-256 sidecar are ignored build artifacts. At runtime the extension atomically installs a changed bundled database into its private writable Application Support directory, keeping dictionary access local without requesting Open Access.
+
+## TestFlight publishing
+
+The public release assets remain unsigned and reproducible. When the repository has all three
+`IOS_APP_STORE_CONNECT_API_KEY_BASE64`, `IOS_APP_STORE_CONNECT_API_KEY_ID`, and
+`IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID` Actions secrets, `release.yml` additionally uses Xcode
+automatic signing on the macOS runner and uploads a distribution-signed build to TestFlight. The
+API key must be a Team API key with permission to manage signing assets; the App ID records must exist for
+`com.houko.metasequoiaime.ios` and `com.houko.metasequoiaime.ios.keyboard`.
+
+To create the base64 secret without printing the private key:
+
+```sh
+openssl base64 -A -in AuthKey_<KEY_ID>.p8 | pbcopy
+```
+
+The issuer ID and key ID are entered as plain text in their respective secrets. The workflow uses
+the existing `MACOS_NOTARY_TEAM_ID` secret for the Apple Developer team ID because both workflows
+belong to the same team.

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -18,6 +18,7 @@ settings:
     # target without it links as a bare `-l` and builds products named `.xctest` or `-Runner.app`.
     # Targets that publish a different product name still override this below.
     PRODUCT_NAME: $(TARGET_NAME)
+    DEVELOPMENT_TEAM: LXCL4Z68GU
 
 targets:
   MetasequoiaAppleBridge:
@@ -102,6 +103,7 @@ targets:
         CODE_SIGN_ENTITLEMENTS: $(PROJECT_DIR)/../../platforms/ios/App/Resources/MetasequoiaImeIOS.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios
         PRODUCT_NAME: MetasequoiaIME
+        CODE_SIGN_STYLE: Automatic
     dependencies:
       - target: MetasequoiaKeyboard
 
@@ -126,6 +128,7 @@ targets:
         CODE_SIGN_ENTITLEMENTS: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Resources/MetasequoiaKeyboard.entitlements
         PRODUCT_BUNDLE_IDENTIFIER: com.houko.metasequoiaime.ios.keyboard
         PRODUCT_NAME: MetasequoiaKeyboard
+        CODE_SIGN_STYLE: Automatic
         SWIFT_OBJC_BRIDGING_HEADER: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Sources/MetasequoiaKeyboard-Bridging-Header.h
         HEADER_SEARCH_PATHS:
           - $(inherited)

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a distribution-signed iOS archive with Xcode cloud signing and upload its IPA to
+# App Store Connect. The existing package_ios_archive.sh intentionally remains the reproducible,
+# unsigned release artifact; this script is the TestFlight-only path.
+
+project_root=${METASEQUOIA_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}
+project_root=$(cd "$project_root" && pwd)
+tag_name=${1:-}
+
+: "${METASEQUOIA_IOS_TEAM_ID:?METASEQUOIA_IOS_TEAM_ID is required}"
+: "${METASEQUOIA_IOS_AUTH_KEY_ID:?METASEQUOIA_IOS_AUTH_KEY_ID is required}"
+: "${METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID:?METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID is required}"
+: "${METASEQUOIA_IOS_AUTH_KEY_PATH:?METASEQUOIA_IOS_AUTH_KEY_PATH is required}"
+
+if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    printf '%s\n' 'Tag must use the vMAJOR.MINOR.PATCH format.' >&2
+    exit 1
+fi
+if [[ ! -s "$METASEQUOIA_IOS_AUTH_KEY_PATH" ]]; then
+    printf 'App Store Connect API key not found at %s\n' "$METASEQUOIA_IOS_AUTH_KEY_PATH" >&2
+    exit 1
+fi
+
+for tool in xcodegen xcodebuild xcrun; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        printf 'Required tool is missing: %s\n' "$tool" >&2
+        exit 1
+    fi
+done
+
+spec="$project_root/platforms/ios/project.yml"
+dictionary="$project_root/platforms/ios/KeyboardExtension/Resources/msime.db"
+if [[ ! -f "$spec" ]]; then
+    printf 'iOS project spec not found at %s\n' "$spec" >&2
+    exit 1
+fi
+if [[ ! -s "$dictionary" ]]; then
+    printf 'iOS dictionary not found at %s. Run platforms/ios/scripts/prepare_dictionary.py first.\n' "$dictionary" >&2
+    exit 1
+fi
+
+version=${tag_name#v}
+build_root="$project_root/build/ios-testflight"
+archive_path="$build_root/MetasequoiaIME.xcarchive"
+export_path="$build_root/export"
+rm -rf -- "$build_root"
+mkdir -p "$build_root" "$export_path"
+
+xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
+
+xcodebuild archive \
+    -project "$build_root/MetasequoiaImeIOS.xcodeproj" \
+    -scheme MetasequoiaImeIOS \
+    -configuration Release \
+    -destination 'generic/platform=iOS' \
+    -archivePath "$archive_path" \
+    -derivedDataPath "$build_root/derived" \
+    MARKETING_VERSION="$version" \
+    CURRENT_PROJECT_VERSION="$version" \
+    CODE_SIGNING_ALLOWED=YES \
+    CODE_SIGNING_REQUIRED=YES \
+    CODE_SIGN_STYLE=Automatic \
+    DEVELOPMENT_TEAM="$METASEQUOIA_IOS_TEAM_ID" \
+    -allowProvisioningUpdates \
+    -authenticationKeyPath "$METASEQUOIA_IOS_AUTH_KEY_PATH" \
+    -authenticationKeyID "$METASEQUOIA_IOS_AUTH_KEY_ID" \
+    -authenticationKeyIssuerID "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID"
+
+application="$archive_path/Products/Applications/MetasequoiaIME.app"
+extension="$application/PlugIns/MetasequoiaKeyboard.appex"
+if [[ ! -d "$application" || ! -d "$extension" ]]; then
+    printf '%s\n' 'Signed archive is missing the host application or keyboard extension.' >&2
+    exit 1
+fi
+
+export_options="$build_root/ExportOptions.plist"
+cat > "$export_options" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>$METASEQUOIA_IOS_TEAM_ID</string>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+xcodebuild -exportArchive \
+    -archivePath "$archive_path" \
+    -exportPath "$export_path" \
+    -exportOptionsPlist "$export_options" \
+    -allowProvisioningUpdates \
+    -authenticationKeyPath "$METASEQUOIA_IOS_AUTH_KEY_PATH" \
+    -authenticationKeyID "$METASEQUOIA_IOS_AUTH_KEY_ID" \
+    -authenticationKeyIssuerID "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID"
+
+ipa=$(find "$export_path" -maxdepth 1 -type f -name '*.ipa' -print -quit)
+if [[ -z "$ipa" ]]; then
+    printf '%s\n' 'Xcode export did not produce an IPA.' >&2
+    exit 1
+fi
+
+xcrun altool \
+    --upload-app \
+    --file "$ipa" \
+    --type ios \
+    --api-key "$METASEQUOIA_IOS_AUTH_KEY_ID" \
+    --api-issuer "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID" \
+    --p8-file-path "$METASEQUOIA_IOS_AUTH_KEY_PATH"
+
+printf 'Uploaded %s to TestFlight.\n' "$tag_name"


### PR DESCRIPTION
## Summary
- add the signed iOS archive/export/upload path for TestFlight
- use the existing App Store Connect API key and Apple team secrets in release automation
- keep the unsigned reproducible iOS archive as the public release artifact

## Verification
- `python3 platforms/ios/tests/ProjectConfigurationTests.py`
- `python3 platforms/ios/tests/DictionaryPackagingTests.py`
- `actionlint .github/workflows/release.yml`
- `bash -n platforms/ios/scripts/package_ios_testflight.sh`
- `git diff --check`
