### PR TITLE
fix: map iOS export profiles explicitly

### DIFF
--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -70,6 +70,8 @@ for profile in \
     uuid=$(security cms -D -i "$profile" | plutil -extract UUID raw -o - -)
     cp "$profile" "$profiles_dir/$uuid.mobileprovision"
 done
+host_profile_name=$(security cms -D -i "$METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH" | plutil -extract Name raw -o - -)
+keyboard_profile_name=$(security cms -D -i "$METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH" | plutil -extract Name raw -o - -)
 
 archive_log="$build_root/archive.log"
 set +e
@@ -116,6 +118,13 @@ cat > "$export_options" <<EOF
     <string>manual</string>
     <key>teamID</key>
     <string>$METASEQUOIA_IOS_TEAM_ID</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>app.msime.ios</key>
+        <string>$host_profile_name</string>
+        <key>app.msime.ios.keyboard</key>
+        <string>$keyboard_profile_name</string>
+    </dict>
     <key>uploadSymbols</key>
     <true/>
 </dict>

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -195,6 +195,8 @@ class ProjectConfigurationTests(unittest.TestCase):
         script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()
 
         self.assertIn("METASEQUOIA_IOS_RELEASE_DIR", script)
+        self.assertIn("provisioningProfiles", script)
+        self.assertIn("app.msime.ios.keyboard", script)
         self.assertIn("ios-testflight.xcarchive.zip", script)
         self.assertIn("ios-testflight.ipa", script)
         self.assertIn("Uploaded %s to TestFlight", script)


### PR DESCRIPTION
修复 TestFlight export：archive 已签名成功，但 exportArchive 需要在 ExportOptions.plist 中显式映射 host 与 keyboard bundle ID 到对应 distribution provisioning profile。

不包含旧版本兼容逻辑。

验证：96 个相关测试、bash 语法检查、release workflow actionlint 已通过。