### PR TITLE
feat(ios): add nine-key pinyin keyboard

### DIFF
--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct OnboardingView: View {
   @State private var sampleText = ""
   @FocusState private var tryoutFocused: Bool
-  @State private var usesShuangpin = InputSchemePreference.usesShuangpin
+  @State private var inputScheme = InputSchemePreference.scheme
   @State private var usesTraditionalOutput = ChineseOutputPreference.usesTraditional
 
   private let steps = [
@@ -63,14 +63,15 @@ struct OnboardingView: View {
             }
           }
 
-          Picker("输入方案", selection: $usesShuangpin) {
-            Text("全拼").tag(false)
-            Text("小鹤双拼").tag(true)
+          Picker("输入方案", selection: $inputScheme) {
+            ForEach(ChineseInputScheme.allCases, id: \.self) { scheme in
+              Text(scheme.title).tag(scheme)
+            }
           }
           .pickerStyle(.segmented)
           .accessibilityIdentifier("inputSchemePicker")
-          .onChange(of: usesShuangpin) { newValue in
-            InputSchemePreference.usesShuangpin = newValue
+          .onChange(of: inputScheme) { newValue in
+            InputSchemePreference.scheme = newValue
           }
 
           Divider()
@@ -110,7 +111,7 @@ struct OnboardingView: View {
             .stroke(MetasequoiaTheme.needle.opacity(0.12), lineWidth: 1)
         }
         .onAppear {
-          usesShuangpin = InputSchemePreference.usesShuangpin
+          inputScheme = InputSchemePreference.scheme
           usesTraditionalOutput = ChineseOutputPreference.usesTraditional
         }
 

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -466,6 +466,11 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     playInputClick()
     if isChineseMode {
       synchronizeInputSchemePreference()
+      // A host setting can change while this view is open. Do not start an alphabetic composition
+      // from a stale 26-key tap after switching to nine keys; local utilities still need letters.
+      if inputScheme == .nineKey && !session.isInLocalMode && !("2"..."9").contains(character) {
+        return
+      }
       render(session.handleCharacter(character))
     } else {
       let output = letterCaseState == .lowercase ? character : character.uppercased()
@@ -841,7 +846,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   }
 
   private func updateKeyboardLayout() {
-    let nineKey = isChineseMode && inputScheme == .nineKey
+    let nineKey = isChineseMode && inputScheme == .nineKey && !session.isInLocalMode
     letterRowViews.forEach { $0.isHidden = showsSymbols || nineKey }
     nineKeyContainer.isHidden = showsSymbols || !nineKey
     nineKeyRows.forEach { $0.isHidden = showsSymbols || !nineKey }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -25,7 +25,12 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   private var didRepeatBackspace = false
   private var hasComposition = false
   private var isChineseMode = true
-  private var usesShuangpin = false
+  private var inputScheme: ChineseInputScheme = .quanpin
+  private var usesShuangpin: Bool { inputScheme == .shuangpin }
+  private var nineKeyRows: [UIView] = []
+  private let nineKeyContainer = UIStackView()
+  private let spellingScrollView = UIScrollView()
+  private let spellingStack = UIStackView()
   private var usesTraditionalOutput = false
   private var visiblePreedit = ""
   private var visibleCandidates: [String] = []
@@ -62,11 +67,9 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    usesShuangpin = InputSchemePreference.usesShuangpin
+    inputScheme = InputSchemePreference.scheme
     usesTraditionalOutput = ChineseOutputPreference.usesTraditional
-    if usesShuangpin {
-      _ = session.switch(toShuangpin: true)
-    }
+    _ = applyInputScheme()
     view.backgroundColor = MetasequoiaTheme.keyboardBackground
     installKeyboard()
     updateReturnKey()
@@ -132,11 +135,62 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     ])
 
     root.addArrangedSubview(makeCandidateStrip())
+    preeditButton.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor, multiplier: 0.28).isActive = true
     for (index, row) in letterRows.enumerated() {
       let rowView = makeLetterRow(row, includesShift: index == letterRows.count - 1)
       letterRowViews.append(rowView)
       root.addArrangedSubview(rowView)
     }
+    nineKeyContainer.axis = .horizontal
+    nineKeyContainer.spacing = 6
+    nineKeyContainer.addArrangedSubview(makeSpellingStrip())
+    let nineKeyGrid = UIStackView()
+    nineKeyGrid.axis = .vertical
+    nineKeyGrid.spacing = 7
+    nineKeyGrid.distribution = .fillEqually
+    nineKeyContainer.addArrangedSubview(nineKeyGrid)
+    let groups = [["1", "ABC", "DEF"], ["GHI", "JKL", "MNO"], ["PQRS", "TUV", "WXYZ"]]
+    for (rowIndex, lettersInRow) in groups.enumerated() {
+      let row = makeRow()
+      for (column, letters) in lettersInRow.enumerated() {
+        let digit = rowIndex * 3 + column + 1
+        let button = makeKey(
+          title: digit == 1 ? "，。？！" : letters,
+          accessibilityLabel: digit == 1 ? "逗号，长按选择标点" : "\(digit) \(letters)"
+        ) { [weak self] in
+          if digit == 1 { self?.handleSymbol(",") }
+          else { self?.handleCharacter(String(digit)) }
+        }
+        button.accessibilityIdentifier = "nineKey\(digit)"
+        if var configuration = button.configuration {
+          configuration.contentInsets = .zero
+          button.configuration = configuration
+        }
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
+        button.titleLabel?.minimumScaleFactor = 0.7
+        if digit == 1 {
+          button.menu = UIMenu(children: [",", ".", "?", "!", "、"].map { symbol in
+            UIAction(title: symbol) { [weak self] _ in self?.handleSymbol(symbol) }
+          })
+        } else {
+          let number = UILabel()
+          number.text = String(digit)
+          number.font = .systemFont(ofSize: 10)
+          number.textColor = .secondaryLabel
+          number.translatesAutoresizingMaskIntoConstraints = false
+          number.isAccessibilityElement = false
+          button.addSubview(number)
+          NSLayoutConstraint.activate([
+            number.topAnchor.constraint(equalTo: button.topAnchor, constant: 3),
+            number.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -5),
+          ])
+        }
+        row.addArrangedSubview(button)
+      }
+      nineKeyGrid.addArrangedSubview(row)
+      nineKeyRows.append(row)
+    }
+    root.addArrangedSubview(nineKeyContainer)
     for row in symbolRows {
       let rowView = makeSymbolRow(row)
       rowView.isHidden = true
@@ -144,6 +198,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
       root.addArrangedSubview(rowView)
     }
     root.addArrangedSubview(makeActionRow())
+    updateKeyboardLayout()
   }
 
   private func makeCandidateStrip() -> UIView {
@@ -153,6 +208,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
 
     var preeditConfiguration = UIButton.Configuration.plain()
     preeditConfiguration.contentInsets = .zero
+    preeditConfiguration.titleLineBreakMode = .byTruncatingHead
     preeditConfiguration.baseForegroundColor = MetasequoiaTheme.forestUIColor
     preeditConfiguration.titleTextAttributesTransformer =
       UIConfigurationTextAttributesTransformer { attributes in
@@ -161,7 +217,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         return attributes
       }
     preeditButton.configuration = preeditConfiguration
-    preeditButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+    preeditButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     preeditButton.showsMenuAsPrimaryAction = true
     preeditButton.accessibilityIdentifier = "preeditButton"
 
@@ -171,8 +227,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     languageModeButton.widthAnchor.constraint(equalToConstant: 36).isActive = true
 
     updateSchemeButton()
-    schemeButton.addAction(
-      UIAction { [weak self] _ in self?.toggleScheme() }, for: .primaryActionTriggered)
+    schemeButton.showsMenuAsPrimaryAction = true
     schemeButton.widthAnchor.constraint(equalToConstant: 48).isActive = true
 
     candidateStack.axis = .horizontal
@@ -226,6 +281,53 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
         equalTo: candidateScrollView.frameLayoutGuide.heightAnchor),
     ])
     return container
+  }
+
+  private func makeSpellingStrip() -> UIView {
+    spellingScrollView.showsVerticalScrollIndicator = false
+    spellingStack.axis = .vertical
+    spellingStack.spacing = 6
+    spellingStack.translatesAutoresizingMaskIntoConstraints = false
+    spellingScrollView.addSubview(spellingStack)
+    let width = spellingScrollView.widthAnchor.constraint(equalToConstant: 58)
+    width.priority = .defaultHigh
+    width.isActive = true
+    NSLayoutConstraint.activate([
+
+      spellingStack.leadingAnchor.constraint(equalTo: spellingScrollView.contentLayoutGuide.leadingAnchor),
+      spellingStack.trailingAnchor.constraint(equalTo: spellingScrollView.contentLayoutGuide.trailingAnchor),
+      spellingStack.topAnchor.constraint(equalTo: spellingScrollView.contentLayoutGuide.topAnchor),
+      spellingStack.bottomAnchor.constraint(equalTo: spellingScrollView.contentLayoutGuide.bottomAnchor),
+      spellingStack.widthAnchor.constraint(equalTo: spellingScrollView.frameLayoutGuide.widthAnchor),
+    ])
+    return spellingScrollView
+  }
+
+  private func updateSpellingStrip() {
+    spellingStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    for (index, spelling) in session.nineKeySpellings().enumerated() {
+      let button = UIButton(type: .system)
+      var configuration = UIButton.Configuration.tinted()
+      configuration.title = spelling
+      configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 2, bottom: 6, trailing: 2)
+      configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attributes in
+        var attributes = attributes
+        attributes.font = .systemFont(ofSize: 14)
+        return attributes
+      }
+      configuration.baseForegroundColor = MetasequoiaTheme.forestUIColor
+      button.configuration = configuration
+      button.accessibilityLabel = "选择拼音 \(spelling)"
+      button.accessibilityIdentifier = "nineKeySpelling_\(spelling)"
+      button.addAction(UIAction { [weak self] _ in
+        guard let self else { return }
+        self.playInputClick()
+        self.render(self.session.chooseNineKeySpelling(at: UInt(index)))
+      }, for: .primaryActionTriggered)
+      spellingStack.addArrangedSubview(button)
+    }
+    spellingScrollView.setContentOffset(.zero, animated: false)
+    updateKeyboardLayout()
   }
 
   private func makeLetterRow(_ letters: [Character], includesShift: Bool) -> UIStackView {
@@ -309,6 +411,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     layoutToggle.titleLabel?.adjustsFontSizeToFitWidth = true
     layoutToggle.titleLabel?.minimumScaleFactor = 0.7
     layoutToggle.titleLabel?.lineBreakMode = .byClipping
+    layoutToggle.accessibilityIdentifier = "layoutToggleButton"
     layoutToggleButton = layoutToggle
     row.addArrangedSubview(layoutToggle)
 
@@ -554,6 +657,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     languageModeButton.accessibilityLabel =
       isChineseMode ? "切换到英文输入" : "切换到中文输入"
     languageModeButton.accessibilityValue = isChineseMode ? "中文输入" : "英文输入"
+    updateKeyboardLayout()
   }
 
   private func updateReturnKey() {
@@ -590,22 +694,28 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     enterButton?.accessibilityLabel = title
   }
 
-  private func toggleScheme() {
+  private func applyInputScheme() -> MetasequoiaInputSnapshot {
+    inputScheme == .nineKey ? session.switchToNineKey()
+      : session.switch(toShuangpin: usesShuangpin)
+  }
+
+  private func selectInputScheme(_ scheme: ChineseInputScheme) {
+    guard scheme != inputScheme else { return }
     playInputClick()
-    usesShuangpin.toggle()
-    let snapshot = session.switch(toShuangpin: usesShuangpin)
-    InputSchemePreference.usesShuangpin = usesShuangpin
+    inputScheme = scheme
+    let snapshot = applyInputScheme()
+    InputSchemePreference.scheme = scheme
+    showsSymbols = false
     updateSchemeButton()
     render(snapshot)
   }
 
   private func synchronizeInputSchemePreference() {
     guard !hasComposition else { return }
-    let sharedValue = InputSchemePreference.usesShuangpin
-    guard sharedValue != usesShuangpin else { return }
-
-    usesShuangpin = sharedValue
-    let snapshot = session.switch(toShuangpin: usesShuangpin)
+    let sharedValue = InputSchemePreference.scheme
+    guard sharedValue != inputScheme else { return }
+    inputScheme = sharedValue
+    let snapshot = applyInputScheme()
     updateSchemeButton()
     render(snapshot)
   }
@@ -705,7 +815,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     updateLetterCaseControls()
 
     var configuration = UIButton.Configuration.plain()
-    configuration.title = usesShuangpin ? "小鹤" : "全拼"
+    configuration.title = inputScheme == .nineKey ? "九键" : (usesShuangpin ? "小鹤" : "全拼")
     configuration.baseForegroundColor = MetasequoiaTheme.forestUIColor
     configuration.contentInsets = NSDirectionalEdgeInsets(
       top: 3, leading: 4, bottom: 3, trailing: 4)
@@ -714,17 +824,31 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     configuration.background.cornerRadius = 8
     schemeButton.configuration = configuration
     schemeButton.accessibilityIdentifier = "schemeButton"
-    schemeButton.accessibilityLabel = usesShuangpin ? "切换到全拼" : "切换到小鹤双拼"
-    schemeButton.accessibilityValue = usesShuangpin ? "小鹤双拼" : "全拼"
+    schemeButton.accessibilityLabel = "选择输入方案"
+    schemeButton.accessibilityValue = inputScheme.title
+    schemeButton.menu = UIMenu(children: ChineseInputScheme.allCases.map { scheme in
+      UIAction(title: scheme.title, state: scheme == inputScheme ? .on : .off) { [weak self] _ in
+        self?.selectInputScheme(scheme)
+      }
+    })
+    updateKeyboardLayout()
   }
 
   private func toggleLayout() {
     playInputClick()
     showsSymbols.toggle()
-    letterRowViews.forEach { $0.isHidden = showsSymbols }
+    updateKeyboardLayout()
+  }
+
+  private func updateKeyboardLayout() {
+    let nineKey = isChineseMode && inputScheme == .nineKey
+    letterRowViews.forEach { $0.isHidden = showsSymbols || nineKey }
+    nineKeyContainer.isHidden = showsSymbols || !nineKey
+    nineKeyRows.forEach { $0.isHidden = showsSymbols || !nineKey }
+    spellingScrollView.isHidden = session.nineKeySpellings().isEmpty
     symbolRowViews.forEach { $0.isHidden = !showsSymbols }
     if var configuration = layoutToggleButton?.configuration {
-      configuration.title = showsSymbols ? "ABC" : "123"
+      configuration.title = showsSymbols ? (nineKey ? "九键" : "ABC") : "123"
       layoutToggleButton?.configuration = configuration
     }
     layoutToggleButton?.accessibilityLabel =
@@ -835,6 +959,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
     hasComposition = !snapshot.preedit.isEmpty
     showDiagnostic(snapshot.diagnosticText)
     updateCandidateStrip(preedit: snapshot.preedit, candidates: snapshot.candidates)
+    updateSpellingStrip()
   }
 
   // A diagnostic means the key was handled but something behind it failed, so input keeps working
@@ -938,6 +1063,7 @@ final class KeyboardViewController: UIInputViewController, UIInputViewAudioFeedb
   ) -> UIButton {
     var configuration = UIButton.Configuration.plain()
     configuration.title = title
+    configuration.titleLineBreakMode = .byClipping
     configuration.baseForegroundColor = emphasized ? .white : .label
     configuration.background.backgroundColor =
       emphasized

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+import UIKit
+
+@MainActor
+final class NineKeyKeyboardTests: XCTestCase {
+  private func descendants(_ view: UIView) -> [UIView] {
+    [view] + view.subviews.flatMap { descendants($0) }
+  }
+
+  private func button(_ identifier: String, in controller: KeyboardViewController) throws -> UIButton {
+    try XCTUnwrap(descendants(controller.view).first {
+      $0.accessibilityIdentifier == identifier
+    } as? UIButton)
+  }
+
+  func testNineKeyInputAndLayoutSwitches() throws {
+    let previous = InputSchemePreference.scheme
+    InputSchemePreference.scheme = .nineKey
+    defer { InputSchemePreference.scheme = previous }
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 320, height: 216)
+    controller.view.layoutIfNeeded()
+
+    let nine = try button("nineKey6", in: controller)
+    XCTAssertFalse(try XCTUnwrap(nine.superview).isHidden)
+    XCTAssertEqual(try button("schemeButton", in: controller).menu?.children.count, 3)
+    for digit in "64426" {
+      try button("nineKey\(digit)", in: controller).sendActions(for: .primaryActionTriggered)
+    }
+    XCTAssertTrue(try XCTUnwrap(button("candidate-1", in: controller).configuration?.title).contains("你好"))
+    try button("nineKeySpelling_ni", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertTrue(try XCTUnwrap(button("candidate-1", in: controller).configuration?.title).contains("你好"))
+    controller.view.layoutIfNeeded()
+    XCTAssertGreaterThanOrEqual(nine.bounds.height, 30)
+    XCTAssertGreaterThan(nine.bounds.width, 60)
+    let image = UIGraphicsImageRenderer(bounds: controller.view.bounds).image { context in
+      controller.view.layer.render(in: context.cgContext)
+    }
+    let attachment = XCTAttachment(image: image)
+    attachment.name = "Nine-key pinyin keyboard"
+    attachment.lifetime = .keepAlways
+    add(attachment)
+
+    try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertTrue(try XCTUnwrap(nine.superview).isHidden)
+    try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertFalse(try XCTUnwrap(nine.superview).isHidden)
+    try button("languageModeButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertTrue(try XCTUnwrap(nine.superview).isHidden)
+    try button("languageModeButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertFalse(try XCTUnwrap(nine.superview).isHidden)
+    XCTAssertEqual(try button("schemeButton", in: controller).accessibilityValue, "全拼 9 键")
+
+    InputSchemePreference.scheme = .shuangpin
+    controller.viewWillAppear(false)
+    XCTAssertTrue(try XCTUnwrap(nine.superview).isHidden)
+    XCTAssertEqual(try button("schemeButton", in: controller).accessibilityValue, "小鹤双拼")
+  }
+}

--- a/platforms/ios/SharedUI/InputSchemePreference.swift
+++ b/platforms/ios/SharedUI/InputSchemePreference.swift
@@ -1,6 +1,34 @@
 import Foundation
 
+enum ChineseInputScheme: String, CaseIterable {
+  case quanpin, nineKey, shuangpin
+
+  var title: String {
+    switch self {
+    case .quanpin: "全拼 26 键"
+    case .nineKey: "全拼 9 键"
+    case .shuangpin: "小鹤双拼"
+    }
+  }
+}
+
 enum InputSchemePreference {
+  private static let schemeKey = "chineseInputScheme"
+  static var scheme: ChineseInputScheme {
+    get {
+      let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+      if let value = defaults.string(forKey: schemeKey), let scheme = ChineseInputScheme(rawValue: value) {
+        return scheme
+      }
+      return usesShuangpin ? .shuangpin : .quanpin
+    }
+    set {
+      let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+      defaults.set(newValue == .shuangpin, forKey: key)
+      defaults.set(newValue.rawValue, forKey: schemeKey)
+    }
+  }
+
   static let appGroupIdentifier = "group.app.msime.ios"
   private static let key = "inputSchemeUsesShuangpin"
 
@@ -19,6 +47,7 @@ enum InputSchemePreference {
     set {
       let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
       defaults.set(newValue, forKey: key)
+      defaults.set(newValue ? ChineseInputScheme.shuangpin.rawValue : ChineseInputScheme.quanpin.rawValue, forKey: schemeKey)
     }
   }
 }

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -15,8 +15,11 @@ final class OnboardingUITests: XCTestCase {
 
     let schemePicker = app.segmentedControls["inputSchemePicker"]
     XCTAssertTrue(schemePicker.exists)
-    XCTAssertTrue(schemePicker.buttons["全拼"].exists)
+    XCTAssertTrue(schemePicker.buttons["全拼 26 键"].exists)
     XCTAssertTrue(schemePicker.buttons["小鹤双拼"].exists)
+    XCTAssertTrue(schemePicker.buttons["全拼 9 键"].exists)
+    schemePicker.buttons["全拼 9 键"].tap()
+    XCTAssertTrue(schemePicker.buttons["全拼 9 键"].isSelected)
 
     let outputPicker = app.segmentedControls["chineseOutputPicker"]
     XCTAssertTrue(outputPicker.exists)

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -149,6 +149,29 @@ targets:
       - target: MetasequoiaAppleBridge
       - sdk: libsqlite3.tbd
 
+  MetasequoiaKeyboardTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: platforms/ios/KeyboardTests
+      - path: platforms/ios/KeyboardExtension/Sources
+      - path: platforms/ios/SharedUI
+      - path: platforms/ios/KeyboardExtension/Resources/msime.db
+        buildPhase: resources
+      - path: platforms/ios/KeyboardExtension/Resources/msime.db.sha256
+        buildPhase: resources
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: app.msime.ios.keyboardtests
+        SWIFT_OBJC_BRIDGING_HEADER: $(PROJECT_DIR)/../../platforms/ios/KeyboardExtension/Sources/MetasequoiaKeyboard-Bridging-Header.h
+        HEADER_SEARCH_PATHS:
+          - $(inherited)
+          - $(PROJECT_DIR)/../../shared/apple-bridge
+    dependencies:
+      - target: MetasequoiaAppleBridge
+      - sdk: libsqlite3.tbd
+
   MetasequoiaImeIOSUITests:
     type: bundle.ui-testing
     platform: iOS
@@ -172,3 +195,4 @@ schemes:
     test:
       targets:
         - MetasequoiaImeIOSUITests
+        - MetasequoiaKeyboardTests

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -149,6 +149,24 @@ int RunTest()
 
     {
         metasequoia::apple::InputSessionAdapter adapter;
+        adapter.switch_to_nine_key();
+        for (char digit : std::string("7484"))
+            Require(adapter.handle_character(digit).handled, "Nine-key digit was not handled.");
+        Require(!adapter.nine_key_spellings().empty(), "Nine-key spelling choices were not bridged.");
+        const auto unchanged = adapter.switch_to_nine_key();
+        Require(!unchanged.handled && unchanged.preedit == "7484", "Idempotent nine-key switch cleared input.");
+        const auto switched = adapter.switch_to_shuangpin(false);
+        Require(switched.commit == "水" && switched.preedit.empty(), "Switching to 26 keys lost composition.");
+        Require(!adapter.handle_character('7').handled, "Nine-key digits leaked into ordinary quanpin.");
+        adapter.handle_character('s');
+        adapter.handle_character('h');
+        adapter.handle_character('u');
+        adapter.handle_character('i');
+        Require(adapter.switch_to_nine_key().commit == "水", "Switching to nine keys lost quanpin input.");
+    }
+
+    {
+        metasequoia::apple::InputSessionAdapter adapter;
         // A capital typed as a key is still not a mode trigger. The keyboard has no shift in Chinese
         // mode, and the engine reads A-Z during a composition as helpcode, which no Apple frontend
         // offers, so it has to come back unhandled for the host application to insert.

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -163,6 +163,10 @@ int RunTest()
         adapter.handle_character('u');
         adapter.handle_character('i');
         Require(adapter.switch_to_nine_key().commit == "水", "Switching to nine keys lost quanpin input.");
+        Require(adapter.open_local_mode('U').handled && adapter.in_local_mode() && adapter.in_unicode_mode(),
+                "Nine-key layout did not expose alphabetic local-mode requirements.");
+        adapter.cancel();
+        Require(!adapter.in_local_mode(), "Closing a local mode did not restore the pinyin layout.");
     }
 
     {

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -129,7 +129,7 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         self.assertIn('private static let key = "inputSchemeUsesShuangpin"', shared_preference)
         self.assertIn("UserDefaults(suiteName: appGroupIdentifier)", shared_preference)
         self.assertIn("UserDefaults.standard.object(forKey: key)", shared_preference)
-        self.assertIn("InputSchemePreference.usesShuangpin", controller)
+        self.assertIn("InputSchemePreference.scheme", controller)
         self.assertNotIn("schemePreferenceKey", controller)
 
     def test_english_capitalization_policy(self):
@@ -459,14 +459,14 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
         self.assertIn(
-            "@State private var usesShuangpin = InputSchemePreference.usesShuangpin",
+            "@State private var inputScheme = InputSchemePreference.scheme",
             onboarding,
         )
-        self.assertIn('Picker("输入方案", selection: $usesShuangpin)', onboarding)
-        self.assertIn('Text("全拼").tag(false)', onboarding)
-        self.assertIn('Text("小鹤双拼").tag(true)', onboarding)
+        self.assertIn('Picker("输入方案", selection: $inputScheme)', onboarding)
+        self.assertIn("ChineseInputScheme.allCases", onboarding)
+        self.assertIn("Text(scheme.title).tag(scheme)", onboarding)
         self.assertIn('.accessibilityIdentifier("inputSchemePicker")', onboarding)
-        self.assertIn("InputSchemePreference.usesShuangpin = newValue", onboarding)
+        self.assertIn("InputSchemePreference.scheme = newValue", onboarding)
         self.assertIn("private var hasComposition = false", controller)
         self.assertIn("override func viewWillAppear", controller)
         self.assertIn("synchronizeInputSchemePreference()", controller)
@@ -649,9 +649,9 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         adapter_header = (IOS_ROOT.parents[1] / "shared/apple-bridge/InputSessionAdapter.h").read_text()
 
         self.assertIn("schemeButton", controller)
-        self.assertIn("toggleScheme", controller)
-        self.assertIn("usesShuangpin = InputSchemePreference.usesShuangpin", controller)
-        self.assertIn("InputSchemePreference.usesShuangpin = usesShuangpin", controller)
+        self.assertIn("selectInputScheme", controller)
+        self.assertIn("inputScheme = InputSchemePreference.scheme", controller)
+        self.assertIn("InputSchemePreference.scheme = scheme", controller)
         self.assertIn("session.switch(toShuangpin: usesShuangpin)", controller)
         self.assertIn('usesShuangpin ? "小鹤" : "全拼"', controller)
         self.assertIn('schemeButton.accessibilityIdentifier = "schemeButton"', controller)

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -43,6 +43,7 @@ class InputSessionAdapter::Impl
     }
 
     Session session;
+    bool nine_key = false;
 };
 
 namespace
@@ -142,7 +143,7 @@ InputSnapshot InputSessionAdapter::select_candidate(std::size_t index)
 
 InputSnapshot InputSessionAdapter::switch_to_shuangpin(bool uses_shuangpin)
 {
-    if (uses_shuangpin == this->uses_shuangpin())
+    if (uses_shuangpin == this->uses_shuangpin() && !impl_->nine_key)
     {
         return MakeSnapshot(impl_->session, {});
     }
@@ -151,6 +152,25 @@ InputSnapshot InputSessionAdapter::switch_to_shuangpin(bool uses_shuangpin)
     const auto scheme = uses_shuangpin ? SchemeType::Shuangpin : SchemeType::Quanpin;
     impl_ = std::make_unique<Impl>(scheme);
     return snapshot;
+}
+
+InputSnapshot InputSessionAdapter::switch_to_nine_key()
+{
+    if (impl_->nine_key)
+        return MakeSnapshot(impl_->session, {});
+    auto snapshot = MakeSnapshot(impl_->session, impl_->session.finish());
+    impl_ = std::make_unique<Impl>();
+    impl_->session.set_nine_key_enabled(true);
+    impl_->nine_key = true;
+    return snapshot;
+}
+InputSnapshot InputSessionAdapter::choose_nine_key_spelling(std::size_t index)
+{
+    return MakeSnapshot(impl_->session, impl_->session.choose_nine_key_spelling(index));
+}
+std::vector<std::string> InputSessionAdapter::nine_key_spellings() const
+{
+    return impl_->session.snapshot().nine_key_spellings;
 }
 
 bool InputSessionAdapter::uses_shuangpin() const

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -96,6 +96,11 @@ InputSnapshot InputSessionAdapter::open_local_mode(char trigger)
     return MakeSnapshot(impl_->session, impl_->session.character(trigger, true));
 }
 
+bool InputSessionAdapter::in_local_mode() const
+{
+    return impl_->session.snapshot().local_mode != LocalInputMode::None;
+}
+
 bool InputSessionAdapter::in_unicode_mode() const
 {
     return impl_->session.snapshot().local_mode == LocalInputMode::Unicode;

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -48,6 +48,9 @@ class InputSessionAdapter
     InputSnapshot select_candidate(std::size_t index);
     InputSnapshot switch_to_shuangpin(bool uses_shuangpin);
     bool uses_shuangpin() const;
+    InputSnapshot switch_to_nine_key();
+    InputSnapshot choose_nine_key_spelling(std::size_t index);
+    std::vector<std::string> nine_key_spellings() const;
 
   private:
     class Impl;

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -38,6 +38,7 @@ class InputSessionAdapter
     // None while no local mode is open. A frontend needs this to know that its digits are input for a
     // Unicode code point rather than candidate numbers.
     bool in_unicode_mode() const;
+    bool in_local_mode() const;
     InputSnapshot handle_candidate_key(char character);
     InputSnapshot handle_punctuation(char character);
     InputSnapshot handle_backspace();

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (MetasequoiaInputSnapshot *)cancel;
 - (MetasequoiaInputSnapshot *)selectCandidateAtIndex:(NSUInteger)index;
 - (MetasequoiaInputSnapshot *)switchToShuangpin:(BOOL)usesShuangpin;
+- (MetasequoiaInputSnapshot *)switchToNineKey;
+- (MetasequoiaInputSnapshot *)chooseNineKeySpellingAtIndex:(NSUInteger)index;
+- (NSArray<NSString *> *)nineKeySpellings;
 
 /// Opens one of the engine's local input modes by its trigger letter. The engine keys these off a
 /// capital delivered with a shift-only modifier, which this keyboard has no way to produce, so the

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -43,6 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// YES while the Unicode local mode is open, when the digits are input for a code point rather than
 /// candidate numbers.
 @property(nonatomic, readonly, getter=isInUnicodeMode) BOOL inUnicodeMode;
+/// Local utilities need alphabetic keys even when nine-key pinyin is selected.
+@property(nonatomic, readonly, getter=isInLocalMode) BOOL inLocalMode;
 
 /// Per-key double-pinyin hints for the scheme the session is actually running, keyed by uppercase
 /// letter. Empty in full pinyin. Derived from the engine's own profile so a frontend never hardcodes

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -234,6 +234,11 @@ void ConfigureDataDirectory()
     return [self snapshotFrom:_adapter->open_local_mode(utf8[0])];
 }
 
+- (BOOL)isInLocalMode
+{
+    return _adapter->in_local_mode();
+}
+
 - (BOOL)isInUnicodeMode
 {
     return _adapter->in_unicode_mode() ? YES : NO;

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -208,6 +208,22 @@ void ConfigureDataDirectory()
     return [self snapshotFrom:_adapter->switch_to_shuangpin(usesShuangpin)];
 }
 
+- (MetasequoiaInputSnapshot *)switchToNineKey
+{
+    return [self snapshotFrom:_adapter->switch_to_nine_key()];
+}
+- (MetasequoiaInputSnapshot *)chooseNineKeySpellingAtIndex:(NSUInteger)index
+{
+    return [self snapshotFrom:_adapter->choose_nine_key_spelling(index)];
+}
+- (NSArray<NSString *> *)nineKeySpellings
+{
+    NSMutableArray<NSString *> *result = [NSMutableArray array];
+    for (const auto &spelling : _adapter->nine_key_spellings())
+        [result addObject:StringFromUTF8(spelling)];
+    return result;
+}
+
 - (MetasequoiaInputSnapshot *)openLocalMode:(NSString *)trigger
 {
     const char *utf8 = trigger.UTF8String;


### PR DESCRIPTION
Adds a Chinese nine-key keyboard alongside full-pinyin 26 keys and Xiaohe double pinyin. Choose “全拼 9 键” in the keyboard's scheme menu or the host app's settings; the selection persists across launches while existing full/double-pinyin preferences migrate automatically.

The nine-key grid sends 2–9 to Engine, displays its spelling choices in a scrollable sidebar, and preserves candidate selection, partial commits, backspace, punctuation and return behavior. English and alphabetic local utilities use the 26-key layout. Compact layouts keep key labels on one line and constrain long preedit text so candidates remain visible.

Uses the merged producer implementation in https://github.com/metasequoiaime/MSIME-Engine/pull/66. The published dictionary and its source/digests remain unchanged.

Validation:
- Engine Release build and all 16 CTest targets passed, including ambiguity, spelling constraints, phrase/partial selection, locked suffix preservation, invalid indices, digit limits and mode isolation.
- Apple C++ input-adapter tests passed, including nine-key scheme transitions and local utility state.
- iOS configuration tests (45), dictionary packaging tests, shared contract checks and formatting check passed.
- Native onboarding and keyboard tests passed on iOS 26.5 and iOS 18.4 simulators. Inspected the 320×216 keyboard screenshot; tests cover 64426 → 你好, spelling selection, English/symbol transitions and persisted scheme switching.
- Unsigned iOS Release archive succeeded locally; App Store signing/upload is not part of this PR.
