### PR TITLE
fix(ios): remove conflicting TestFlight signing identity

### DIFF
--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -50,8 +50,8 @@ mkdir -p "$build_root" "$export_path"
 
 xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
 
-# Explicit distribution signing is required here. Without it Xcode chooses Apple Development for
-# the archive, then exportArchive cannot find a distribution profile for the host or extension.
+# Keep signing automatic so Xcode can use the App Store Connect profiles for both the host app and
+# keyboard extension. CODE_SIGN_STYLE=Automatic must not be paired with a manual identity.
 xcodebuild archive \
     -project "$build_root/MetasequoiaImeIOS.xcodeproj" \
     -scheme MetasequoiaImeIOS \
@@ -64,7 +64,6 @@ xcodebuild archive \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \
     CODE_SIGN_STYLE=Automatic \
-    CODE_SIGN_IDENTITY="Apple Distribution" \
     DEVELOPMENT_TEAM="$METASEQUOIA_IOS_TEAM_ID" \
     -allowProvisioningUpdates \
     -authenticationKeyPath "$METASEQUOIA_IOS_AUTH_KEY_PATH" \

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -167,13 +167,11 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: app.msime.ios.keyboard\n", project)
         self.assertIn("deploymentTarget:\n    iOS: \"15.0\"", project)
 
-    def test_testflight_archive_requests_distribution_signing(self):
+    def test_testflight_archive_uses_automatic_signing(self):
         script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()
 
-        # Automatic signing otherwise selects Apple Development for the archive. That archive can
-        # be signed successfully but exportArchive then has no distribution profiles to use for
-        # the host or keyboard extension.
-        self.assertIn('CODE_SIGN_IDENTITY="Apple Distribution"', script)
+        self.assertNotIn('CODE_SIGN_IDENTITY="Apple Distribution"', script)
+        self.assertIn("CODE_SIGN_STYLE=Automatic", script)
         self.assertIn('<string>app-store-connect</string>', script)
         self.assertIn('<string>automatic</string>', script)
 


### PR DESCRIPTION
CI archive failed because the TestFlight script passed CODE_SIGN_IDENTITY="Apple Distribution" while the generated targets use CODE_SIGN_STYLE=Automatic.

This removes the manual identity override and keeps automatic App Store Connect signing for the host app and keyboard extension. The iOS project configuration tests pass locally.