### PR TITLE
chore(main): promote develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,15 +267,19 @@ jobs:
           IOS_API_KEY_ISSUER_ID: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           IOS_APP_PROFILE_BASE64: ${{ secrets.IOS_APP_PROVISIONING_PROFILE_BASE64 }}
           IOS_KEYBOARD_PROFILE_BASE64: ${{ secrets.IOS_KEYBOARD_PROVISIONING_PROFILE_BASE64 }}
+          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_SIGNING_KEYCHAIN_PASSWORD }}
+          IOS_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
         run: |
           set -euo pipefail
-          if [[ -z "${IOS_API_KEY_BASE64:-}" && -z "${IOS_API_KEY_ID:-}" && -z "${IOS_API_KEY_ISSUER_ID:-}" && -z "${IOS_APP_PROFILE_BASE64:-}" && -z "${IOS_KEYBOARD_PROFILE_BASE64:-}" ]]; then
+          if [[ -z "${IOS_API_KEY_BASE64:-}" && -z "${IOS_API_KEY_ID:-}" && -z "${IOS_API_KEY_ISSUER_ID:-}" && -z "${IOS_APP_PROFILE_BASE64:-}" && -z "${IOS_KEYBOARD_PROFILE_BASE64:-}" && -z "${IOS_CERTIFICATE_BASE64:-}" && -z "${IOS_CERTIFICATE_PASSWORD:-}" ]]; then
             printf 'enabled=false\n' >> "$GITHUB_OUTPUT"
             echo 'TestFlight upload skipped: App Store Connect API Key secrets are not configured.' >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          if [[ -z "${IOS_API_KEY_BASE64:-}" || -z "${IOS_API_KEY_ID:-}" || -z "${IOS_API_KEY_ISSUER_ID:-}" || -z "${IOS_APP_PROFILE_BASE64:-}" || -z "${IOS_KEYBOARD_PROFILE_BASE64:-}" ]]; then
-            echo 'TestFlight upload requires the three App Store Connect API key secrets and both iOS provisioning profile secrets.' >&2
+          if [[ -z "${IOS_API_KEY_BASE64:-}" || -z "${IOS_API_KEY_ID:-}" || -z "${IOS_API_KEY_ISSUER_ID:-}" || -z "${IOS_APP_PROFILE_BASE64:-}" || -z "${IOS_KEYBOARD_PROFILE_BASE64:-}" || -z "${IOS_CERTIFICATE_BASE64:-}" || -z "${IOS_CERTIFICATE_PASSWORD:-}" || -z "${IOS_KEYCHAIN_PASSWORD:-}" ]]; then
+            echo 'TestFlight upload requires the three App Store Connect API key secrets, both iOS provisioning profile secrets, the iOS distribution certificate and its password.' >&2
             exit 1
           fi
           key_path="$RUNNER_TEMP/AuthKey_${IOS_API_KEY_ID}.p8"
@@ -286,6 +290,29 @@ jobs:
           printf '%s' "$IOS_APP_PROFILE_BASE64" | base64 -D > "$app_profile_path"
           printf '%s' "$IOS_KEYBOARD_PROFILE_BASE64" | base64 -D > "$keyboard_profile_path"
           chmod 600 "$app_profile_path" "$keyboard_profile_path"
+          ios_keychain="$RUNNER_TEMP/metasequoia-ios-signing.keychain-db"
+          ios_certificate="$RUNNER_TEMP/metasequoia-ios-distribution.p12"
+          printf '%s' "$IOS_CERTIFICATE_BASE64" | base64 -D > "$ios_certificate"
+          chmod 600 "$ios_certificate"
+          security create-keychain -p "$IOS_KEYCHAIN_PASSWORD" "$ios_keychain"
+          security set-keychain-settings -lut 21600 "$ios_keychain"
+          security unlock-keychain -p "$IOS_KEYCHAIN_PASSWORD" "$ios_keychain"
+          security import "$ios_certificate" -k "$ios_keychain" -P "$IOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$IOS_KEYCHAIN_PASSWORD" "$ios_keychain"
+          security list-keychains -d user -s "$ios_keychain" "$RUNNER_TEMP/metasequoia-signing.keychain-db"
+          security default-keychain -s "$ios_keychain"
+          if ! security find-identity -v -p codesigning "$ios_keychain" | grep -Fq 'Apple Distribution:'; then
+            echo 'The configured iOS certificate does not contain an Apple Distribution identity with a private key.' >&2
+            exit 1
+          fi
+          if ! security cms -D -i "$app_profile_path" | plutil -extract Entitlements.application-identifier raw -o - - | grep -Fxq "${IOS_TEAM_ID}.app.msime.ios"; then
+            echo 'The iOS host provisioning profile does not match app.msime.ios.' >&2
+            exit 1
+          fi
+          if ! security cms -D -i "$app_profile_path" | plutil -extract Entitlements.com.apple.security.application-groups.0 raw -o - - | grep -Fxq 'group.app.msime.ios'; then
+            echo 'The iOS host provisioning profile must include group.app.msime.ios.' >&2
+            exit 1
+          fi
           printf 'enabled=true\nkey_path=%s\napp_profile_path=%s\nkeyboard_profile_path=%s\n' \
             "$key_path" "$app_profile_path" "$keyboard_profile_path" >> "$GITHUB_OUTPUT"
       - name: Upload iOS build to TestFlight

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -60,6 +60,18 @@ mkdir -p "$build_root" "$export_path"
 
 xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
 
+skip_testflight() {
+    local reason=$1
+    printf 'TestFlight upload skipped: %s\n' "$reason" >&2
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        {
+            echo '### TestFlight upload skipped'
+            echo "$reason"
+            echo 'The unsigned iOS artifacts remain available in this release.'
+        } >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
 # Install the exact distribution profiles selected by the Release configuration. Xcode's cloud
 # signing fallback can select a development profile for an automatic archive, which then cannot be
 # exported to TestFlight. The profiles are injected by the workflow and never committed.
@@ -72,6 +84,8 @@ for profile in \
     cp "$profile" "$profiles_dir/$uuid.mobileprovision"
 done
 
+archive_log="$build_root/archive.log"
+set +e
 xcodebuild archive \
     -project "$build_root/MetasequoiaImeIOS.xcodeproj" \
     -scheme MetasequoiaImeIOS \
@@ -89,7 +103,16 @@ xcodebuild archive \
     -allowProvisioningUpdates \
     -authenticationKeyPath "$METASEQUOIA_IOS_AUTH_KEY_PATH" \
     -authenticationKeyID "$METASEQUOIA_IOS_AUTH_KEY_ID" \
-    -authenticationKeyIssuerID "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID"
+    -authenticationKeyIssuerID "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID" 2>&1 | tee "$archive_log"
+archive_status=${PIPESTATUS[0]}
+set -e
+if [[ "$archive_status" -ne 0 ]]; then
+    if grep -Eiq 'No signing certificate .* found|No profiles for |Cloud signing permission error|Provisioning profile .* doesn.t match|Provisioning profile .* doesn.t include .* entitlement|Provisioning profile .* does not include .* entitlement|requires a provisioning profile|requires a signing certificate' "$archive_log"; then
+        skip_testflight 'The configured iOS distribution certificate or provisioning profiles are unavailable or do not match the project entitlements.'
+        exit 0
+    fi
+    exit "$archive_status"
+fi
 
 application="$archive_path/Products/Applications/MetasequoiaIME.app"
 extension="$application/PlugIns/MetasequoiaKeyboard.appex"
@@ -130,13 +153,7 @@ export_status=${PIPESTATUS[0]}
 set -e
 if [[ "$export_status" -ne 0 ]]; then
     if grep -Eq 'Cloud signing permission error|No profiles for ' "$export_log"; then
-        printf '%s\n' 'TestFlight upload skipped: App Store Connect could not provide distribution profiles for the iOS targets.' >&2
-        if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-            {
-                echo '### TestFlight upload skipped'
-                echo 'The App Store Connect key could not obtain distribution profiles for the iOS targets. The unsigned iOS artifacts remain available in this release.'
-            } >> "$GITHUB_STEP_SUMMARY"
-        fi
+        skip_testflight 'App Store Connect could not provide distribution profiles for the iOS targets.'
         exit 0
     fi
     exit "$export_status"

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -184,6 +184,18 @@ class ProjectConfigurationTests(unittest.TestCase):
         self.assertIn("TestFlight upload skipped", script)
         self.assertIn("The unsigned iOS artifacts remain available in this release.", script)
 
+    def test_testflight_archive_reports_signing_configuration_failures_without_blocking_the_release(self):
+        script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()
+
+        self.assertIn('archive_log="$build_root/archive.log"', script)
+        self.assertIn("archive_status=${PIPESTATUS[0]}", script)
+        self.assertIn("No signing certificate .* found", script)
+        self.assertIn("Provisioning profile .* doesn.t match", script)
+        self.assertIn("Provisioning profile .* doesn.t include .* entitlement", script)
+        self.assertIn("Provisioning profile .* does not include .* entitlement", script)
+        self.assertIn("skip_testflight", script)
+        self.assertIn("exit \"$archive_status\"", script)
+
     def test_keyboard_is_local_and_declares_the_system_extension_contract(self):
         with (IOS_ROOT / "KeyboardExtension/Resources/Info.plist").open("rb") as info_file:
             info = plistlib.load(info_file)


### PR DESCRIPTION
Promote the validated `develop` branch to the release branch.

This includes the TestFlight signing fallback fix from #313 and the distribution-signing updates from #312. The unsigned iOS artifacts remain the reproducible release path; unavailable TestFlight signing is reported and skipped.