### PR TITLE
fix(ios): pass Xcode 16 altool authentication options

### DIFF
--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -166,12 +166,17 @@ if [[ -n "${METASEQUOIA_IOS_RELEASE_DIR:-}" ]]; then
     )
 fi
 
-xcrun altool \
+# Xcode 16 altool uses camel-case API options and discovers AuthKey_<ID>.p8 by directory.
+private_keys_dir="$build_root/private_keys"
+mkdir -p "$private_keys_dir"
+chmod 700 "$private_keys_dir"
+install -m 600 "$METASEQUOIA_IOS_AUTH_KEY_PATH" "$private_keys_dir/AuthKey_$METASEQUOIA_IOS_AUTH_KEY_ID.p8"
+trap 'rm -rf -- "$private_keys_dir"' EXIT
+API_PRIVATE_KEYS_DIR="$private_keys_dir" xcrun altool \
     --upload-app \
     --file "$ipa" \
     --type ios \
-    --api-key "$METASEQUOIA_IOS_AUTH_KEY_ID" \
-    --api-issuer "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID" \
-    --p8-file-path "$METASEQUOIA_IOS_AUTH_KEY_PATH"
+    --apiKey "$METASEQUOIA_IOS_AUTH_KEY_ID" \
+    --apiIssuer "$METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID"
 
 printf 'Uploaded %s to TestFlight.\n' "$tag_name"

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -1,3 +1,4 @@
+import os
 import plistlib
 import subprocess
 import tempfile
@@ -9,6 +10,48 @@ IOS_ROOT = Path(__file__).resolve().parents[1]
 
 
 class ProjectConfigurationTests(unittest.TestCase):
+    def test_testflight_upload_passes_xcode16_credentials_and_cleans_up_key(self):
+        script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()
+        upload = script[script.index('private_keys_dir="$build_root/private_keys"'):]
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            key = root / "custom key.p8"
+            key.write_text("test private key")
+            mock = root / "xcrun"
+            mock.write_text('''#!/usr/bin/env python3
+import os
+import pathlib
+import stat
+import sys
+assert sys.argv[1:] == ["altool", "--upload-app", "--file", "signed app.ipa", "--type", "ios", "--apiKey", "TESTKEY", "--apiIssuer", "TESTISSUER"]
+key = pathlib.Path(os.environ["API_PRIVATE_KEYS_DIR"]) / "AuthKey_TESTKEY.p8"
+assert key.read_text() == "test private key"
+assert stat.S_IMODE(key.stat().st_mode) == 0o600
+sys.exit(int(os.environ["UPLOAD_STATUS"]))
+''')
+            mock.chmod(0o755)
+            for status in (0, 17):
+                with self.subTest(status=status):
+                    result = subprocess.run(
+                        ["bash", "-eu", "-c", upload],
+                        env={
+                            **os.environ,
+                            "PATH": f"{root}:{os.environ['PATH']}",
+                            "build_root": str(root / "build"),
+                            "METASEQUOIA_IOS_AUTH_KEY_PATH": str(key),
+                            "METASEQUOIA_IOS_AUTH_KEY_ID": "TESTKEY",
+                            "METASEQUOIA_IOS_AUTH_KEY_ISSUER_ID": "TESTISSUER",
+                            "ipa": "signed app.ipa",
+                            "tag_name": "v0.48.4",
+                            "UPLOAD_STATUS": str(status),
+                        },
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, status, result.stderr)
+                    self.assertFalse((root / "build/private_keys").exists())
+                    self.assertTrue(key.exists())
+
     def test_host_and_keyboard_bundle_the_required_reason_privacy_manifest(self):
         project = (IOS_ROOT / "project.yml").read_text()
         manifest_path = IOS_ROOT / "SharedResources/PrivacyInfo.xcprivacy"


### PR DESCRIPTION
v0.48.4 发布重跑已成功导出 IPA，但 Xcode 16.4 的 altool 不识别 --api-key、--api-issuer 和 --p8-file-path，上传报缺少认证信息。改用 --apiKey / --apiIssuer，并将私钥以 AuthKey_<ID>.p8 放入 API_PRIVATE_KEYS_DIR；上传结束或失败后清理临时副本。

验证：44 项 iOS 配置测试通过，bash 语法与 git diff --check 通过。新增命令执行测试验证参数、包含空格的路径、私钥权限、成功/失败退出码及清理。真实 TestFlight 上传需合入 main 后重跑验证。
