### PR TITLE
fix(release): keep missing TestFlight signing non-blocking

### DIFF
--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -60,6 +60,18 @@ mkdir -p "$build_root" "$export_path"
 
 xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
 
+skip_testflight() {
+    local reason=$1
+    printf 'TestFlight upload skipped: %s\n' "$reason" >&2
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        {
+            echo '### TestFlight upload skipped'
+            echo "$reason"
+            echo 'The unsigned iOS artifacts remain available in this release.'
+        } >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
 # Install the exact distribution profiles selected by the Release configuration. Xcode's cloud
 # signing fallback can select a development profile for an automatic archive, which then cannot be
 # exported to TestFlight. The profiles are injected by the workflow and never committed.
@@ -72,6 +84,8 @@ for profile in \
     cp "$profile" "$profiles_dir/$uuid.mobileprovision"
 done
 
+archive_log="$build_root/archive.log"
+set +e
 xcodebuild archive \
     -project "$build_root/MetasequoiaImeIOS.xcodeproj" \
     -scheme MetasequoiaImeIOS \
@@ -89,7 +103,16 @@ xcodebuild archive \
     -allowProvisioningUpdates \
     -authenticationKeyPath "$METASEQUOIA_IOS_AUTH_KEY_PATH" \
     -authenticationKeyID "$METASEQUOIA_IOS_AUTH_KEY_ID" \
-    -authenticationKeyIssuerID "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID"
+    -authenticationKeyIssuerID "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID" 2>&1 | tee "$archive_log"
+archive_status=${PIPESTATUS[0]}
+set -e
+if [[ "$archive_status" -ne 0 ]]; then
+    if grep -Eiq 'No signing certificate .* found|No profiles for |Cloud signing permission error|Provisioning profile .* doesn.t match|Provisioning profile .* doesn.t include .* entitlement|Provisioning profile .* does not include .* entitlement|requires a provisioning profile|requires a signing certificate' "$archive_log"; then
+        skip_testflight 'The configured iOS distribution certificate or provisioning profiles are unavailable or do not match the project entitlements.'
+        exit 0
+    fi
+    exit "$archive_status"
+fi
 
 application="$archive_path/Products/Applications/MetasequoiaIME.app"
 extension="$application/PlugIns/MetasequoiaKeyboard.appex"
@@ -130,13 +153,7 @@ export_status=${PIPESTATUS[0]}
 set -e
 if [[ "$export_status" -ne 0 ]]; then
     if grep -Eq 'Cloud signing permission error|No profiles for ' "$export_log"; then
-        printf '%s\n' 'TestFlight upload skipped: App Store Connect could not provide distribution profiles for the iOS targets.' >&2
-        if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-            {
-                echo '### TestFlight upload skipped'
-                echo 'The App Store Connect key could not obtain distribution profiles for the iOS targets. The unsigned iOS artifacts remain available in this release.'
-            } >> "$GITHUB_STEP_SUMMARY"
-        fi
+        skip_testflight 'App Store Connect could not provide distribution profiles for the iOS targets.'
         exit 0
     fi
     exit "$export_status"

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -184,6 +184,18 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("TestFlight upload skipped", script)
         self.assertIn("The unsigned iOS artifacts remain available in this release.", script)
 
+    def test_testflight_archive_reports_signing_configuration_failures_without_blocking_the_release(self):
+        script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()
+
+        self.assertIn('archive_log="$build_root/archive.log"', script)
+        self.assertIn("archive_status=${PIPESTATUS[0]}", script)
+        self.assertIn("No signing certificate .* found", script)
+        self.assertIn("Provisioning profile .* doesn.t match", script)
+        self.assertIn("Provisioning profile .* doesn.t include .* entitlement", script)
+        self.assertIn("Provisioning profile .* does not include .* entitlement", script)
+        self.assertIn("skip_testflight", script)
+        self.assertIn("exit \"$archive_status\"", script)
+
     def test_keyboard_is_local_and_declares_the_system_extension_contract(self):
         with (IOS_ROOT / "KeyboardExtension/Resources/Info.plist").open("rb") as info_file:
             info = plistlib.load(info_file)


### PR DESCRIPTION
## Summary
- keep unsigned iOS release artifacts publishable when TestFlight archive signing is unavailable
- report missing certificates and mismatched provisioning entitlements in the step summary
- preserve failures for unknown archive errors

## Verification
- `python3 platforms/ios/tests/ProjectConfigurationTests.py`
- `python3 platforms/ios/tests/DictionaryPackagingTests.py`
- `python3 platforms/macos/tests/ReleaseConfigurationTests.py`
- `actionlint -color`
- `bash -n platforms/ios/scripts/package_ios_testflight.sh`