### PR TITLE
chore(release): patch-digit bumps, and an iOS version scheme that costs one review per minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ GitHub 没有自定义频道，只有 Latest / Pre-release / Draft 三种状态�
 
 合并到 `main` 会根据 conventional commit 历史更新 Release Please 的 pull request。合并该发布 PR 会更新 `version.txt`、`CMakeLists.txt` 和 `CHANGELOG.md`，创建对应的 `vX.Y.Z` 标签，构建并测试通用架构的输入法 bundle，然后发布带有以下产物的 GitHub Release：
 
+### 版本号怎么推进
+
+`release-please-config.json` 里的 `bump-patch-for-minor-pre-major` 与 `bump-minor-pre-major` 定义了三条规则：
+
+- **没有 `!`** —— `feat:`、`fix:` 和其余任何类型都只推 **z**。默认行为是 `feat:` 直接推 y，`0.48` 这个 y 就是这样攒出来的。
+- **一个 `!`**（`feat!:`，或正文里的 `BREAKING CHANGE:`）—— 推 **y**。
+- **x** —— 没有自动路径。conventional commits 只定义了单个 `!`，`!!` 不是它的语法，release-please 也不认。要推 x 就在某条 commit 的 footer 里写 `Release-As: 1.0.0`。这是有意留成手动的：从 0.x 迈到 1.0 是一次性的产品决定，不该由谁在 commit 标题上多敲一个感叹号触发。
+
+这两个开关**只在版本号小于 `1.0.0` 时生效**。真发布 1.0.0 之后它们自动失效，退回 release-please 的默认行为（`feat:` 推 y、`!` 推 x），届时要重新决定这一段怎么写。
+
+发布 PR 里带的产物：
+
 - `MetasequoiaIME-vX.Y.Z-macos-universal.pkg`
 - `MetasequoiaIME-vX.Y.Z-macos-universal.pkg.sha256`
 - `MetasequoiaIME-vX.Y.Z-macos-universal.zip`

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,8 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "version-file": "version.txt",
+      "bump-patch-for-minor-pre-major": true,
+      "bump-minor-pre-major": true,
       "draft": true,
       "force-tag-creation": true,
       "pull-request-header": "This PR prepares the next Metasequoia IME for macOS release.",


### PR DESCRIPTION
Three versioning changes that came out of the same problem: releases churn the version number, every churn starts a new TestFlight version train, and each train costs a Beta App Review.

## 1. Feature commits stop moving the minor digit

`feat:` bumped the minor digit, which is how the version reached 0.48 in 48 steps rather than through 48 deliberate decisions. Two release-please switches move each bump down a digit while the version is below 1.0.0.

| commit | before | after |
| --- | --- | --- |
| `feat:`, `fix:`, anything else | minor / patch | **patch** |
| `feat!:` or `BREAKING CHANGE:` | major | **minor** |

Verified against the seven commits then on `develop`, via `release-please release-pr --dry-run`. Same input, both rule sets:

```
old   title: chore(develop): release 0.49.0
new   title: chore(develop): release 0.48.7
```

The major digit keeps no automatic path on purpose. Conventional commits defines a single `!` and nothing past it, so leaving 0.x for 1.0 stays a `Release-As: 1.0.0` footer written deliberately rather than a second exclamation mark someone types by accident.

Both switches only apply below 1.0.0. On the day 1.0.0 ships they stop having any effect and release-please returns to its defaults. The README section says so, because the alternative is discovering it from a release.

## 2. The build number is no longer a copy of the marketing version

`package_ios_testflight.sh` and `package_ios_archive.sh` both passed the release version as `CURRENT_PROJECT_VERSION` as well as `MARKETING_VERSION`. App Store Connect wants `CFBundleVersion` unique and increasing inside one `CFBundleShortVersionString`, so that allowed exactly one upload per release: a build rejected by Beta App Review could only be replaced by cutting another release. The `CURRENT_PROJECT_VERSION: 1` sitting in `project.yml` never reached either script — it only applies to local Xcode builds, and now says so.

The commit count replaces it: monotonic, reproducible from the checkout, unrelated to the marketing version. A shallow checkout would restart it low enough for the next upload to read as a downgrade, so both scripts refuse one instead of computing that number. `git` joins the required-tools check in both.

## 3. iOS ships x.y as the marketing version

TestFlight groups builds by `CFBundleShortVersionString` and reviews each group separately, so carrying the patch digit bought a Beta App Review for every release no matter how small. The release scripts truncate to `x.y`; the build number carries the rest. A minor bump is now the only thing that opens a new group.

Both paths truncate. If only the signed path did, a maintainer uploading the unsigned archive from Organizer would open a second group for a release CI had already published.

`project.yml` keeps the full version — that is what release-please writes and what `platforms/macos/tests/ReleaseConfigurationTests.py` asserts — and local Xcode builds never upload. Release artifacts keep the full tag in their file names.

The cost is the patch digit disappearing from the version iOS users see in Settings. The build number still tells the builds apart.

### On the ordering

App Store Connect already holds a `0.48.6` train. A first upload reporting `0.48` would be a lower version string, which is why the third commit is marked `feat(ios)!:` — under the rules in part 1 that bumps the minor digit, so the first release under this scheme is `0.49` and the new group sorts above the existing one rather than below it.

## Verification

- `platforms/ios/tests/ProjectConfigurationTests.py` — 46 tests, including a new one that builds a real git repository, runs the fragment both scripts share, and checks the commit count, the shallow refusal, the non-repository refusal, and that both scripts truncate the marketing version alike. It fails against the previous scripts.
- `platforms/macos/tests/ReleaseConfigurationTests.py` — 18 tests, unchanged and passing; it pins the full version in `project.yml`.
- `shellcheck` clean on both scripts.
