### PR TITLE
feat(ios)!: one Beta App Review per minor, not per release

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ GitHub 没有自定义频道，只有 Latest / Pre-release / Draft 三种状态�
 
 这两个开关**只在版本号小于 `1.0.0` 时生效**。真发布 1.0.0 之后它们自动失效，退回 release-please 的默认行为（`feat:` 推 y、`!` 推 x），届时要重新决定这一段怎么写。
 
+iOS 的版本号有一处刻意的偏离：发布脚本把 `MARKETING_VERSION` 截断成 **x.y** 再归档，第三位交给 `CURRENT_PROJECT_VERSION`（取 `git rev-list --count HEAD`）承载。TestFlight 按 `CFBundleShortVersionString` 分组并逐组做 Beta App Review，带上 z 就等于每发一版重审一次；截断之后只有 y 变才开新组。macOS 与 Linux 不受影响，产物文件名也照旧使用完整的 tag。
+
 发布 PR 里带的产物：
 
 - `MetasequoiaIME-vX.Y.Z-macos-universal.pkg`

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -8,6 +8,9 @@ options:
 
 settings:
   base:
+    # Only used by local Xcode builds, which never upload. The release scripts override it with the
+    # commit count, because App Store Connect wants this unique and increasing inside one
+    # MARKETING_VERSION and would reject a second upload that reused the value.
     CURRENT_PROJECT_VERSION: 1
     # Bumped by release-please alongside CMakeLists.txt. It used to be pinned at 0.1.0 while the
     # project shipped 0.45.x, so any iOS artifact would have carried a version that matched nothing.

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -14,6 +14,9 @@ settings:
     CURRENT_PROJECT_VERSION: 1
     # Bumped by release-please alongside CMakeLists.txt. It used to be pinned at 0.1.0 while the
     # project shipped 0.45.x, so any iOS artifact would have carried a version that matched nothing.
+    # The release scripts truncate this to x.y before archiving, because TestFlight reviews each
+    # CFBundleShortVersionString separately and the patch digit would buy a review per release. The
+    # full value stays here: it is what release-please writes, and local builds never upload.
     MARKETING_VERSION: 0.48.6 # x-release-please-version
     SWIFT_VERSION: 6.0
     IPHONEOS_DEPLOYMENT_TARGET: 15.0

--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -29,12 +29,25 @@ if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 version=${tag_name#v}
 
-for tool in xcodegen xcodebuild ditto shasum; do
+for tool in git xcodegen xcodebuild ditto shasum; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         printf 'Required tool is missing: %s\n' "$tool" >&2
         exit 1
     fi
 done
+
+# This archive is what a maintainer opens in Xcode Organizer to push to TestFlight, so it needs the
+# same build number rule as the signed path: unique and increasing within one marketing version,
+# rather than a copy of the marketing version that allows only one build per release.
+if ! git -C "$project_root" rev-parse --git-dir >/dev/null 2>&1; then
+    printf 'Not a git checkout, so the build number cannot be derived: %s\n' "$project_root" >&2
+    exit 1
+fi
+if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]; then
+    printf 'Refusing to build from a shallow checkout: the commit count would restart low and App Store Connect would reject the build as a downgrade. Check out with fetch-depth: 0.\n' >&2
+    exit 1
+fi
+build_number=$(git -C "$project_root" rev-list --count HEAD)
 
 spec="$project_root/platforms/ios/project.yml"
 if [[ ! -f "$spec" ]]; then
@@ -70,7 +83,7 @@ xcodebuild archive \
     -archivePath "$archive_path" \
     -derivedDataPath "$build_root/derived" \
     MARKETING_VERSION="$version" \
-    CURRENT_PROJECT_VERSION="$version" \
+    CURRENT_PROJECT_VERSION="$build_number" \
     CODE_SIGNING_ALLOWED=NO \
     CODE_SIGNING_REQUIRED=NO \
     CODE_SIGN_IDENTITY="" \

--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -49,6 +49,13 @@ if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]
 fi
 build_number=$(git -C "$project_root" rev-list --count HEAD)
 
+# TestFlight groups builds by CFBundleShortVersionString and reviews each group on its own, so
+# carrying the patch digit here bought a fresh Beta App Review for every release. iOS ships x.y and
+# lets the build number carry the rest; only a minor bump opens a new group now. This archive has to
+# agree with the signed path, or a maintainer uploading it from Organizer would open a second group
+# for the same release. The release artifacts still take their names from the full tag.
+marketing_version=${version%.*}
+
 spec="$project_root/platforms/ios/project.yml"
 if [[ ! -f "$spec" ]]; then
     printf 'iOS project spec not found at %s\n' "$spec" >&2
@@ -73,8 +80,8 @@ mkdir -p "$build_root" "$output_dir"
 
 xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
 
-# MARKETING_VERSION is passed on the command line as well as being bumped in project.yml, so the
-# archive carries the release version even when the spec is momentarily behind the tag being built.
+# The version settings are passed on the command line as well as being bumped in project.yml, so the
+# archive follows the tag being built even when the spec is momentarily behind it.
 xcodebuild archive \
     -project "$build_root/MetasequoiaImeIOS.xcodeproj" \
     -scheme MetasequoiaImeIOS \
@@ -82,7 +89,7 @@ xcodebuild archive \
     -destination 'generic/platform=iOS' \
     -archivePath "$archive_path" \
     -derivedDataPath "$build_root/derived" \
-    MARKETING_VERSION="$version" \
+    MARKETING_VERSION="$marketing_version" \
     CURRENT_PROJECT_VERSION="$build_number" \
     CODE_SIGNING_ALLOWED=NO \
     CODE_SIGNING_REQUIRED=NO \

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -32,7 +32,7 @@ for profile in \
     fi
 done
 
-for tool in xcodegen xcodebuild xcrun; do
+for tool in git xcodegen xcodebuild xcrun; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         printf 'Required tool is missing: %s\n' "$tool" >&2
         exit 1
@@ -51,6 +51,22 @@ if [[ ! -s "$dictionary" ]]; then
 fi
 
 version=${tag_name#v}
+
+# CFBundleVersion has to be unique and strictly increasing within one CFBundleShortVersionString.
+# Deriving it from the marketing version left exactly one possible build per release, so a build that
+# failed Beta App Review could not be replaced without cutting another release -- and every new
+# marketing version starts a fresh TestFlight version train that needs its own review. The commit
+# count is monotonic and reproducible from the checkout alone.
+if ! git -C "$project_root" rev-parse --git-dir >/dev/null 2>&1; then
+    printf 'Not a git checkout, so the build number cannot be derived: %s\n' "$project_root" >&2
+    exit 1
+fi
+if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]; then
+    printf 'Refusing to build from a shallow checkout: the commit count would restart low and App Store Connect would reject the build as a downgrade. Check out with fetch-depth: 0.\n' >&2
+    exit 1
+fi
+build_number=$(git -C "$project_root" rev-list --count HEAD)
+
 build_root="$project_root/build/ios-testflight"
 archive_path="$build_root/MetasequoiaIME.xcarchive"
 export_path="$build_root/export"
@@ -83,7 +99,7 @@ xcodebuild archive \
     -archivePath "$archive_path" \
     -derivedDataPath "$build_root/derived" \
     MARKETING_VERSION="$version" \
-    CURRENT_PROJECT_VERSION="$version" \
+    CURRENT_PROJECT_VERSION="$build_number" \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \
     CODE_SIGN_STYLE=Manual \

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -67,6 +67,12 @@ if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]
 fi
 build_number=$(git -C "$project_root" rev-list --count HEAD)
 
+# TestFlight groups builds by CFBundleShortVersionString and reviews each group on its own, so
+# carrying the patch digit here bought a fresh Beta App Review for every release. iOS ships x.y and
+# lets the build number carry the rest; only a minor bump opens a new group now. The release
+# artifacts still take their names from the full tag.
+marketing_version=${version%.*}
+
 build_root="$project_root/build/ios-testflight"
 archive_path="$build_root/MetasequoiaIME.xcarchive"
 export_path="$build_root/export"
@@ -98,7 +104,7 @@ xcodebuild archive \
     -destination 'generic/platform=iOS' \
     -archivePath "$archive_path" \
     -derivedDataPath "$build_root/derived" \
-    MARKETING_VERSION="$version" \
+    MARKETING_VERSION="$marketing_version" \
     CURRENT_PROJECT_VERSION="$build_number" \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -717,7 +717,18 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         for name, script in scripts.items():
             self.assertIn('CURRENT_PROJECT_VERSION="$build_number"', script, name)
             self.assertNotIn('CURRENT_PROJECT_VERSION="$version"', script, name)
-            self.assertIn('MARKETING_VERSION="$version"', script, name)
+            # TestFlight reviews each CFBundleShortVersionString on its own, so shipping the patch
+            # digit meant a Beta App Review per release. Both paths must truncate alike, or an
+            # archive uploaded from Organizer opens a second group for the same release.
+            self.assertIn("marketing_version=${version%.*}", script, name)
+            self.assertIn('MARKETING_VERSION="$marketing_version"', script, name)
+            self.assertNotIn('MARKETING_VERSION="$version"', script, name)
+
+        truncation = subprocess.run(
+            ["bash", "-c", 'version="0.48.6"; printf "%s" "${version%.*}"'],
+            capture_output=True, text=True, check=True,
+        )
+        self.assertEqual(truncation.stdout, "0.48")
 
         start = 'if ! git -C "$project_root" rev-parse --git-dir'
         end = 'build_number=$(git -C "$project_root" rev-list --count HEAD)'

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -706,6 +706,71 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         self.assertIn("render(session.handleCharacter(character))", character_handler)
         self.assertNotIn("uppercased()", character_handler.split("} else {", 1)[0])
 
+    def test_build_number_is_the_commit_count_and_not_the_marketing_version(self):
+        # App Store Connect keys Beta App Review to CFBundleShortVersionString and rejects a repeated
+        # CFBundleVersion inside it. Both used to carry the release version, which allowed exactly one
+        # upload per release: a build that failed review could only be replaced by cutting another.
+        scripts = {
+            name: (IOS_ROOT / "scripts" / name).read_text()
+            for name in ("package_ios_testflight.sh", "package_ios_archive.sh")
+        }
+        for name, script in scripts.items():
+            self.assertIn('CURRENT_PROJECT_VERSION="$build_number"', script, name)
+            self.assertNotIn('CURRENT_PROJECT_VERSION="$version"', script, name)
+            self.assertIn('MARKETING_VERSION="$version"', script, name)
+
+        start = 'if ! git -C "$project_root" rev-parse --git-dir'
+        end = 'build_number=$(git -C "$project_root" rev-list --count HEAD)'
+        fragments = {
+            name: script[script.index(start):script.index(end) + len(end)]
+            for name, script in scripts.items()
+        }
+        self.assertEqual(*fragments.values(), "both release paths must derive the build number alike")
+
+        fragment = next(iter(fragments.values()))
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            origin = root / "origin"
+            origin.mkdir()
+            env = {
+                **os.environ,
+                "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            }
+            subprocess.run(["git", "init", "-q", "-b", "main", str(origin)], check=True)
+            for index in range(3):
+                (origin / "f").write_text(str(index))
+                subprocess.run(["git", "-C", str(origin), "add", "f"], check=True)
+                subprocess.run(
+                    ["git", "-C", str(origin), "commit", "-q", "-m", f"c{index}"], check=True, env=env
+                )
+
+            runner = root / "run.sh"
+            runner.write_text(
+                f'#!/usr/bin/env bash\nset -euo pipefail\nproject_root="$1"\n{fragment}\n'
+                'printf "%s\\n" "$build_number"\n'
+            )
+            runner.chmod(0o755)
+
+            done = subprocess.run(
+                [str(runner), str(origin)], capture_output=True, text=True, check=True
+            )
+            self.assertEqual(done.stdout.strip(), "3")
+
+            # A shallow checkout restarts the count low enough that App Store Connect reads the next
+            # upload as a downgrade, so the scripts have to stop rather than produce that number.
+            shallow = root / "shallow"
+            subprocess.run(
+                ["git", "clone", "-q", "--depth", "1", origin.as_uri(), str(shallow)], check=True
+            )
+            refused = subprocess.run([str(runner), str(shallow)], capture_output=True, text=True)
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("shallow", refused.stderr)
+
+            outside = subprocess.run([str(runner), str(root)], capture_output=True, text=True)
+            self.assertNotEqual(outside.returncode, 0)
+            self.assertIn("Not a git checkout", outside.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-on to #341, which merged while it still held only the release-please change. These are the two iOS commits from the same piece of work.

## 1. The build number is no longer a copy of the marketing version

`package_ios_testflight.sh` and `package_ios_archive.sh` both passed the release version as `CURRENT_PROJECT_VERSION` as well as `MARKETING_VERSION`. App Store Connect wants `CFBundleVersion` unique and increasing inside one `CFBundleShortVersionString`, so that allowed exactly one upload per release: a build rejected by Beta App Review could only be replaced by cutting another release. The `CURRENT_PROJECT_VERSION: 1` sitting in `project.yml` never reached either script — it only applies to local Xcode builds, and now says so.

The commit count replaces it: monotonic, reproducible from the checkout, unrelated to the marketing version. A shallow checkout would restart it low enough for the next upload to read as a downgrade, so both scripts refuse one instead of computing that number. `git` joins the required-tools check in both.

## 2. iOS ships x.y as the marketing version

TestFlight groups builds by `CFBundleShortVersionString` and reviews each group separately, so carrying the patch digit bought a Beta App Review for every release no matter how small. The release scripts truncate to `x.y`; the build number carries the rest. A minor bump is now the only thing that opens a new group.

Both paths truncate. If only the signed path did, a maintainer uploading the unsigned archive from Organizer would open a second group for a release CI had already published.

`project.yml` keeps the full version — that is what release-please writes and what `platforms/macos/tests/ReleaseConfigurationTests.py` asserts — and local Xcode builds never upload. Release artifacts keep the full tag in their file names.

The cost is the patch digit disappearing from the version iOS users see in Settings. The build number still tells the builds apart.

### On the ordering

App Store Connect already holds a `0.48.6` train. A first upload reporting `0.48` would be a lower version string, which is why the second commit is marked `feat(ios)!:` — under the rules #341 just merged that bumps the minor digit, so the first release under this scheme is `0.49` and the new group sorts above the existing one rather than below it.

## Verification

- `platforms/ios/tests/ProjectConfigurationTests.py` — 46 tests, including a new one that builds a real git repository, runs the fragment both scripts share, and checks the commit count, the shallow refusal, the non-repository refusal, and that both scripts truncate the marketing version alike. It fails against the previous scripts.
- `platforms/macos/tests/ReleaseConfigurationTests.py` — 18 tests, unchanged and passing; it pins the full version in `project.yml`.
- `shellcheck` clean on both scripts.
