### PR TITLE
fix(ios): declare no non-exempt encryption

### DIFF
--- a/platforms/ios/App/Resources/Info.plist
+++ b/platforms/ios/App/Resources/Info.plist
@@ -20,6 +20,8 @@
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>CFBundleIconName</key>
     <string>AppIcon</string>
     <key>UILaunchScreen</key>


### PR DESCRIPTION
为 iOS 宿主 App 的 Info.plist 添加布尔值 ITSAppUsesNonExemptEncryption=false，避免后续上传重复出现 App 加密文稿问卷。核对当前 iOS target 的本地 Engine 源码与依赖，未发现自带加密实现；App Store Connect 中 0.48.6 的元数据也已显示非豁免类加密为否。验证：plutil -lint 通过，plistlib 确认值为 Boolean false，git diff --check 通过。