### PR TITLE
fix(ios): use distribution profiles for TestFlight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,21 +265,29 @@ jobs:
           IOS_API_KEY_BASE64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_BASE64 }}
           IOS_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
           IOS_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          IOS_APP_PROFILE_BASE64: ${{ secrets.IOS_APP_PROVISIONING_PROFILE_BASE64 }}
+          IOS_KEYBOARD_PROFILE_BASE64: ${{ secrets.IOS_KEYBOARD_PROVISIONING_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
-          if [[ -z "${IOS_API_KEY_BASE64:-}" && -z "${IOS_API_KEY_ID:-}" && -z "${IOS_API_KEY_ISSUER_ID:-}" ]]; then
+          if [[ -z "${IOS_API_KEY_BASE64:-}" && -z "${IOS_API_KEY_ID:-}" && -z "${IOS_API_KEY_ISSUER_ID:-}" && -z "${IOS_APP_PROFILE_BASE64:-}" && -z "${IOS_KEYBOARD_PROFILE_BASE64:-}" ]]; then
             printf 'enabled=false\n' >> "$GITHUB_OUTPUT"
             echo 'TestFlight upload skipped: App Store Connect API Key secrets are not configured.' >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          if [[ -z "${IOS_API_KEY_BASE64:-}" || -z "${IOS_API_KEY_ID:-}" || -z "${IOS_API_KEY_ISSUER_ID:-}" ]]; then
-            echo 'TestFlight upload requires IOS_APP_STORE_CONNECT_API_KEY_BASE64, IOS_APP_STORE_CONNECT_API_KEY_ID, and IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID.' >&2
+          if [[ -z "${IOS_API_KEY_BASE64:-}" || -z "${IOS_API_KEY_ID:-}" || -z "${IOS_API_KEY_ISSUER_ID:-}" || -z "${IOS_APP_PROFILE_BASE64:-}" || -z "${IOS_KEYBOARD_PROFILE_BASE64:-}" ]]; then
+            echo 'TestFlight upload requires the three App Store Connect API key secrets and both iOS provisioning profile secrets.' >&2
             exit 1
           fi
           key_path="$RUNNER_TEMP/AuthKey_${IOS_API_KEY_ID}.p8"
           printf '%s' "$IOS_API_KEY_BASE64" | base64 -D > "$key_path"
           chmod 600 "$key_path"
-          printf 'enabled=true\nkey_path=%s\n' "$key_path" >> "$GITHUB_OUTPUT"
+          app_profile_path="$RUNNER_TEMP/MSIME_iOS_TestFlight.mobileprovision"
+          keyboard_profile_path="$RUNNER_TEMP/MSIME_iOS_Keyboard_TestFlight.mobileprovision"
+          printf '%s' "$IOS_APP_PROFILE_BASE64" | base64 -D > "$app_profile_path"
+          printf '%s' "$IOS_KEYBOARD_PROFILE_BASE64" | base64 -D > "$keyboard_profile_path"
+          chmod 600 "$app_profile_path" "$keyboard_profile_path"
+          printf 'enabled=true\nkey_path=%s\napp_profile_path=%s\nkeyboard_profile_path=%s\n' \
+            "$key_path" "$app_profile_path" "$keyboard_profile_path" >> "$GITHUB_OUTPUT"
       - name: Upload iOS build to TestFlight
         if: ${{ steps.testflight_credentials.outputs.enabled == 'true' }}
         env:
@@ -288,6 +296,8 @@ jobs:
           IOS_API_KEY_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ID }}
           IOS_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           IOS_API_KEY_PATH: ${{ steps.testflight_credentials.outputs.key_path }}
+          IOS_APP_PROFILE_PATH: ${{ steps.testflight_credentials.outputs.app_profile_path }}
+          IOS_KEYBOARD_PROFILE_PATH: ${{ steps.testflight_credentials.outputs.keyboard_profile_path }}
           METASEQUOIA_PROJECT_ROOT: ${{ github.workspace }}
         run: |
           set -euo pipefail
@@ -295,6 +305,8 @@ jobs:
           export METASEQUOIA_IOS_AUTH_KEY_ID="$IOS_API_KEY_ID"
           export METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID="$IOS_API_KEY_ISSUER_ID"
           export METASEQUOIA_IOS_AUTH_KEY_PATH="$IOS_API_KEY_PATH"
+          export METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH="$IOS_APP_PROFILE_PATH"
+          export METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH="$IOS_KEYBOARD_PROFILE_PATH"
           exec "$RUNNER_TEMP/package-ios-testflight.sh" "$TAG_NAME"
       - name: Detect the Sparkle update key
         id: sparkle

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -35,10 +35,11 @@ The host app also exposes a simplified/traditional output setting, shared throug
 
 The public release assets remain unsigned and reproducible. When the repository has all three
 `IOS_APP_STORE_CONNECT_API_KEY_BASE64`, `IOS_APP_STORE_CONNECT_API_KEY_ID`, and
-`IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID` Actions secrets, `release.yml` additionally uses Xcode
-automatic signing on the macOS runner and uploads a distribution-signed build to TestFlight. The
-API key must be a Team API key with permission to manage signing assets; the App ID records must exist for
-`app.msime.ios` and `app.msime.ios.keyboard`.
+`IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID` plus the two distribution profile secrets
+`IOS_APP_PROVISIONING_PROFILE_BASE64` and `IOS_KEYBOARD_PROVISIONING_PROFILE_BASE64`, `release.yml`
+uses the matching distribution profiles on the macOS runner and uploads the build to TestFlight. The
+API key must be a Team API key with permission to manage signing assets; the App ID records and the
+profiles must exist for `app.msime.ios` and `app.msime.ios.keyboard`.
 
 To create the base64 secret without printing the private key:
 

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -104,6 +104,11 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: app.msime.ios
         PRODUCT_NAME: MetasequoiaIME
         CODE_SIGN_STYLE: Automatic
+      configs:
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER: MSIME iOS TestFlight v2
     dependencies:
       - target: MetasequoiaKeyboard
 
@@ -133,6 +138,11 @@ targets:
         HEADER_SEARCH_PATHS:
           - $(inherited)
           - $(PROJECT_DIR)/../../shared/apple-bridge
+      configs:
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER: MSIME iOS Keyboard TestFlight
     dependencies:
       - target: MetasequoiaAppleBridge
       - sdk: libsqlite3.tbd

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build a distribution-signed iOS archive with Xcode cloud signing and upload its IPA to
-# App Store Connect. The existing package_ios_archive.sh intentionally remains the reproducible,
-# unsigned release artifact; this script is the TestFlight-only path.
+# Build a distribution-signed iOS archive with checked-in project settings and downloaded profiles,
+# then upload its IPA to App Store Connect. The existing package_ios_archive.sh intentionally remains
+# the reproducible, unsigned release artifact; this script is the TestFlight-only path.
 
 project_root=${METASEQUOIA_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}
 project_root=$(cd "$project_root" && pwd)
@@ -13,6 +13,8 @@ tag_name=${1:-}
 : "${METASEQUOIA_IOS_AUTH_KEY_ID:?METASEQUOIA_IOS_AUTH_KEY_ID is required}"
 : "${METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID:?METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID is required}"
 : "${METASEQUOIA_IOS_AUTH_KEY_PATH:?METASEQUOIA_IOS_AUTH_KEY_PATH is required}"
+: "${METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH:?METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH is required}"
+: "${METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH:?METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH is required}"
 
 if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     printf '%s\n' 'Tag must use the vMAJOR.MINOR.PATCH format.' >&2
@@ -22,6 +24,14 @@ if [[ ! -s "$METASEQUOIA_IOS_AUTH_KEY_PATH" ]]; then
     printf 'App Store Connect API key not found at %s\n' "$METASEQUOIA_IOS_AUTH_KEY_PATH" >&2
     exit 1
 fi
+for profile in \
+    "$METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH" \
+    "$METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH"; do
+    if [[ ! -s "$profile" ]]; then
+        printf 'Provisioning profile not found at %s\n' "$profile" >&2
+        exit 1
+    fi
+done
 
 for tool in xcodegen xcodebuild xcrun; do
     if ! command -v "$tool" >/dev/null 2>&1; then
@@ -50,8 +60,18 @@ mkdir -p "$build_root" "$export_path"
 
 xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
 
-# Keep signing automatic so Xcode can use the App Store Connect profiles for both the host app and
-# keyboard extension. CODE_SIGN_STYLE=Automatic must not be paired with a manual identity.
+# Install the exact distribution profiles selected by the Release configuration. Xcode's cloud
+# signing fallback can select a development profile for an automatic archive, which then cannot be
+# exported to TestFlight. The profiles are injected by the workflow and never committed.
+profiles_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
+mkdir -p "$profiles_dir"
+for profile in \
+    "$METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH" \
+    "$METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH"; do
+    uuid=$(security cms -D -i "$profile" | plutil -extract UUID raw -o - -)
+    cp "$profile" "$profiles_dir/$uuid.mobileprovision"
+done
+
 xcodebuild archive \
     -project "$build_root/MetasequoiaImeIOS.xcodeproj" \
     -scheme MetasequoiaImeIOS \
@@ -63,7 +83,8 @@ xcodebuild archive \
     CURRENT_PROJECT_VERSION="$version" \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \
-    CODE_SIGN_STYLE=Automatic \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="Apple Distribution" \
     DEVELOPMENT_TEAM="$METASEQUOIA_IOS_TEAM_ID" \
     -allowProvisioningUpdates \
     -authenticationKeyPath "$METASEQUOIA_IOS_AUTH_KEY_PATH" \
@@ -86,7 +107,7 @@ cat > "$export_options" <<EOF
     <key>method</key>
     <string>app-store-connect</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
     <key>teamID</key>
     <string>$METASEQUOIA_IOS_TEAM_ID</string>
     <key>uploadSymbols</key>

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -167,13 +167,15 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: app.msime.ios.keyboard\n", project)
         self.assertIn("deploymentTarget:\n    iOS: \"15.0\"", project)
 
-    def test_testflight_archive_uses_automatic_signing(self):
+    def test_testflight_archive_uses_distribution_profiles(self):
         script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()
 
-        self.assertNotIn('CODE_SIGN_IDENTITY="Apple Distribution"', script)
-        self.assertIn("CODE_SIGN_STYLE=Automatic", script)
+        self.assertIn('CODE_SIGN_IDENTITY="Apple Distribution"', script)
+        self.assertIn("CODE_SIGN_STYLE=Manual", script)
+        self.assertIn("METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH", script)
+        self.assertIn("METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH", script)
         self.assertIn('<string>app-store-connect</string>', script)
-        self.assertIn('<string>automatic</string>', script)
+        self.assertIn('<string>manual</string>', script)
 
     def test_keyboard_is_local_and_declares_the_system_extension_contract(self):
         with (IOS_ROOT / "KeyboardExtension/Resources/Info.plist").open("rb") as info_file:


### PR DESCRIPTION
The TestFlight archive was signing with Apple Development under automatic signing, and exportArchive then failed with cloud signing permission / no profiles errors.

This installs the two checked-in distribution profiles from Actions secrets, uses manual Release signing for the host and keyboard targets, and keeps the public iOS archive unsigned.

Validation: ProjectConfigurationTests.py (40 tests), xcodegen generation, and a local archive attempt confirmed the profile/entitlement mismatch is now surfaced for the stale host profile.