### PR TITLE
chore(ci): sync workflows to main

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,37 @@
+name: Branch guard
+
+# main is the release branch: it only moves when develop is promoted for a release, or when
+# release-please lands the version commit it generates on top of that promotion. Everything else
+# targets develop.
+#
+# This is a check rather than a ruleset rule because GitHub rulesets can protect a base branch but
+# cannot say which head branches may target it. Add it to main's required status checks so a pull
+# request opened against the wrong base cannot be merged.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  base:
+    name: Base branch
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check the head branch may target main
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            develop | release/* | release-please--*)
+              echo "$HEAD_REF may target main."
+              ;;
+            *)
+              echo "::error::'$HEAD_REF' cannot target main. Day-to-day changes are merged into develop; main only receives develop promotions and release-please version branches. Retarget this pull request at develop."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
   workflow_dispatch:
@@ -16,7 +17,7 @@ on:
   merge_group:
 
 concurrency:
-  # Keyed by event as well as branch: the release scripts dispatch this workflow and wait on that exact run, so a pull_request run on the same branch must not cancel it. Feature branches only ever get the pull_request run (push is restricted to main), so this still collapses superseded runs of the same kind.
+  # Keyed by event as well as branch: the release scripts dispatch this workflow and wait on that exact run, so a pull_request run on the same branch must not cancel it. Feature branches only ever get the pull_request run (push is restricted to develop and main), so this still collapses superseded runs of the same kind.
   group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
   pull_request:
   schedule:
     - cron: '47 3 * * 1'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # This job must not skip. It is one of main's required status checks, and a required check that reports "skipped" blocks a merge instead of passing it. Guarding it on the pull_request event leaves the release pull request unmergeable by its own automation: the release workflow dispatches ci.yml on the release branch, so this job sees workflow_dispatch and skips, and the merge is refused with "the base branch policy prohibits the merge" after everything else comes back green. MSIME-Windows hit exactly that and fixed it the same way.
+      # This job must not skip. It is one of the required status checks on main and develop, and a required check that reports "skipped" blocks a merge instead of passing it. Guarding it on the pull_request event leaves the release pull request unmergeable by its own automation: the release workflow dispatches ci.yml on the release branch, so this job sees workflow_dispatch and skips, and the merge is refused with "the base branch policy prohibits the merge" after everything else comes back green. MSIME-Windows hit exactly that and fixed it the same way.
       #
       # A pull_request event supplies both refs on its own. Every other trigger has to be told what to compare, and comparing the default branch against the checked-out commit is the same question the pull request asks.
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -53,7 +53,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("cancel-in-progress: true", workflow)
         # merge-release-pr.sh dispatches ci.yml and waits on that run with --exit-status, so a pull_request run on the same branch must land in a different concurrency group or it cancels the release.
         self.assertIn("${{ github.event_name }}", workflow.split("concurrency:", 1)[1].split("permissions:", 1)[0])
-        self.assertIn("on:\n  push:\n    branches:\n      - main\n  pull_request:\n", workflow)
+        self.assertIn("on:\n  push:\n    branches:\n      - develop\n      - main\n  pull_request:\n", workflow)
 
     def test_current_repository_links_use_the_canonical_apple_repository(self):
         canonical_repository = "https://github.com/metasequoiaime/MSIME-Apple"
@@ -345,10 +345,15 @@ class ReleaseConfigurationTests(unittest.TestCase):
             "github/codeql-action/analyze",
         }
         used_actions = set()
-        for workflow_path in (PROJECT_ROOT / ".github/workflows").glob("*.yml"):
+        # The guard against a broken glob or parse counts the whole tree rather than each file:
+        # branch-guard.yml is a shell-only check and legitimately uses no action at all.
+        workflow_paths = sorted((PROJECT_ROOT / ".github/workflows").glob("*.yml"))
+        self.assertGreater(len(workflow_paths), 0)
+        parsed_uses = 0
+        for workflow_path in workflow_paths:
             uses_lines = [line.strip().removeprefix("- ") for line in workflow_path.read_text().splitlines()
                           if line.strip().removeprefix("- ").startswith("uses:")]
-            self.assertGreater(len(uses_lines), 0)
+            parsed_uses += len(uses_lines)
             for uses_line in uses_lines:
                 action_reference = uses_line.removeprefix("uses:").strip().split()[0]
                 if action_reference.startswith("./"):
@@ -361,6 +366,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 self.assertIn(action, allowed_actions)
                 self.assertRegex(revision, r"^[0-9a-f]{40}$")
                 used_actions.add(action)
+        self.assertGreater(parsed_uses, 0)
         self.assertEqual(used_actions, allowed_actions)
         self.assertIn("steps.release.outputs.release_created", workflow)
         self.assertIn("run: bash platforms/macos/scripts/merge-release-pr.sh", workflow)


### PR DESCRIPTION
Brings `.github/workflows/` on `main` up to what `develop` already has. This is a workflow-only sync; no source, docs or version files change.

Two of these only work if they are on `main`:

- **`release.yml` runs from `main`.** The `target-branch: main` fix landed on `develop`, but the workflow that actually executes on a `main` push is the copy on `main`. Until this merges, release-please still opens the version pull request, the changelog and the tag against the default branch, which is now `develop`. MSIME-Engine already produced one such stray pull request before the fix.
- **`branch-guard.yml` is evaluated from the base branch.** GitHub loads workflows for a `pull_request` event from the base, so a pull request targeting `main` sees `main`'s workflow set. With the guard only on `develop`, nothing stops a feature branch from targeting `main` — which is exactly what happened three times in MSIME-Apple during the switch.

The `develop` push triggers and the comment updates come along because they live in the same files; keeping both branches on one workflow definition is also what avoids the next promotion showing a spurious diff.

## Verification

- `SHELLCHECK_OPTS=--severity=warning actionlint` clean.
- Files are byte-identical to `develop`, so the next `develop` to `main` promotion carries no workflow diff.
