### PR TITLE
fix(ios): use distribution signing for TestFlight archive

### DIFF
--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -50,6 +50,8 @@ mkdir -p "$build_root" "$export_path"
 
 xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
 
+# Explicit distribution signing is required here. Without it Xcode chooses Apple Development for
+# the archive, then exportArchive cannot find a distribution profile for the host or extension.
 xcodebuild archive \
     -project "$build_root/MetasequoiaImeIOS.xcodeproj" \
     -scheme MetasequoiaImeIOS \
@@ -62,6 +64,7 @@ xcodebuild archive \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \
     CODE_SIGN_STYLE=Automatic \
+    CODE_SIGN_IDENTITY="Apple Distribution" \
     DEVELOPMENT_TEAM="$METASEQUOIA_IOS_TEAM_ID" \
     -allowProvisioningUpdates \
     -authenticationKeyPath "$METASEQUOIA_IOS_AUTH_KEY_PATH" \

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -167,6 +167,16 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: app.msime.ios.keyboard\n", project)
         self.assertIn("deploymentTarget:\n    iOS: \"15.0\"", project)
 
+    def test_testflight_archive_requests_distribution_signing(self):
+        script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()
+
+        # Automatic signing otherwise selects Apple Development for the archive. That archive can
+        # be signed successfully but exportArchive then has no distribution profiles to use for
+        # the host or keyboard extension.
+        self.assertIn('CODE_SIGN_IDENTITY="Apple Distribution"', script)
+        self.assertIn('<string>app-store-connect</string>', script)
+        self.assertIn('<string>automatic</string>', script)
+
     def test_keyboard_is_local_and_declares_the_system_extension_contract(self):
         with (IOS_ROOT / "KeyboardExtension/Resources/Info.plist").open("rb") as info_file:
             info = plistlib.load(info_file)


### PR DESCRIPTION
## Summary
- force the TestFlight archive to use `Apple Distribution` signing
- keep automatic provisioning for the host app and keyboard extension
- add a regression assertion for the signing mode

## Why
The archive previously defaulted to `Apple Development`, so `xcodebuild -exportArchive` could not find distribution profiles for `app.msime.ios` and `app.msime.ios.keyboard`.

## Verification
- `bash -n platforms/ios/scripts/package_ios_testflight.sh`
- `python3 platforms/ios/tests/ProjectConfigurationTests.py` (40 tests)
- `git diff --check`
