### PR TITLE
feat(contracts): sync engine punctuation and product lock contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Validate the product lock
         run: |
           python3 scripts/check-dictionary-contract.py
+          python3 scripts/check-product-lock-contract.py
           python3 scripts/product_lock.py validate
           python3 platforms/macos/tests/ProductLockTests.py
       # The unit tests run against a fixture rather than the released database: they assert behaviour

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -23,6 +23,7 @@
 #include "CandidateSelectionState.h"
 #include "InputControllerKeyRouting.h"
 #include <metasequoia/session.h>
+#include "../../../vendor/MetasequoiaImeEngine/contracts/punctuation/policy.h"
 
 #import <Carbon/Carbon.h>
 
@@ -601,15 +602,9 @@ bool SessionMatchesPreferences(const metasequoia::SessionOptions &options, const
                     }
                 }
             }
-            // Mirrors the engine's own switch in handle_punctuation. ` $ ^ _ were added there
-            // alongside < >, and only the latter pair was picked up here, so those four kept
-            // inserting ASCII while 中文标点 was on. handle_punctuation returns an unhandled result
-            // when the preference is off, which leaves the existing ASCII and full-width fallback
-            // in charge exactly as before.
-            else if (character == ',' || character == '.' || character == '?' || character == '!' || character == ';' ||
-                     character == ':' || character == '"' || character == '\'' || character == '(' ||
-                     character == ')' || character == '[' || character == ']' || character == '<' || character == '>' ||
-                     character == '\\' || character == '`' || character == '$' || character == '^' || character == '_')
+            // Keep the host's routing predicate tied to the Engine punctuation contract. The
+            // Session still owns translation and stateful quote/book-title behaviour.
+            else if (metasequoia::punctuation_contract::is_supported(static_cast<char>(character)))
             {
                 result = _session->punctuation(static_cast<char>(character));
             }

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -264,31 +264,26 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("x-release-please-version", project_line)
 
     def test_punctuation_dispatch_matches_the_pinned_engine_table(self):
-        # The controller forwards a hardcoded set of characters to the engine's punctuation policy.
-        # When the engine's table grew ` $ ^ _ alongside < >, only the latter pair was picked up
-        # here, so with 中文标点 on Shift+4 kept inserting $ instead of ￥ and nothing noticed —
-        # neither repository has a test that compares the two, and the engine bump that introduced
-        # the divergence merged normally. Compare them directly instead.
-        def literals(pattern, text):
-            escapes = {"\\\\": "\\", "\\'": "'", '\\"': '"'}
-            return {escapes.get(match, match) for match in re.findall(pattern, text)}
-
-        policy = (
-            PROJECT_ROOT / "vendor/MetasequoiaImeEngine/core/punctuation_policy.cpp"
-        ).read_text()
-        engine_characters = literals(r"case '(\\.|[^'])':", policy)
-
         controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
-        # The branch that reaches the engine, not the full-width or candidate-number branches.
-        branch = controller.split("_session->punctuation(", 1)[0].rsplit("else if (", 1)[1]
-        dispatched = literals(r"character == '(\\.|[^'])'", branch)
-
-        self.assertGreater(len(engine_characters), 10, "the engine punctuation table was not parsed")
-        self.assertEqual(
-            dispatched,
-            engine_characters,
-            "the controller's punctuation whitelist and the pinned engine's table disagree",
+        policy = json.loads(
+            (PROJECT_ROOT / "vendor/MetasequoiaImeEngine/contracts/punctuation/policy.json").read_text()
         )
+        engine_characters = {
+            entry["input"]
+            for section in (policy["simple"], policy["alternating"])
+            for entry in section
+        }
+        engine_characters.update(
+            (policy["nested"]["openingInput"], policy["nested"]["closingInput"])
+        )
+
+        # The host delegates the complete supported-key decision to the pinned Engine contract, so
+        # a future contract addition cannot be silently omitted from this routing branch.
+        self.assertIn(
+            "metasequoia::punctuation_contract::is_supported(static_cast<char>(character))",
+            controller,
+        )
+        self.assertGreater(len(engine_characters), 10, "the Engine punctuation contract was not parsed")
 
     def test_release_automation_bumps_tags_and_uploads_installable_assets(self):
         config = json.loads((PROJECT_ROOT / "release-please-config.json").read_text())

--- a/scripts/check-product-lock-contract.py
+++ b/scripts/check-product-lock-contract.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Reject a product-lock helper that differs from the reviewed Engine contract."""
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+engine = root / 'vendor/MetasequoiaImeEngine/contracts/product_lock.py'
+vendored = root / 'scripts/product_lock_shared.py'
+for path in (engine, vendored):
+    if not path.is_file():
+        raise SystemExit(f'{path.relative_to(root)} is missing; initialize the Engine submodule')
+if engine.read_bytes() != vendored.read_bytes():
+    raise SystemExit('Product-lock shared helper differs from the pinned Engine contract')
+print('Product-lock shared helper matches the pinned Engine contract')

--- a/scripts/product_lock.py
+++ b/scripts/product_lock.py
@@ -16,14 +16,15 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import hashlib
 import json
 import re
 import subprocess
 import tempfile
-import urllib.error
-import urllib.request
 from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import product_lock_shared as shared
 
 ROOT = Path(__file__).resolve().parents[1]
 _product_spec = importlib.util.spec_from_file_location("dictionary_product", Path(__file__).with_name("dictionary_product.py"))
@@ -85,29 +86,16 @@ def write_json(path: Path, data: dict) -> None:
 
 
 def sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as source:
-        for chunk in iter(lambda: source.read(1 << 20), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+    return shared.sha256(path)
 
 
 def verify_assets(directory: Path, data: dict) -> None:
     """Fail on the committed digest, never on the checksum file that shipped with the data."""
-    for name, expected in data["dictionary"]["assets"].items():
-        path = directory / name
-        if not path.is_file():
-            raise ValueError(f"Locked dictionary asset is missing: {name}")
-        actual = sha256(path)
-        if actual != expected:
-            raise ValueError(f"{name} does not match the product lock: expected {expected}, got {actual}")
+    shared.verify_digests(directory, data["dictionary"]["assets"])
 
     if PRODUCT_MANIFEST in data["dictionary"]["assets"]:
-        manifest = _product.verify_product(directory, "desktop", DATABASES)
-        source = manifest.get("source", {})
-        if (source.get("repository") != data["dictionary"]["repository"] or
-                source.get("commit") != data["dictionary"]["source_commit"] or source.get("dirty") is not False):
-            raise ValueError("Dictionary manifest provenance does not match the reviewed source commit")
+        shared.verify_manifest_provenance(directory, PRODUCT_MANIFEST, _product.verify_product, DATABASES,
+                                          data["dictionary"]["repository"], data["dictionary"]["source_commit"])
 
 
 def download_assets(tag: str, destination: Path, repository: str = DICTIONARY_REPOSITORY) -> None:
@@ -124,18 +112,7 @@ def download_assets(tag: str, destination: Path, repository: str = DICTIONARY_RE
     for name in names:
         url = f"https://github.com/{repository}/releases/download/{tag}/{name}"
         target = destination / name
-        last_error: Exception | None = None
-        for attempt in range(1, 4):
-            try:
-                with urllib.request.urlopen(url, timeout=120) as response, target.open("wb") as out:
-                    while chunk := response.read(1 << 20):
-                        out.write(chunk)
-                break
-            except (urllib.error.URLError, TimeoutError, OSError) as error:
-                last_error = error
-                print(f"  attempt {attempt} for {name} failed: {error}")
-        else:
-            raise ValueError(f"Could not download {url}: {last_error}")
+        shared.download_with_retries(url, target)
         print(f"downloaded {name} ({target.stat().st_size} bytes)")
 
 
@@ -146,32 +123,11 @@ def resolve_tag_commit(tag: str) -> str:
 
     Both refs are requested by name. ls-remote filters on the ref as written, and the peeled ref is literally named refs/tags/<tag>^{}, so asking only for refs/tags/<tag> gets an annotated tag's tag object and nothing else. A trailing glob would return the peeled ref too, but it would also match dict-2026.01.01-rc1.
     """
-    if not TAG.fullmatch(tag):
-        raise ValueError("Refusing to resolve a tag that is not an explicit dict-* release")
-    output = subprocess.check_output(
-        ["git", "ls-remote", DICTIONARY_URL, f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"], text=True
-    )
-    references = {}
-    for line in output.splitlines():
-        commit, _, reference = line.partition("\t")
-        references[reference.strip()] = commit.strip()
-    # An annotated tag lists the tag object under the plain name and the commit it points at under
-    # ^{}; a lightweight one only has the plain reference. Locking the tag object's own SHA would
-    # record something that is not a commit in MSIME-Dict's history at all, and it is 40 hex digits
-    # like any other object, so nothing downstream would notice.
-    commit = references.get(f"refs/tags/{tag}^{{}}") or references.get(f"refs/tags/{tag}")
-    if not commit or not SHA.fullmatch(commit):
-        raise ValueError(f"{tag} does not resolve to a commit in {DICTIONARY_REPOSITORY}")
-    return commit
+    return shared.resolve_tag_commit(DICTIONARY_URL, tag)
 
 
 def published_checksums(directory: Path) -> dict[str, str]:
-    checksums = {}
-    for line in (directory / "SHA256SUMS.txt").read_text(encoding="utf-8").splitlines():
-        digest, _, name = line.partition("  ")
-        if name.strip():
-            checksums[name.strip()] = digest.strip()
-    return checksums
+    return shared.published_checksums(directory / "SHA256SUMS.txt")
 
 
 def git(directory: Path, *args: str) -> str:

--- a/scripts/product_lock_shared.py
+++ b/scripts/product_lock_shared.py
@@ -1,0 +1,122 @@
+"""Shared primitives for platform product locks.
+
+Platform locks keep their repository-specific constants and command-line interface, but vendor this
+module for the security-sensitive digest, manifest, download and tag-resolution operations. A
+consumer must compare its vendored copy byte-for-byte with this file in CI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Callable, Mapping
+
+SHA = re.compile(r"[0-9a-f]{40}\Z")
+TAG = re.compile(r"dict-[A-Za-z0-9._-]+\Z")
+
+
+def _asset_path(directory: Path, name: str) -> Path:
+    path = PurePosixPath(name)
+    if path.is_absolute() or len(path.parts) != 1 or path.parts[0] in ("", ".", "..") or "\\" in name:
+        raise ValueError(f"Invalid product asset name: {name}")
+    return directory / path.parts[0]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_digests(directory: Path, expected: Mapping[str, str]) -> None:
+    """Verify every locked asset without trusting a checksum file shipped beside it."""
+    directory = Path(directory)
+    for name, digest in expected.items():
+        path = _asset_path(directory, name)
+        if not path.is_file():
+            raise ValueError(f"Locked product asset is missing: {name}")
+        actual = sha256(path)
+        if actual != digest:
+            raise ValueError(f"{name} does not match the product lock: expected {digest}, got {actual}")
+
+
+def verify_manifest_provenance(
+    directory: Path,
+    manifest_name: str,
+    verify_product: Callable[..., dict],
+    required_files: set[str] | tuple[str, ...],
+    repository: str,
+    commit: str,
+) -> dict:
+    """Validate a dictionary manifest and bind its source to the product lock."""
+    manifest = verify_product(directory, "desktop", required_files)
+    source = manifest.get("source", {})
+    if (source.get("repository") != repository or source.get("commit") != commit or
+            source.get("dirty") is not False):
+        raise ValueError(f"{manifest_name} provenance does not match the product lock")
+    return manifest
+
+
+def published_checksums(path: Path) -> dict[str, str]:
+    """Read the conventional two-space-separated SHA256SUMS.txt format."""
+    checksums = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        digest, separator, name = line.partition("  ")
+        if separator and name.strip():
+            name = name.strip()
+            if name in checksums:
+                raise ValueError(f"Duplicate published checksum entry: {name}")
+            checksums[name] = digest.strip()
+    return checksums
+
+
+def download_with_retries(url: str, target: Path, *, attempts: int = 3, timeout: int = 120) -> None:
+    """Download one asset atomically, retrying transient URL and filesystem failures."""
+    if attempts < 1 or timeout <= 0:
+        raise ValueError("Download attempts and timeout must be positive")
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    last_error: Exception | None = None
+    for _ in range(attempts):
+        temporary_name: str | None = None
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:
+                with tempfile.NamedTemporaryFile(dir=target.parent, delete=False) as temporary:
+                    temporary_name = temporary.name
+                    for chunk in iter(lambda: response.read(1 << 20), b""):
+                        temporary.write(chunk)
+            os.replace(temporary_name, target)
+            return
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            last_error = error
+            if temporary_name:
+                try:
+                    Path(temporary_name).unlink()
+                except OSError:
+                    pass
+    raise ValueError(f"Could not download {url}: {last_error}") from last_error
+
+
+def resolve_tag_commit(repository_url: str, tag: str) -> str:
+    """Resolve an explicit tag to a commit using git's unauthenticated read-only protocol."""
+    if not TAG.fullmatch(tag):
+        raise ValueError("Tag must be an explicit dict-* release")
+    output = subprocess.check_output(
+        ["git", "ls-remote", repository_url, f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"], text=True
+    )
+    references = {}
+    for line in output.splitlines():
+        commit, _, reference = line.partition("\t")
+        references[reference.strip()] = commit.strip()
+    commit = references.get(f"refs/tags/{tag}^{{}}") or references.get(f"refs/tags/{tag}")
+    if not commit or not SHA.fullmatch(commit):
+        raise ValueError(f"{tag} does not resolve to a commit in {repository_url}")
+    return commit


### PR DESCRIPTION
## Summary
- consume the Engine punctuation contract directly instead of maintaining a hand-written macOS table
- vendor the shared product-lock implementation and verify it byte-for-byte against the pinned Engine contract
- pin vendor/MetasequoiaImeEngine to Engine main at b411f68d9b0bf3e18c858ea725a241efbd8b3bb1

## Verification
- Apple build passed
- Apple CTest: 40/40
- ProductLockTests: 15/15
- contract and formatting checks passed

Addresses metasequoiaime/MSIME-Engine#47 and #48.