### PR TITLE
feat(ios): add skin community, custom design studio and clipboard history

### DIFF
--- a/platforms/ios/App/Services/SkinCommunityAPI.swift
+++ b/platforms/ios/App/Services/SkinCommunityAPI.swift
@@ -17,6 +17,8 @@ struct CommunityPage: Decodable, Sendable { let skins: [CommunitySkin]; let has_
 struct CommunityChallenge: Decodable, Sendable { let challenge_id: String; let nonce: String }
 struct CommunityUser: Codable, Sendable { let id: String; let display_name: String }
 struct CommunityTokens: Codable, Sendable {
+  var saved_at: Date?
+  var expires_in: Int?
   let access_token: String
   let refresh_token: String
   let user: CommunityUser
@@ -85,8 +87,11 @@ actor SkinCommunityAPI {
     return (data, response.statusCode)
   }
   private func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil, authenticated: Bool = false) async throws -> T {
-    let tokens = (path == "/v1/auth/challenges" || path == "/v1/auth/login") ? nil : try readCredentials()
+    var tokens = (path == "/v1/auth/challenges" || path == "/v1/auth/login") ? nil : try readCredentials()
     if authenticated && tokens == nil { throw CommunityFailure(message: "请先使用 Apple 登录。") }
+    if let previous = tokens, Date().timeIntervalSince(previous.saved_at ?? .distantPast) >= Double(max(0, (previous.expires_in ?? 900) - 60)) {
+      tokens = try await refresh(previous)
+    }
     var (data, status) = try await transport(path, method: method, body: body, token: tokens?.access_token)
     if status == 401, let tokens {
       let fresh = try await refresh(tokens)
@@ -107,7 +112,8 @@ actor SkinCommunityAPI {
     }
     refreshTask = task
     defer { refreshTask = nil }
-    let result = try await task.value
+    var result = try await task.value
+    result.saved_at = Date()
     guard currentGeneration == generation else { throw CancellationError() }
     try writeCredentials(result)
     return result
@@ -136,7 +142,8 @@ actor SkinCommunityAPI {
     try await request("/v1/auth/challenges", method: "POST", body: JSONSerialization.data(withJSONObject: ["provider": "apple", "purpose": "login"]))
   }
   func login(challenge: String, identityToken: String) async throws {
-    let result: CommunityTokens = try await request("/v1/auth/login", method: "POST", body: JSONSerialization.data(withJSONObject: ["challenge_id": challenge, "credential": identityToken]))
+    var result: CommunityTokens = try await request("/v1/auth/login", method: "POST", body: JSONSerialization.data(withJSONObject: ["challenge_id": challenge, "credential": identityToken]))
+    result.saved_at = Date()
     generation += 1
     try writeCredentials(result)
   }

--- a/platforms/ios/App/Services/SkinCommunityAPI.swift
+++ b/platforms/ios/App/Services/SkinCommunityAPI.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Security
+
+struct CommunitySkin: Codable, Identifiable, Sendable {
+  let id: String
+  let name: String
+  let description: String
+  let author: String
+  let design: CustomKeyboardSkin
+  let downloads: Int
+  let rating_count: Int
+  let rating_average: Double
+  let owned: Bool
+  let my_rating: Int
+}
+struct CommunityPage: Decodable, Sendable { let skins: [CommunitySkin]; let has_more: Bool }
+struct CommunityChallenge: Decodable, Sendable { let challenge_id: String; let nonce: String }
+struct CommunityUser: Codable, Sendable { let id: String; let display_name: String }
+struct CommunityTokens: Codable, Sendable {
+  let access_token: String
+  let refresh_token: String
+  let user: CommunityUser
+}
+struct CommunityFailure: LocalizedError {
+  let message: String
+  var errorDescription: String? { message }
+}
+
+enum CommunityCredentials {
+  private static var query: [String: Any] { [kSecClass as String: kSecClassGenericPassword,
+    kSecAttrService as String: "app.msime.ios.community", kSecAttrAccount as String: "api.msime.app"] }
+  static func load() throws -> CommunityTokens? {
+    var query = query
+    query[kSecReturnData as String] = true
+    var value: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &value)
+    if status == errSecItemNotFound { return nil }
+    guard status == errSecSuccess, let data = value as? Data else { throw CommunityFailure(message: "请解锁设备后读取登录状态。") }
+    return try JSONDecoder().decode(CommunityTokens.self, from: data)
+  }
+  static func save(_ tokens: CommunityTokens?) throws {
+    guard let tokens else {
+      let status = SecItemDelete(query as CFDictionary)
+      guard status == errSecSuccess || status == errSecItemNotFound else { throw CommunityFailure(message: "无法清除登录状态。") }
+      return
+    }
+    let values: [String: Any] = [kSecValueData as String: try JSONEncoder().encode(tokens)]
+    var status = SecItemUpdate(query as CFDictionary, values as CFDictionary)
+    if status == errSecItemNotFound {
+      var item = query.merging(values) { _, new in new }
+      item[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+      status = SecItemAdd(item as CFDictionary, nil)
+    }
+    guard status == errSecSuccess else { throw CommunityFailure(message: "无法安全保存登录状态。") }
+  }
+}
+
+actor SkinCommunityAPI {
+  static let shared = SkinCommunityAPI()
+  private let base = URL(string: "https://api.msime.app")!
+  private let session: URLSession
+  private let readCredentials: @Sendable () throws -> CommunityTokens?
+  private let writeCredentials: @Sendable (CommunityTokens?) throws -> Void
+  init(configuration: URLSessionConfiguration = .ephemeral,
+       readCredentials: @escaping @Sendable () throws -> CommunityTokens? = { try CommunityCredentials.load() },
+       writeCredentials: @escaping @Sendable (CommunityTokens?) throws -> Void = { try CommunityCredentials.save($0) }) {
+    session = URLSession(configuration: configuration, delegate: NoRedirects(), delegateQueue: nil)
+    self.readCredentials = readCredentials
+    self.writeCredentials = writeCredentials
+  }
+  private var refreshTask: Task<CommunityTokens, Error>?
+  private var generation = 0
+
+  func signedIn() throws -> Bool { try readCredentials() != nil }
+  private func transport(_ path: String, method: String, body: Data?, token: String?) async throws -> (Data, Int) {
+    guard let url = URL(string: path, relativeTo: base) else { throw CommunityFailure(message: "请求地址无效。") }
+    var request = URLRequest(url: url)
+    request.httpMethod = method
+    request.httpBody = body
+    request.timeoutInterval = 25
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    if let token { request.setValue("Bearer " + token, forHTTPHeaderField: "Authorization") }
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse, data.count <= 1_000_000 else { throw CommunityFailure(message: "社区响应格式无效。") }
+    return (data, response.statusCode)
+  }
+  private func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil, authenticated: Bool = false) async throws -> T {
+    let tokens = (path == "/v1/auth/challenges" || path == "/v1/auth/login") ? nil : try readCredentials()
+    if authenticated && tokens == nil { throw CommunityFailure(message: "请先使用 Apple 登录。") }
+    var (data, status) = try await transport(path, method: method, body: body, token: tokens?.access_token)
+    if status == 401, let tokens {
+      let fresh = try await refresh(tokens)
+      (data, status) = try await transport(path, method: method, body: body, token: fresh.access_token)
+    }
+    guard (200..<300).contains(status) else { throw Self.failure(data, status: status) }
+    return try JSONDecoder().decode(T.self, from: status == 204 ? Data("{}".utf8) : data)
+  }
+  private func refresh(_ previous: CommunityTokens) async throws -> CommunityTokens {
+    if let current = try readCredentials(), current.access_token != previous.access_token { return current }
+    if let refreshTask { return try await refreshTask.value }
+    let currentGeneration = generation
+    let task = Task { () throws -> CommunityTokens in
+      let body = try JSONSerialization.data(withJSONObject: ["refresh_token": previous.refresh_token])
+      let (data, status) = try await self.transport("/v1/auth/refresh", method: "POST", body: body, token: nil)
+      guard status == 200 else { throw Self.failure(data, status: status) }
+      return try JSONDecoder().decode(CommunityTokens.self, from: data)
+    }
+    refreshTask = task
+    defer { refreshTask = nil }
+    let result = try await task.value
+    guard currentGeneration == generation else { throw CancellationError() }
+    try writeCredentials(result)
+    return result
+  }
+  private static func failure(_ data: Data, status: Int) -> CommunityFailure {
+    let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    let code = (root?["error"] as? [String: String])?["code"] ?? ""
+    let message: String
+    switch code {
+    case "provider_disabled", "user_auth_disabled": message = "社区登录尚未启用，请稍后重试。"
+    case "download_before_rating_or_own_skin": message = "下载使用后才能评分，且不能评价自己的作品。"
+    case "skin_publish_limit": message = "最多发布 50 款皮肤，请先下架部分作品。"
+    case "recent_login_required": message = "请退出并重新使用 Apple 登录后，再注销账号。"
+    case "invalid_skin_design", "invalid_skin_metadata": message = "皮肤内容或名称不符合发布要求。"
+    default:
+      switch status {
+      case 401: message = "登录已过期，请重新使用 Apple 登录。"
+      case 404: message = "社区功能尚未上线，或这款皮肤已下架。"
+      case 429: message = "操作较频繁，请稍后重试。"
+      default: message = "社区暂时不可用，请稍后重试。"
+      }
+    }
+    return CommunityFailure(message: message)
+  }
+  func challenge() async throws -> CommunityChallenge {
+    try await request("/v1/auth/challenges", method: "POST", body: JSONSerialization.data(withJSONObject: ["provider": "apple", "purpose": "login"]))
+  }
+  func login(challenge: String, identityToken: String) async throws {
+    let result: CommunityTokens = try await request("/v1/auth/login", method: "POST", body: JSONSerialization.data(withJSONObject: ["challenge_id": challenge, "credential": identityToken]))
+    generation += 1
+    try writeCredentials(result)
+  }
+  func logout(deleteAccount: Bool = false) async throws {
+    let _: [String: Bool] = try await request(deleteAccount ? "/v1/users/me" : "/v1/auth/logout", method: deleteAccount ? "DELETE" : "POST", body: deleteAccount ? nil : JSONSerialization.data(withJSONObject: ["all": false]), authenticated: true)
+    generation += 1
+    try writeCredentials(nil)
+  }
+  func clearExpiredLogin() throws { generation += 1; try writeCredentials(nil) }
+  func list(offset: Int = 0, search: String = "") async throws -> CommunityPage {
+    var parts = URLComponents()
+    parts.path = "/v1/community/skins"
+    parts.queryItems = [.init(name: "offset", value: String(offset)), .init(name: "q", value: search)]
+    return try await request(parts.string!)
+  }
+  func detail(_ id: String) async throws -> CommunitySkin { try await request("/v1/community/skins/\(id)") }
+  func publish(id: String, name: String, description: String, design: CustomKeyboardSkin) async throws {
+    struct Payload: Encodable { let id: String; let name: String; let description: String; let design: CustomKeyboardSkin }
+    let _: [String: String] = try await request("/v1/community/skins", method: "POST", body: JSONEncoder().encode(Payload(id: id, name: name, description: description, design: design.normalized)), authenticated: true)
+  }
+  func download(_ id: String) async throws -> CustomKeyboardSkin {
+    struct Result: Decodable, Sendable { let design: CustomKeyboardSkin }
+    let result: Result = try await request("/v1/community/skins/\(id)/download", method: "POST", body: Data("{}".utf8), authenticated: true)
+    return result.design.normalized
+  }
+  func rate(_ id: String, stars: Int) async throws {
+    let _: [String: Int] = try await request("/v1/community/skins/\(id)/rating", method: "PUT", body: JSONSerialization.data(withJSONObject: ["stars": stars]), authenticated: true)
+  }
+  func unpublish(_ id: String) async throws {
+    let _: [String: Bool] = try await request("/v1/community/skins/\(id)", method: "DELETE", authenticated: true)
+  }
+}

--- a/platforms/ios/App/Services/SkinCommunityAPI.swift
+++ b/platforms/ios/App/Services/SkinCommunityAPI.swift
@@ -73,6 +73,7 @@ actor SkinCommunityAPI {
   private var refreshTask: Task<CommunityTokens, Error>?
   private var generation = 0
 
+  func currentUser() throws -> CommunityUser? { try readCredentials()?.user }
   func signedIn() throws -> Bool { try readCredentials() != nil }
   private func transport(_ path: String, method: String, body: Data?, token: String?) async throws -> (Data, Int) {
     guard let url = URL(string: path, relativeTo: base) else { throw CommunityFailure(message: "请求地址无效。") }

--- a/platforms/ios/App/Services/SkinCommunityAPI.swift
+++ b/platforms/ios/App/Services/SkinCommunityAPI.swift
@@ -15,13 +15,22 @@ struct CommunitySkin: Codable, Identifiable, Sendable {
 }
 struct CommunityPage: Decodable, Sendable { let skins: [CommunitySkin]; let has_more: Bool }
 struct CommunityChallenge: Decodable, Sendable { let challenge_id: String; let nonce: String }
-struct CommunityUser: Codable, Sendable { let id: String; let display_name: String }
+struct CommunityUser: Codable, Sendable {
+  let id: String
+  let display_name: String
+  var created_at: String? = nil
+}
+struct CommunityIdentity: Decodable, Sendable { let provider: String }
+struct CommunityProfile: Decodable, Sendable {
+  let user: CommunityUser
+  let identities: [CommunityIdentity]
+}
 struct CommunityTokens: Codable, Sendable {
   var saved_at: Date?
   var expires_in: Int?
   let access_token: String
   let refresh_token: String
-  let user: CommunityUser
+  var user: CommunityUser
 }
 struct CommunityFailure: LocalizedError {
   let message: String
@@ -147,6 +156,28 @@ actor SkinCommunityAPI {
     result.saved_at = Date()
     generation += 1
     try writeCredentials(result)
+  }
+  func profile() async throws -> CommunityProfile {
+    let expectedGeneration = generation
+    let profile: CommunityProfile = try await request("/v1/users/me", authenticated: true)
+    guard expectedGeneration == generation, var tokens = try readCredentials(), tokens.user.id == profile.user.id else {
+      throw CancellationError()
+    }
+    tokens.user = profile.user
+    try writeCredentials(tokens)
+    return profile
+  }
+  func updateProfile(name: String) async throws -> CommunityProfile {
+    let name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !name.isEmpty, name.unicodeScalars.count <= 64,
+          !name.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else {
+      throw CommunityFailure(message: "昵称需为 1–64 个字符，不能包含换行或控制字符。")
+    }
+    let expectedGeneration = generation
+    let _: [String: Bool] = try await request("/v1/users/me", method: "PATCH",
+      body: JSONSerialization.data(withJSONObject: ["display_name": name]), authenticated: true)
+    guard expectedGeneration == generation else { throw CancellationError() }
+    return try await profile()
   }
   func logout(deleteAccount: Bool = false) async throws {
     let _: [String: Bool] = try await request(deleteAccount ? "/v1/users/me" : "/v1/auth/logout", method: deleteAccount ? "DELETE" : "POST", body: deleteAccount ? nil : JSONSerialization.data(withJSONObject: ["all": false]), authenticated: true)

--- a/platforms/ios/App/Services/SkinCommunityAPI.swift
+++ b/platforms/ios/App/Services/SkinCommunityAPI.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Security
 
 struct CommunitySkin: Codable, Identifiable, Sendable {
   let id: String
@@ -15,118 +14,35 @@ struct CommunitySkin: Codable, Identifiable, Sendable {
 }
 struct CommunityPage: Decodable, Sendable { let skins: [CommunitySkin]; let has_more: Bool }
 struct CommunityChallenge: Decodable, Sendable { let challenge_id: String; let nonce: String }
-struct CommunityUser: Codable, Sendable {
-  let id: String
-  let display_name: String
-  var created_at: String? = nil
-}
-struct CommunityIdentity: Decodable, Sendable { let provider: String }
-struct CommunityProfile: Decodable, Sendable {
-  let user: CommunityUser
-  let identities: [CommunityIdentity]
-}
-struct CommunityTokens: Codable, Sendable {
-  var saved_at: Date?
-  var expires_in: Int?
-  let access_token: String
-  let refresh_token: String
-  var user: CommunityUser
-}
+typealias CommunityUser = BackendAccountClient.User
+typealias CommunityProfile = BackendAccountClient.Profile
 struct CommunityFailure: LocalizedError {
   let message: String
   var errorDescription: String? { message }
 }
 
-enum CommunityCredentials {
-  private static var query: [String: Any] { [kSecClass as String: kSecClassGenericPassword,
-    kSecAttrService as String: "app.msime.ios.community", kSecAttrAccount as String: "api.msime.app"] }
-  static func load() throws -> CommunityTokens? {
-    var query = query
-    query[kSecReturnData as String] = true
-    var value: CFTypeRef?
-    let status = SecItemCopyMatching(query as CFDictionary, &value)
-    if status == errSecItemNotFound { return nil }
-    guard status == errSecSuccess, let data = value as? Data else { throw CommunityFailure(message: "请解锁设备后读取登录状态。") }
-    return try JSONDecoder().decode(CommunityTokens.self, from: data)
-  }
-  static func save(_ tokens: CommunityTokens?) throws {
-    guard let tokens else {
-      let status = SecItemDelete(query as CFDictionary)
-      guard status == errSecSuccess || status == errSecItemNotFound else { throw CommunityFailure(message: "无法清除登录状态。") }
-      return
-    }
-    let values: [String: Any] = [kSecValueData as String: try JSONEncoder().encode(tokens)]
-    var status = SecItemUpdate(query as CFDictionary, values as CFDictionary)
-    if status == errSecItemNotFound {
-      var item = query.merging(values) { _, new in new }
-      item[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-      status = SecItemAdd(item as CFDictionary, nil)
-    }
-    guard status == errSecSuccess else { throw CommunityFailure(message: "无法安全保存登录状态。") }
-  }
-}
-
 actor SkinCommunityAPI {
   static let shared = SkinCommunityAPI()
-  private let base = URL(string: "https://api.msime.app")!
-  private let session: URLSession
-  private let readCredentials: @Sendable () throws -> CommunityTokens?
-  private let writeCredentials: @Sendable (CommunityTokens?) throws -> Void
-  init(configuration: URLSessionConfiguration = .ephemeral,
-       readCredentials: @escaping @Sendable () throws -> CommunityTokens? = { try CommunityCredentials.load() },
-       writeCredentials: @escaping @Sendable (CommunityTokens?) throws -> Void = { try CommunityCredentials.save($0) }) {
-    session = URLSession(configuration: configuration, delegate: NoRedirects(), delegateQueue: nil)
-    self.readCredentials = readCredentials
-    self.writeCredentials = writeCredentials
+  private let client: BackendAccountClient
+  private let account: BackendAccountSession
+  init(client: BackendAccountClient = BackendAccountClient(), account: BackendAccountSession = .shared) {
+    self.client = client; self.account = account
   }
-  private var refreshTask: Task<CommunityTokens, Error>?
-  private var generation = 0
-
-  func currentUser() throws -> CommunityUser? { try readCredentials()?.user }
-  func signedIn() throws -> Bool { try readCredentials() != nil }
-  private func transport(_ path: String, method: String, body: Data?, token: String?) async throws -> (Data, Int) {
-    guard let url = URL(string: path, relativeTo: base) else { throw CommunityFailure(message: "请求地址无效。") }
-    var request = URLRequest(url: url)
-    request.httpMethod = method
-    request.httpBody = body
-    request.timeoutInterval = 25
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    if let token { request.setValue("Bearer " + token, forHTTPHeaderField: "Authorization") }
-    let (data, response) = try await session.data(for: request)
-    guard let response = response as? HTTPURLResponse, data.count <= 1_000_000 else { throw CommunityFailure(message: "社区响应格式无效。") }
-    return (data, response.statusCode)
-  }
+  func currentUser() async throws -> CommunityUser? { try await account.user() }
+  func signedIn() async throws -> Bool { try await account.user() != nil }
   private func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil, authenticated: Bool = false) async throws -> T {
-    var tokens = (path == "/v1/auth/challenges" || path == "/v1/auth/login") ? nil : try readCredentials()
-    if authenticated && tokens == nil { throw CommunityFailure(message: "请先使用 Apple 登录。") }
-    if let previous = tokens, Date().timeIntervalSince(previous.saved_at ?? .distantPast) >= Double(max(0, (previous.expires_in ?? 900) - 60)) {
-      tokens = try await refresh(previous)
-    }
-    var (data, status) = try await transport(path, method: method, body: body, token: tokens?.access_token)
-    if status == 401, let tokens {
-      let fresh = try await refresh(tokens)
-      (data, status) = try await transport(path, method: method, body: body, token: fresh.access_token)
-    }
-    guard (200..<300).contains(status) else { throw Self.failure(data, status: status) }
-    return try JSONDecoder().decode(T.self, from: status == 204 ? Data("{}".utf8) : data)
-  }
-  private func refresh(_ previous: CommunityTokens) async throws -> CommunityTokens {
-    if let current = try readCredentials(), current.access_token != previous.access_token { return current }
-    if let refreshTask { return try await refreshTask.value }
-    let currentGeneration = generation
-    let task = Task { () throws -> CommunityTokens in
-      let body = try JSONSerialization.data(withJSONObject: ["refresh_token": previous.refresh_token])
-      let (data, status) = try await self.transport("/v1/auth/refresh", method: "POST", body: body, token: nil)
-      guard status == 200 else { throw Self.failure(data, status: status) }
-      return try JSONDecoder().decode(CommunityTokens.self, from: data)
-    }
-    refreshTask = task
-    defer { refreshTask = nil }
-    var result = try await task.value
-    result.saved_at = Date()
-    guard currentGeneration == generation else { throw CancellationError() }
-    try writeCredentials(result)
-    return result
+    var token: String?
+    if try await account.user() != nil { token = try await account.accessToken() }
+    if authenticated && token == nil { throw CommunityFailure(message: "请先使用 Apple 登录。") }
+    let data: Data
+    do {
+      do { data = try await client.request(method, path, token: token, body: body) }
+      catch let error as BackendAccountClient.Failure where error.status == 401 && token != nil {
+        let fresh = try await account.accessToken(retrying: token)
+        data = try await client.request(method, path, token: fresh, body: body)
+      }
+    } catch let error as BackendAccountClient.Failure { throw Self.failure(Data(), status: error.status) }
+    return try JSONDecoder().decode(T.self, from: data.isEmpty ? Data("{}".utf8) : data)
   }
   private static func failure(_ data: Data, status: Int) -> CommunityFailure {
     let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -149,22 +65,17 @@ actor SkinCommunityAPI {
     return CommunityFailure(message: message)
   }
   func challenge() async throws -> CommunityChallenge {
-    try await request("/v1/auth/challenges", method: "POST", body: JSONSerialization.data(withJSONObject: ["provider": "apple", "purpose": "login"]))
+    let value = try await client.challenge(provider: "apple")
+    guard let nonce = value.nonce else { throw CommunityFailure(message: "Apple 登录暂不可用，请稍后重试。") }
+    return CommunityChallenge(challenge_id: value.challenge_id, nonce: nonce)
   }
   func login(challenge: String, identityToken: String) async throws {
-    var result: CommunityTokens = try await request("/v1/auth/login", method: "POST", body: JSONSerialization.data(withJSONObject: ["challenge_id": challenge, "credential": identityToken]))
-    result.saved_at = Date()
-    generation += 1
-    try writeCredentials(result)
+    try await account.signIn(challenge: challenge, credential: identityToken)
   }
   func profile() async throws -> CommunityProfile {
-    let expectedGeneration = generation
-    let profile: CommunityProfile = try await request("/v1/users/me", authenticated: true)
-    guard expectedGeneration == generation, var tokens = try readCredentials(), tokens.user.id == profile.user.id else {
-      throw CancellationError()
-    }
-    tokens.user = profile.user
-    try writeCredentials(tokens)
+    let token = try await account.accessToken()
+    let profile = try await client.profile(token: token)
+    try await account.updateUser(profile.user, matching: token)
     return profile
   }
   func updateProfile(name: String) async throws -> CommunityProfile {
@@ -173,18 +84,20 @@ actor SkinCommunityAPI {
           !name.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else {
       throw CommunityFailure(message: "昵称需为 1–64 个字符，不能包含换行或控制字符。")
     }
-    let expectedGeneration = generation
-    let _: [String: Bool] = try await request("/v1/users/me", method: "PATCH",
-      body: JSONSerialization.data(withJSONObject: ["display_name": name]), authenticated: true)
-    guard expectedGeneration == generation else { throw CancellationError() }
-    return try await profile()
+    let token = try await account.accessToken()
+    try await client.rename(name, token: token)
+    let profile = try await client.profile(token: token)
+    try await account.updateUser(profile.user, matching: token)
+    return profile
   }
-  func logout(deleteAccount: Bool = false) async throws {
-    let _: [String: Bool] = try await request(deleteAccount ? "/v1/users/me" : "/v1/auth/logout", method: deleteAccount ? "DELETE" : "POST", body: deleteAccount ? nil : JSONSerialization.data(withJSONObject: ["all": false]), authenticated: true)
-    generation += 1
-    try writeCredentials(nil)
+  func logout(deleteAccount: Bool = false, all: Bool = false) async throws {
+    if deleteAccount {
+      let token = try await account.accessToken()
+      try await client.deleteAccount(token: token)
+      try await account.forget()
+    } else { try await account.logout(all: all) }
   }
-  func clearExpiredLogin() throws { generation += 1; try writeCredentials(nil) }
+  func clearExpiredLogin() async throws { try await account.forget() }
   func list(offset: Int = 0, search: String = "") async throws -> CommunityPage {
     var parts = URLComponents()
     parts.path = "/v1/community/skins"

--- a/platforms/ios/App/Sources/AccountCodeLoginView.swift
+++ b/platforms/ios/App/Sources/AccountCodeLoginView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+@MainActor
+final class CodeLoginModel: ObservableObject {
+  @Published var user: BackendAccountClient.User?
+  @Published var providers: [String: Bool] = [:]
+  @Published var busy = false
+  @Published var message: String?
+  let client = BackendAccountClient()
+  let session = BackendAccountSession.shared
+
+  func loadProviders() async {
+    await perform { self.providers = try await self.client.providers() }
+  }
+  func requestCode(provider: String, target: String) async -> BackendAccountClient.Challenge? {
+    var response: BackendAccountClient.Challenge?
+    await perform {
+      guard self.providers[provider] == true else { throw BackendAccountClient.Failure(status: 503) }
+      response = try await self.client.challenge(provider: provider, target: target)
+    }
+    return response
+  }
+  func signInWithCode(challenge: String, code: String) async {
+    await perform {
+      try await self.session.signIn(challenge: challenge, credential: code)
+      self.user = try await self.session.user()
+    }
+  }
+  private func perform(_ operation: () async throws -> Void) async {
+    guard !busy else { return }
+    busy = true; message = nil
+    defer { busy = false }
+    do { try await operation() }
+    catch is CancellationError { }
+    catch let error as BackendAccountClient.Failure { message = error.localizedDescription }
+    catch { message = "连接未完成，请检查网络后重试。" }
+  }
+}
+
+enum CodeLoginChannel: String, CaseIterable, Identifiable {
+  case email, phone
+  var id: String { rawValue }
+  var title: String { self == .email ? "邮箱登录" : "手机号登录" }
+}
+
+struct CodeLoginView: View {
+  @ObservedObject var model: CodeLoginModel
+  let channel: CodeLoginChannel
+  @Environment(\.dismiss) private var dismiss
+  @State private var target = ""
+  @State private var code = ""
+  @State private var challenge: BackendAccountClient.Challenge?
+  @State private var expiresAt = Date.distantPast
+  @State private var resendAt = Date.distantPast
+  @State private var pending: Task<Void, Never>?
+
+  var body: some View {
+    NavigationView {
+      Form {
+        Section {
+          TextField(channel == .email ? "邮箱地址" : "手机号（含国家区号，如 +86）", text: $target)
+            .keyboardType(channel == .email ? .emailAddress : .phonePad)
+            .textContentType(channel == .email ? .emailAddress : .telephoneNumber)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .accessibilityIdentifier("backendCodeTarget")
+            .onChange(of: target) { _ in challenge = nil; code = "" }
+          TimelineView(.periodic(from: .now, by: 1)) { timeline in
+            let seconds = max(0, Int(ceil(resendAt.timeIntervalSince(timeline.date))))
+            Button(seconds == 0 ? "获取验证码" : "\(seconds) 秒后可重新发送") {
+              pending = Task {
+                let response = await model.requestCode(provider: channel.rawValue,
+                  target: target.trimmingCharacters(in: .whitespacesAndNewlines))
+                guard !Task.isCancelled, let response else { return }
+                challenge = response; code = ""
+                expiresAt = Date().addingTimeInterval(TimeInterval(response.expires_in))
+                resendAt = Date().addingTimeInterval(60)
+              }
+            }
+            .disabled(seconds > 0 || target.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          }
+          if let challenge {
+            TextField("6 位验证码", text: $code)
+              .keyboardType(.numberPad)
+              .textContentType(.oneTimeCode)
+              .accessibilityIdentifier("backendVerificationCode")
+            TimelineView(.periodic(from: .now, by: 1)) { timeline in
+              let expired = expiresAt <= timeline.date
+              Button(expired ? "验证码已过期，请重新获取" : "登录") {
+                pending = Task { await model.signInWithCode(challenge: challenge.challenge_id, code: code) }
+              }
+              .disabled(expired || code.utf8.count != 6 || !code.utf8.allSatisfy { (48...57).contains($0) })
+            }
+          }
+        } footer: {
+          Text("验证码只用于本次登录，请勿向他人透露。")
+        }
+        if model.busy { ProgressView("正在处理…") }
+        if let message = model.message { Text(message).foregroundStyle(.secondary) }
+      }
+      .disabled(model.busy)
+      .navigationTitle(channel.title)
+      .toolbar { ToolbarItem(placement: .cancellationAction) { Button("取消") { pending?.cancel(); dismiss() } } }
+    }
+    .onChange(of: model.user?.id) { userID in if userID != nil { dismiss() } }
+    .onDisappear { pending?.cancel() }
+  }
+}

--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -36,6 +36,14 @@ struct AccountSettingsView: View {
         }
       }
 
+      if signedIn {
+        Section("云端数据") {
+          NavigationLink(destination: CloudClipboardView(session: .shared, client: BackendAccountClient())) {
+            Label("云剪贴板", systemImage: "doc.on.clipboard")
+          }.accessibilityIdentifier("accountCloudClipboard")
+        }
+      }
+
       Section("发现与记录") {
         NavigationLink(destination: SkinCommunityView()) {
           HStack(spacing: 12) {
@@ -77,6 +85,8 @@ struct AccountSettingsView: View {
 
 struct AppleAccountSection: View {
   @Binding var signedIn: Bool
+  @StateObject private var codeModel = CodeLoginModel()
+  @State private var codeChannel: CodeLoginChannel?
   @State private var user: CommunityUser?
   @State private var editProfile = false
   @State private var needsRecovery = false
@@ -100,7 +110,7 @@ struct AppleAccountSection: View {
         VStack(alignment: .leading, spacing: 5) {
           Text(signedIn ? displayName : "欢迎来到水杉")
             .font(.title3.bold())
-          Text(signedIn ? "Apple 账号已登录" : "登录，分享你的键盘设计")
+          Text(signedIn ? "水杉账号已登录" : "登录，分享你的键盘设计")
             .font(.subheadline).foregroundStyle(.secondary)
         }
       }.padding(.vertical, 10)
@@ -144,9 +154,17 @@ struct AppleAccountSection: View {
               Task { await prepareLogin() }
             }
           }.accessibilityIdentifier("backendAppleSignIn").signInWithAppleButtonStyle(.black).frame(height: 44).disabled(busy)
-        } else {
+        } else if codeModel.providers["apple"] == true {
           Button("准备 Apple 登录") { Task { await prepareLogin() } }.disabled(busy)
         }
+        ForEach(CodeLoginChannel.allCases) { channel in
+          if codeModel.providers[channel.rawValue] == true {
+            Button(channel.title) { codeModel.user = nil; codeModel.message = nil; codeChannel = channel }
+              .accessibilityIdentifier("backendCodeLogin_\(channel.rawValue)")
+          }
+        }
+        Button("刷新登录方式") { Task { await codeModel.loadProviders(); await prepareLogin() } }
+        if let status = codeModel.message { Text(status).font(.caption).foregroundStyle(.secondary) }
         Text("登录后可在皮肤社区发布、下载和评分。日常输入无需登录。").font(.caption).foregroundStyle(.secondary)
         if needsRecovery {
           Button("清除失效登录状态") { run { try await api.clearExpiredLogin(); signedIn = false; needsRecovery = false; await prepareLogin() } }
@@ -155,6 +173,7 @@ struct AppleAccountSection: View {
       }
     }
     .task {
+      await codeModel.loadProviders()
       do { user = try await api.currentUser(); signedIn = user != nil } catch { needsRecovery = true; message = error.localizedDescription }
       if signedIn {
         do { user = try await api.profile().user }
@@ -162,6 +181,12 @@ struct AppleAccountSection: View {
         catch { message = error.localizedDescription }
       } else { await prepareLogin() }
     }
+    .sheet(item: $codeChannel, onDismiss: {
+      Task {
+        do { user = try await api.currentUser(); signedIn = user != nil }
+        catch { message = error.localizedDescription }
+      }
+    }) { channel in CodeLoginView(model: codeModel, channel: channel) }
     .sheet(isPresented: $editProfile) { AccountProfileEditor { profile in user = profile } }
     .alert("账号与登录", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
       Button("好", role: .cancel) {}
@@ -175,6 +200,7 @@ struct AppleAccountSection: View {
   }
   @MainActor private func prepareLogin() async {
     challenge = nil
+    guard codeModel.providers["apple"] == true else { return }
     do { challenge = try await api.challenge() } catch { message = error.localizedDescription }
   }
   private func run(_ action: @escaping @MainActor () async throws -> Void) {

--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -78,6 +78,7 @@ struct AccountSettingsView: View {
 struct AppleAccountSection: View {
   @Binding var signedIn: Bool
   @State private var user: CommunityUser?
+  @State private var editProfile = false
   @State private var needsRecovery = false
   @State private var busy = false
   @State private var message: String?
@@ -86,7 +87,7 @@ struct AppleAccountSection: View {
   private let api = SkinCommunityAPI.shared
 
   private var displayName: String {
-    guard let name = user?.display_name, !name.isEmpty else { return "水杉用户" }
+    guard let name = user?.display_name, !name.isEmpty else { return "尚未设置昵称" }
     return name
   }
 
@@ -103,6 +104,15 @@ struct AppleAccountSection: View {
         }
       }.padding(.vertical, 10)
       if signedIn {
+        Button { editProfile = true } label: {
+          HStack {
+            Label("个人资料", systemImage: "person.text.rectangle")
+            Spacer()
+            Text(user?.display_name.isEmpty == false ? "查看与编辑" : "设置昵称")
+              .font(.subheadline).foregroundStyle(.secondary)
+            Image(systemName: "chevron.right").font(.caption).foregroundStyle(.secondary)
+          }
+        }.accessibilityIdentifier("editAccountProfile")
         Menu("账号") {
           Button("退出登录") { run { try await api.logout(); signedIn = false; await prepareLogin() } }
           Button("重新登录") { run { try await api.clearExpiredLogin(); signedIn = false; await prepareLogin() } }
@@ -144,8 +154,13 @@ struct AppleAccountSection: View {
     }
     .task {
       do { user = try await api.currentUser(); signedIn = user != nil } catch { needsRecovery = true; message = error.localizedDescription }
-      if !signedIn { await prepareLogin() }
+      if signedIn {
+        do { user = try await api.profile().user }
+        catch is CancellationError { }
+        catch { message = error.localizedDescription }
+      } else { await prepareLogin() }
     }
+    .sheet(isPresented: $editProfile) { AccountProfileEditor { profile in user = profile } }
     .alert("账号与登录", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
       Button("好", role: .cancel) {}
     } message: { Text(message ?? "") }
@@ -160,5 +175,95 @@ struct AppleAccountSection: View {
   private func run(_ action: @escaping @MainActor () async throws -> Void) {
     guard !busy else { return }; busy = true
     Task { defer { busy = false }; do { try await action() } catch { message = error.localizedDescription } }
+  }
+}
+
+struct AccountProfileEditor: View {
+  var onSaved: (CommunityUser) -> Void
+  @Environment(\.dismiss) private var dismiss
+  @State private var profile: CommunityProfile?
+  @State private var name = ""
+  @State private var busy = false
+  @State private var message: String?
+  private var normalizedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
+  private var validName: Bool {
+    !normalizedName.isEmpty && normalizedName.unicodeScalars.count <= 64 &&
+      !normalizedName.unicodeScalars.contains { CharacterSet.controlCharacters.contains($0) }
+  }
+  private var joined: String? {
+    guard let value = profile?.user.created_at else { return nil }
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let fractional = formatter.date(from: value)
+    formatter.formatOptions = [.withInternetDateTime]
+    guard let date = fractional ?? formatter.date(from: value) else { return nil }
+    return date.formatted(date: .abbreviated, time: .omitted)
+  }
+  var body: some View {
+    NavigationView {
+      Form {
+        Section {
+          TextField("设置你的昵称", text: $name)
+            .textContentType(.nickname).submitLabel(.done)
+            .accessibilityIdentifier("accountNicknameField")
+            .disabled(profile == nil || busy)
+          Text("\(normalizedName.unicodeScalars.count)/64").font(.caption).foregroundStyle(.secondary)
+        } header: { Text("昵称") } footer: {
+          Text("昵称会公开显示在你的社区作品上，修改后已发布作品也会使用新昵称。")
+        }
+        if let profile {
+          Section("账号信息") {
+            VStack(alignment: .leading, spacing: 6) {
+              Text("账号 ID")
+              Text(profile.user.id).font(.footnote.monospaced()).foregroundStyle(.secondary).textSelection(.enabled)
+            }
+            HStack {
+              Text("登录方式")
+              Spacer()
+              Text(profile.identities.map { $0.provider == "apple" ? "Apple" : $0.provider }.joined(separator: "、"))
+                .foregroundStyle(.secondary)
+            }
+            if let joined {
+              HStack { Text("注册时间"); Spacer(); Text(joined).foregroundStyle(.secondary) }
+            }
+          }
+        }
+        if busy { ProgressView().frame(maxWidth: .infinity) }
+        if profile == nil && !busy { Button("重新加载资料") { load() } }
+      }
+      .navigationTitle("个人资料").navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() }.disabled(busy) }
+        ToolbarItem(placement: .confirmationAction) {
+          Button("保存") {
+            busy = true
+            Task {
+              defer { busy = false }
+              do {
+                let updated = try await SkinCommunityAPI.shared.updateProfile(name: normalizedName)
+                onSaved(updated.user)
+                dismiss()
+              } catch { message = error.localizedDescription }
+            }
+          }.disabled(busy || profile == nil || !validName || normalizedName == profile?.user.display_name)
+            .accessibilityIdentifier("saveAccountProfile")
+        }
+      }
+      .task { load() }
+      .alert("个人资料", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
+        Button("好", role: .cancel) {}
+      } message: { Text(message ?? "") }
+    }
+  }
+  private func load() {
+    guard !busy else { return }; busy = true
+    Task {
+      defer { busy = false }
+      do {
+        let result = try await SkinCommunityAPI.shared.profile()
+        profile = result; name = result.user.display_name
+        onSaved(result.user)
+      } catch { message = error.localizedDescription }
+    }
   }
 }

--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -1,243 +1,164 @@
-import AuthenticationServices
 import SwiftUI
-
-@MainActor
-final class AccountSettingsModel: ObservableObject {
-  @Published var user: BackendAccountClient.User?
-  @Published var providers: [String: Bool] = [:]
-  @Published var challenge: BackendAccountClient.Challenge?
-  @Published var busy = false
-  @Published var message: String?
-  let client = BackendAccountClient()
-  let session = BackendAccountSession.shared
-
-  func load() async {
-    await perform {
-      self.providers = try await self.client.providers()
-      self.user = try await self.session.user()
-      if self.user != nil {
-        do {
-          let token = try await self.session.accessToken()
-          self.user = try await self.client.profile(token: token).user
-        } catch let failure as BackendAccountClient.Failure where failure.status == 401 {
-          try await self.session.forget(); self.user = nil
-        }
-      }
-      if self.user == nil && self.providers["apple"] == true {
-        self.challenge = try await self.client.challenge(provider: "apple")
-      }
-    }
-  }
-  func signIn(_ authorization: ASAuthorization, challenge: BackendAccountClient.Challenge) async {
-    await perform {
-      guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
-            credential.state == challenge.challenge_id,
-            let bytes = credential.identityToken, let token = String(data: bytes, encoding: .utf8)
-      else { throw BackendAccountClient.Failure(status: 401) }
-      try await self.session.signIn(challenge: challenge.challenge_id, credential: token)
-      self.user = try await self.session.user(); self.challenge = nil
-    }
-  }
-  func requestCode(provider: String, target: String) async -> BackendAccountClient.Challenge? {
-    var response: BackendAccountClient.Challenge?
-    await perform {
-      guard self.providers[provider] == true else { throw BackendAccountClient.Failure(status: 503) }
-      response = try await self.client.challenge(provider: provider, target: target)
-    }
-    return response
-  }
-  func signInWithCode(challenge: String, code: String) async {
-    await perform {
-      try await self.session.signIn(challenge: challenge, credential: code)
-      self.user = try await self.session.user(); self.challenge = nil
-    }
-  }
-  func rename(_ name: String) async {
-    await perform {
-      let token = try await self.session.accessToken()
-      try await self.client.rename(name, token: token)
-      self.user = try await self.client.profile(token: token).user
-    }
-  }
-  func logout(all: Bool = false) async {
-    await perform {
-      defer { self.user = nil; self.challenge = nil }
-      try await self.session.logout(all: all)
-    }
-    let logoutMessage = message
-    await load()
-    if let logoutMessage { message = logoutMessage }
-  }
-  func deleteAccount() async {
-    await perform {
-      let token = try await self.session.accessToken()
-      try await self.client.deleteAccount(token: token)
-      try await self.session.forget(); self.user = nil; self.challenge = nil
-    }
-    if user == nil { await load() }
-  }
-  private func perform(_ operation: () async throws -> Void) async {
-    guard !busy else { return }
-    busy = true; message = nil
-    defer { busy = false }
-    do { try await operation() }
-    catch is CancellationError { }
-    catch let error as BackendAccountClient.Failure { message = error.localizedDescription }
-    catch { message = "连接未完成，请检查网络后重试。" }
-  }
-}
+import AuthenticationServices
 
 struct AccountSettingsView: View {
-  @StateObject private var model = AccountSettingsModel()
-  @State private var appleChallenge: BackendAccountClient.Challenge?
-  @State private var name = ""
-  @State private var codeChannel: CodeLoginChannel?
-  @State private var confirmDelete = false
-  @State private var confirmLogoutAll = false
+  @State private var signedIn = false
+  @State private var designs = CustomSkinLibrary.designs
+  @State private var showPublish = false
 
   var body: some View {
     Form {
-      if let user = model.user {
-        Section("我的账号") {
-          Text(user.display_name.isEmpty ? "水杉用户" : user.display_name)
-          TextField("昵称", text: $name)
-            .onAppear { name = user.display_name }
-            .accessibilityIdentifier("accountDisplayName")
-          Button("保存昵称") { Task { await model.rename(name) } }
-            .disabled(name.count > 64 || name == user.display_name)
-          Button("退出登录") { Task { await model.logout() } }
-          Button("退出所有设备") { confirmLogoutAll = true }
-        }
-        Section("云端数据") {
-          NavigationLink(destination: CloudClipboardView(session: model.session, client: model.client)) {
-            Label("云剪贴板", systemImage: "doc.on.clipboard")
-          }
-        }
-        Section {
-          Button("注销账号", role: .destructive) { confirmDelete = true }
-        } footer: {
-          Text("注销会删除云端账号及关联的词库、设置和剪贴板数据，需要最近十分钟内登录。")
-        }
-      } else {
-        Section {
-          if model.providers["apple"] == true {
-            SignInWithAppleButton(.signIn) { request in
-              appleChallenge = model.challenge
-              request.nonce = model.challenge?.nonce
-              request.state = model.challenge?.challenge_id
-            } onCompletion: { result in
-              guard let challenge = appleChallenge else { return }
-              appleChallenge = nil
-              switch result {
-              case .success(let authorization): Task { await model.signIn(authorization, challenge: challenge) }
-              case .failure(let error):
-                if (error as? ASAuthorizationError)?.code != .canceled {
-                  model.message = "Apple 登录未完成，请重试。"
-                }
-                Task { await model.load() }
+      AppleAccountSection(signedIn: $signedIn)
+
+      Section("我的创作") {
+        NavigationLink(destination: CustomSkinEditorView()) {
+          HStack(spacing: 12) {
+            accountIcon("paintbrush.pointed.fill", color: .purple)
+            VStack(alignment: .leading, spacing: 4) {
+              Text("我的设计").foregroundStyle(.primary)
+              Text("保存在本机的 \(designs.count) 款皮肤").font(.caption).foregroundStyle(.secondary)
+            }
+          }.padding(.vertical, 4)
+        }.accessibilityIdentifier("accountLocalDesigns")
+        if signedIn {
+          NavigationLink(destination: SkinCommunityView(onlyMine: true)) {
+            HStack(spacing: 12) {
+              accountIcon("square.stack.3d.up.fill", color: .orange)
+              VStack(alignment: .leading, spacing: 4) {
+                Text("已发布作品").foregroundStyle(.primary)
+                Text("查看下载、评分和管理作品").font(.caption).foregroundStyle(.secondary)
               }
-            }
-            .frame(height: 46)
-            .disabled(model.challenge?.nonce == nil)
-            .accessibilityIdentifier("backendAppleSignIn")
+            }.padding(.vertical, 4)
+          }.accessibilityIdentifier("accountPublishedSkins")
+          Button { showPublish = true } label: {
+            Label("发布新作品", systemImage: "square.and.arrow.up")
           }
-          ForEach(CodeLoginChannel.allCases) { channel in
-            if model.providers[channel.rawValue] == true {
-              Button(channel.title) { model.message = nil; codeChannel = channel }
-                .accessibilityIdentifier("backendCodeLogin_\(channel.rawValue)")
-            }
-          }
-          Button("刷新登录方式") { Task { await model.load() } }
-        } header: {
-          Text("登录水杉账号")
-        } footer: {
-          Text("登录本身不会上传输入内容、个人词库或系统剪贴板。")
         }
       }
-      if model.busy { ProgressView("正在处理…") }
-      if let message = model.message { Text(message).foregroundStyle(.secondary) }
+
+      Section("发现与记录") {
+        NavigationLink(destination: SkinCommunityView()) {
+          HStack(spacing: 12) {
+            accountIcon("person.3.fill", color: MetasequoiaTheme.forest)
+            VStack(alignment: .leading, spacing: 4) {
+              Text("皮肤社区").foregroundStyle(.primary)
+              Text("发现设计，下载使用，为喜欢的作品评分").font(.caption).foregroundStyle(.secondary)
+            }
+          }.padding(.vertical, 4)
+        }
+        NavigationLink(destination: TypingStatisticsView()) {
+          HStack(spacing: 12) {
+            accountIcon("chart.bar.xaxis", color: .blue)
+            VStack(alignment: .leading, spacing: 4) {
+              Text("我的打字统计").foregroundStyle(.primary)
+              Text("查看输入趋势和语言分布").font(.caption).foregroundStyle(.secondary)
+            }
+          }.padding(.vertical, 4)
+        }
+      }
+      Section {
+        Label("本地数据与云端作品", systemImage: "lock.shield")
+          .font(.subheadline)
+        Text("皮肤设计和打字统计保存在本机。只有你主动发布的作品会分享至社区；Apple 登录不会自动上传本地设计或输入记录。")
+          .font(.caption).foregroundStyle(.secondary)
+      }
     }
-    .disabled(model.busy)
-    .navigationTitle("账号")
-    .task { await model.load() }
-    .sheet(item: $codeChannel) { channel in CodeLoginView(model: model, channel: channel) }
-    .alert("注销水杉账号？", isPresented: $confirmDelete) {
-      Button("取消", role: .cancel) { }
-      Button("永久注销", role: .destructive) { Task { await model.deleteAccount() } }
-    } message: { Text("此操作无法撤销。云端账号及关联数据将被删除。") }
-    .alert("退出所有设备？", isPresented: $confirmLogoutAll) {
-      Button("取消", role: .cancel) { }
-      Button("退出所有设备", role: .destructive) { Task { await model.logout(all: true) } }
-    } message: { Text("所有设备都需要重新登录。") }
+    .navigationTitle("我的")
+    .task { designs = CustomSkinLibrary.designs }
+    .sheet(isPresented: $showPublish) { CommunityPublishView {} }
+  }
+
+  private func accountIcon(_ symbol: String, color: Color) -> some View {
+    Image(systemName: symbol).font(.system(size: 19, weight: .semibold))
+      .foregroundStyle(color).frame(width: 42, height: 42)
+      .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
   }
 }
 
-enum CodeLoginChannel: String, CaseIterable, Identifiable {
-  case email, phone
-  var id: String { rawValue }
-  var title: String { self == .email ? "邮箱登录" : "手机号登录" }
-}
+struct AppleAccountSection: View {
+  @Binding var signedIn: Bool
+  @State private var user: CommunityUser?
+  @State private var needsRecovery = false
+  @State private var busy = false
+  @State private var message: String?
+  @State private var challenge: CommunityChallenge?
+  @State private var confirmDeleteAccount = false
+  private let api = SkinCommunityAPI.shared
 
-private struct CodeLoginView: View {
-  @ObservedObject var model: AccountSettingsModel
-  let channel: CodeLoginChannel
-  @Environment(\.dismiss) private var dismiss
-  @State private var target = ""
-  @State private var code = ""
-  @State private var challenge: BackendAccountClient.Challenge?
-  @State private var expiresAt = Date.distantPast
-  @State private var resendAt = Date.distantPast
-  @State private var pending: Task<Void, Never>?
+  private var displayName: String {
+    guard let name = user?.display_name, !name.isEmpty else { return "水杉用户" }
+    return name
+  }
 
   var body: some View {
-    NavigationView {
-      Form {
-        Section {
-          TextField(channel == .email ? "邮箱地址" : "手机号（含国家区号，如 +86）", text: $target)
-            .keyboardType(channel == .email ? .emailAddress : .phonePad)
-            .textContentType(channel == .email ? .emailAddress : .telephoneNumber)
-            .textInputAutocapitalization(.never)
-            .autocorrectionDisabled()
-            .accessibilityIdentifier("backendCodeTarget")
-            .onChange(of: target) { _ in challenge = nil; code = "" }
-          TimelineView(.periodic(from: .now, by: 1)) { timeline in
-            let seconds = max(0, Int(ceil(resendAt.timeIntervalSince(timeline.date))))
-            Button(seconds == 0 ? "获取验证码" : "\(seconds) 秒后可重新发送") {
-              pending = Task {
-                let response = await model.requestCode(provider: channel.rawValue,
-                  target: target.trimmingCharacters(in: .whitespacesAndNewlines))
-                guard !Task.isCancelled, let response else { return }
-                challenge = response; code = ""
-                expiresAt = Date().addingTimeInterval(TimeInterval(response.expires_in))
-                resendAt = Date().addingTimeInterval(60)
-              }
-            }
-            .disabled(seconds > 0 || target.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-          }
-          if let challenge {
-            TextField("6 位验证码", text: $code)
-              .keyboardType(.numberPad)
-              .textContentType(.oneTimeCode)
-              .accessibilityIdentifier("backendVerificationCode")
-            TimelineView(.periodic(from: .now, by: 1)) { timeline in
-              let expired = expiresAt <= timeline.date
-              Button(expired ? "验证码已过期，请重新获取" : "登录") {
-                pending = Task { await model.signInWithCode(challenge: challenge.challenge_id, code: code) }
-              }
-              .disabled(expired || code.utf8.count != 6 || !code.utf8.allSatisfy { (48...57).contains($0) })
-            }
-          }
-        } footer: {
-          Text("验证码只用于本次登录，请勿向他人透露。")
+    Section {
+      HStack(spacing: 14) {
+        Image(systemName: signedIn ? "person.crop.circle.fill" : "person.crop.circle")
+          .font(.system(size: 48)).foregroundStyle(MetasequoiaTheme.forest)
+        VStack(alignment: .leading, spacing: 5) {
+          Text(signedIn ? displayName : "欢迎来到水杉")
+            .font(.title3.bold())
+          Text(signedIn ? "Apple 账号已登录" : "登录，分享你的键盘设计")
+            .font(.subheadline).foregroundStyle(.secondary)
         }
-        if model.busy { ProgressView("正在处理…") }
-        if let message = model.message { Text(message).foregroundStyle(.secondary) }
+      }.padding(.vertical, 10)
+      if signedIn {
+        Menu("账号") {
+          Button("退出登录") { run { try await api.logout(); signedIn = false; await prepareLogin() } }
+          Button("重新登录") { run { try await api.clearExpiredLogin(); signedIn = false; await prepareLogin() } }
+          Button("注销账号", role: .destructive) { confirmDeleteAccount = true }
+        }
+      } else {
+        if let challenge {
+          SignInWithAppleButton(.signIn) { request in
+            request.nonce = challenge.nonce
+            request.state = challenge.challenge_id
+          } onCompletion: { result in
+            switch result {
+            case .success(let authorization):
+              guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                    credential.state == challenge.challenge_id,
+                    let data = credential.identityToken, let token = String(data: data, encoding: .utf8) else {
+                message = "Apple 登录未返回有效凭据，请重试。"; Task { await prepareLogin() }; return
+              }
+              run {
+                do { try await api.login(challenge: challenge.challenge_id, identityToken: token) }
+                catch { await prepareLogin(); throw error }
+                user = try await api.currentUser()
+                signedIn = true
+              }
+            case .failure(let error):
+              if (error as? ASAuthorizationError)?.code != .canceled { message = error.localizedDescription }
+              Task { await prepareLogin() }
+            }
+          }.signInWithAppleButtonStyle(.black).frame(height: 44).disabled(busy)
+        } else {
+          Button("准备 Apple 登录") { Task { await prepareLogin() } }.disabled(busy)
+        }
+        Text("登录后可在皮肤社区发布、下载和评分。日常输入无需登录。").font(.caption).foregroundStyle(.secondary)
+        if needsRecovery {
+          Button("清除失效登录状态") { run { try await api.clearExpiredLogin(); signedIn = false; needsRecovery = false; await prepareLogin() } }
+            .font(.caption)
+        }
       }
-      .disabled(model.busy)
-      .navigationTitle(channel.title)
-      .toolbar { ToolbarItem(placement: .cancellationAction) { Button("取消") { pending?.cancel(); dismiss() } } }
     }
-    .onChange(of: model.user?.id) { userID in if userID != nil { dismiss() } }
-    .onDisappear { pending?.cancel() }
+    .task {
+      do { user = try await api.currentUser(); signedIn = user != nil } catch { needsRecovery = true; message = error.localizedDescription }
+      if !signedIn { await prepareLogin() }
+    }
+    .alert("账号与登录", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
+      Button("好", role: .cancel) {}
+    } message: { Text(message ?? "") }
+    .confirmationDialog("注销账号将删除已发布皮肤、评分及其他云端账号数据，无法撤销。", isPresented: $confirmDeleteAccount, titleVisibility: .visible) {
+      Button("注销账号", role: .destructive) { run { try await api.logout(deleteAccount: true); signedIn = false; await prepareLogin() } }
+    }
+  }
+  @MainActor private func prepareLogin() async {
+    challenge = nil
+    do { challenge = try await api.challenge() } catch { message = error.localizedDescription }
+  }
+  private func run(_ action: @escaping @MainActor () async throws -> Void) {
+    guard !busy else { return }; busy = true
+    Task { defer { busy = false }; do { try await action() } catch { message = error.localizedDescription } }
   }
 }

--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -84,6 +84,7 @@ struct AppleAccountSection: View {
   @State private var message: String?
   @State private var challenge: CommunityChallenge?
   @State private var confirmDeleteAccount = false
+  @State private var confirmLogoutAll = false
   private let api = SkinCommunityAPI.shared
 
   private var displayName: String {
@@ -115,6 +116,7 @@ struct AppleAccountSection: View {
         }.accessibilityIdentifier("editAccountProfile")
         Menu("账号") {
           Button("退出登录") { run { try await api.logout(); signedIn = false; await prepareLogin() } }
+          Button("退出所有设备") { confirmLogoutAll = true }
           Button("重新登录") { run { try await api.clearExpiredLogin(); signedIn = false; await prepareLogin() } }
           Button("注销账号", role: .destructive) { confirmDeleteAccount = true }
         }
@@ -141,7 +143,7 @@ struct AppleAccountSection: View {
               if (error as? ASAuthorizationError)?.code != .canceled { message = error.localizedDescription }
               Task { await prepareLogin() }
             }
-          }.signInWithAppleButtonStyle(.black).frame(height: 44).disabled(busy)
+          }.accessibilityIdentifier("backendAppleSignIn").signInWithAppleButtonStyle(.black).frame(height: 44).disabled(busy)
         } else {
           Button("准备 Apple 登录") { Task { await prepareLogin() } }.disabled(busy)
         }
@@ -164,6 +166,9 @@ struct AppleAccountSection: View {
     .alert("账号与登录", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
       Button("好", role: .cancel) {}
     } message: { Text(message ?? "") }
+    .confirmationDialog("退出所有设备后，所有设备都需要重新登录。", isPresented: $confirmLogoutAll, titleVisibility: .visible) {
+      Button("退出所有设备") { run { try await api.logout(all: true); signedIn = false; await prepareLogin() } }
+    }
     .confirmationDialog("注销账号将删除已发布皮肤、评分及其他云端账号数据，无法撤销。", isPresented: $confirmDeleteAccount, titleVisibility: .visible) {
       Button("注销账号", role: .destructive) { run { try await api.logout(deleteAccount: true); signedIn = false; await prepareLogin() } }
     }
@@ -174,7 +179,17 @@ struct AppleAccountSection: View {
   }
   private func run(_ action: @escaping @MainActor () async throws -> Void) {
     guard !busy else { return }; busy = true
-    Task { defer { busy = false }; do { try await action() } catch { message = error.localizedDescription } }
+    Task {
+      defer { busy = false }
+      do { try await action() }
+      catch {
+        message = error.localizedDescription
+        if let state = try? await api.signedIn() {
+          signedIn = state
+          if !state { await prepareLogin() }
+        }
+      }
+    }
   }
 }
 

--- a/platforms/ios/App/Sources/CustomSkinEditorView.swift
+++ b/platforms/ios/App/Sources/CustomSkinEditorView.swift
@@ -1,18 +1,49 @@
 import SwiftUI
 import UIKit
+import PhotosUI
+import UniformTypeIdentifiers
+import ImageIO
 
 struct CustomSkinEditorView: View {
+  @Environment(\.scenePhase) private var scenePhase
   @State private var design = CustomKeyboardSkinStore.current
   @State private var nineKey = InputSchemePreference.scheme == .nineKey
   @State private var confirmReset = false
+  @State private var section = "设计"
+  @State private var undo: [CustomKeyboardSkin] = []
+  @State private var redo: [CustomKeyboardSkin] = []
+  @State private var sliderStart: CustomKeyboardSkin?
+  @State private var saved = CustomSkinLibrary.designs
+  @State private var showSave = false
+  @State private var name = ""
+  @State private var renaming: UUID?
+  @State private var deleting: SavedKeyboardSkin?
+  @State private var replacing: SavedKeyboardSkin?
+  @State private var showPhotos = false
+  @State private var message: String?
+
+  private func apply(_ next: CustomKeyboardSkin, record: Bool = true) {
+    let next = next.normalized
+    guard next != design else { return }
+    if record { undo.append(design); undo = Array(undo.suffix(30)); redo.removeAll() }
+    CustomKeyboardSkinStore.save(next)
+    design = next
+  }
   @AppStorage(KeyboardSkinPreference.key, store: KeyboardFeedbackPreference.defaults)
   private var selected = KeyboardSkin.forest.rawValue
 
   private func update<T>(_ path: WritableKeyPath<CustomKeyboardSkin, T>, _ value: T) {
     var next = design
     next[keyPath: path] = value
-    CustomKeyboardSkinStore.save(next)
-    design = next.normalized
+    apply(next, record: sliderStart == nil)
+  }
+
+  private func trackSlider(_ editing: Bool) {
+    if editing { sliderStart = design }
+    else {
+      if let start = sliderStart, start != design { undo.append(start); undo = Array(undo.suffix(30)); redo.removeAll() }
+      sliderStart = nil
+    }
   }
 
   private func color(_ path: WritableKeyPath<CustomKeyboardSkin, UInt32>) -> Binding<Color> {
@@ -25,22 +56,98 @@ struct CustomSkinEditorView: View {
   }
 
   var body: some View {
-    Form {
-      Section("实时预览") {
-        Picker("预览布局", selection: $nineKey) {
-          Text("26 键").tag(false)
-          Text("9 键").tag(true)
-        }.pickerStyle(.segmented)
-        KeyboardSkinPreview(skin: .custom, nineKey: nineKey)
-          .id(design)
-          .listRowInsets(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
-        Button {
-          selected = KeyboardSkin.custom.rawValue
-        } label: {
-          Label(selected == KeyboardSkin.custom.rawValue ? "正在使用我的皮肤" : "使用这款皮肤",
-                systemImage: selected == KeyboardSkin.custom.rawValue ? "checkmark.circle.fill" : "checkmark.circle")
-        }.accessibilityIdentifier("applyCustomSkin")
-      }
+    GeometryReader { geometry in
+      VStack(spacing: 0) {
+        VStack(spacing: 2) {
+          HStack {
+            Picker("预览布局", selection: $nineKey) {
+              Text("26 键").tag(false)
+              Text("9 键").tag(true)
+            }.pickerStyle(.segmented)
+            Button { guard let previous = undo.popLast() else { return }; redo.append(design); apply(previous, record: false) } label: {
+              Image(systemName: "arrow.uturn.backward").frame(width: 44, height: 44)
+            }.disabled(undo.isEmpty || sliderStart != nil).accessibilityLabel("撤销设计").accessibilityIdentifier("undoSkinDesign")
+            Button { guard let next = redo.popLast() else { return }; undo.append(design); apply(next, record: false) } label: {
+              Image(systemName: "arrow.uturn.forward").frame(width: 44, height: 44)
+            }.disabled(redo.isEmpty || sliderStart != nil).accessibilityLabel("重做设计")
+          }.padding(.horizontal)
+          KeyboardSkinPreview(skin: .custom, nineKey: nineKey)
+            .id(design)
+            .frame(height: 250)
+            .scaleEffect(geometry.size.height < 650 ? 0.70 : 0.84)
+            .frame(height: geometry.size.height < 650 ? 175 : 210)
+          HStack {
+            Button {
+              selected = KeyboardSkin.custom.rawValue
+            } label: {
+              Label(selected == KeyboardSkin.custom.rawValue ? "正在使用我的皮肤" : "使用这款皮肤", systemImage: "checkmark.circle.fill")
+            }.accessibilityIdentifier("applyCustomSkin")
+            Spacer()
+            Button { renaming = nil; name = "我的设计 \(saved.count + 1)"; showSave = true } label: {
+              Label("存为新皮肤", systemImage: "square.and.arrow.down")
+            }.accessibilityIdentifier("saveCustomSkin")
+          }.font(.subheadline).padding(.horizontal).frame(minHeight: 44)
+        }
+        Picker("编辑类别", selection: $section) {
+          ForEach(["设计", "背景", "配色", "键帽", "我的"], id: \.self) { Text($0).tag($0) }
+        }.pickerStyle(.segmented).padding(.horizontal).padding(.vertical, 8)
+          .accessibilityIdentifier("customSkinSections")
+        Form {
+          if section == "设计" {
+            Section("从一款设计开始") {
+              LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                ForEach(CustomKeyboardSkin.templates, id: \.0) { title, template in
+                  Button { apply(template) } label: {
+                    VStack(alignment: .leading, spacing: 10) {
+                      HStack(spacing: 5) {
+                        ForEach(["A", "S", "↵"], id: \.self) { key in
+                          Text(key).font(.system(.body, design: template.monospaced ? .monospaced : .default).weight(.medium))
+                            .frame(maxWidth: .infinity).frame(height: 34)
+                            .foregroundStyle(Color(uiColor: CustomKeyboardSkin.color(template.keyForeground)))
+                            .background(Color(uiColor: CustomKeyboardSkin.color(template.keyBackground)), in: RoundedRectangle(cornerRadius: template.cornerRadius * 0.6))
+                        }
+                      }
+                      Text(title).font(.caption.weight(.semibold)).foregroundStyle(Color(uiColor: CustomKeyboardSkin.color(template.accent)))
+                    }.padding(10).background(LinearGradient(colors: [Color(uiColor: CustomKeyboardSkin.color(template.background)), Color(uiColor: CustomKeyboardSkin.color(template.gradientEnd ?? template.background))], startPoint: .topLeading, endPoint: .bottomTrailing), in: RoundedRectangle(cornerRadius: 12))
+                  }.buttonStyle(.plain).accessibilityIdentifier("skinTemplate_" + title)
+                }
+              }
+            }
+            Section { Text("选择模板后，继续调整背景、配色和键帽。修改自动保存；撤销可找回刚才的设计，命名保存可保留多套方案。").font(.footnote).foregroundStyle(.secondary) }
+            Section { Button("重置我的皮肤", role: .destructive) { confirmReset = true } }
+          }
+          if section == "背景" {
+            Section("背景底色") {
+              ColorPicker("背景起始色", selection: color(\.background), supportsOpacity: false)
+              Toggle("渐变背景", isOn: Binding(get: { design.gradientEnd != nil }, set: { update(\.gradientEnd, $0 ? design.background : nil) }))
+                .accessibilityIdentifier("customSkinGradient")
+              if design.gradientEnd != nil {
+                ColorPicker("渐变结束色", selection: Binding(get: { Color(uiColor: CustomKeyboardSkin.color(design.gradientEnd ?? design.background)) }, set: { update(\.gradientEnd, CustomKeyboardSkin.rgb(UIColor($0))) }), supportsOpacity: false)
+                Toggle("横向渐变", isOn: Binding(get: { design.gradientHorizontal ?? false }, set: { update(\.gradientHorizontal, $0) }))
+              }
+            }
+            Section("照片壁纸") {
+              Button { showPhotos = true } label: { Label(design.photo == nil ? "选择照片" : "更换照片", systemImage: "photo") }
+                .accessibilityIdentifier("customSkinPhoto")
+              if design.photo != nil {
+                Text("照片位置").font(.subheadline)
+                Slider(value: Binding(get: { design.photoPosition ?? 0.5 }, set: { update(\.photoPosition, $0) }), in: 0...1, onEditingChanged: trackSlider)
+                Text("压暗照片 · \(Int((design.photoShade ?? 0.25) * 100))%")
+                Slider(value: Binding(get: { design.photoShade ?? 0.25 }, set: { update(\.photoShade, $0) }), in: 0...0.8, onEditingChanged: trackSlider)
+                Button("移除照片", role: .destructive) { update(\.photo, nil) }
+              }
+            }
+            Section("纹理") {
+              Picker("背景纹理", selection: value(\.pattern)) {
+                Text("纯色").tag(0); Text("网点").tag(1); Text("网格").tag(2); Text("波纹").tag(3)
+              }.accessibilityIdentifier("customSkinPattern")
+              if design.pattern != 0 {
+                Text("纹理强度 · \(Int((design.patternOpacity ?? 0.15) * 100))%")
+                Slider(value: Binding(get: { design.patternOpacity ?? 0.15 }, set: { update(\.patternOpacity, $0) }), in: 0...0.5, onEditingChanged: trackSlider)
+              }
+            }
+          }
+          if section == "配色" {
       Section("配色") {
         ColorPicker("键盘背景", selection: color(\.background), supportsOpacity: false)
         ColorPicker("键帽", selection: color(\.keyBackground), supportsOpacity: false)
@@ -57,48 +164,157 @@ struct CustomSkinEditorView: View {
           let black = min(CustomKeyboardSkin.contrast(0, next.background), CustomKeyboardSkin.contrast(0, next.keyBackground))
           let white = min(CustomKeyboardSkin.contrast(0xFFFFFF, next.background), CustomKeyboardSkin.contrast(0xFFFFFF, next.keyBackground))
           next.accent = black >= white ? 0 : 0xFFFFFF
-          CustomKeyboardSkinStore.save(next)
-          design = next
+          apply(next)
         }
       }
+      }
+      if section == "键帽" {
       Section("键帽设计") {
         VStack(alignment: .leading) {
+          Text("键帽不透明度 · \(Int((design.keyOpacity ?? 1) * 100))%")
+          Slider(value: Binding(get: { design.keyOpacity ?? 1 }, set: { update(\.keyOpacity, $0) }), in: 0.25...1, onEditingChanged: trackSlider)
+            .accessibilityIdentifier("customSkinKeyOpacity")
+        }
+        if design.photo != nil || (design.keyOpacity ?? 1) < 1 {
+          Text("半透明键帽会露出背景。可在“背景”中压暗照片，让文字更清晰。").font(.footnote).foregroundStyle(.secondary)
+        }
+        VStack(alignment: .leading) {
           Text("圆角 · \(Int(design.cornerRadius))")
-          Slider(value: value(\.cornerRadius), in: 0...20, step: 1)
+          Slider(value: value(\.cornerRadius), in: 0...20, step: 1, onEditingChanged: trackSlider)
             .accessibilityIdentifier("customSkinCornerRadius")
         }
         VStack(alignment: .leading) {
           Text("边框 · \(design.borderWidth, specifier: "%.1f")")
-          Slider(value: value(\.borderWidth), in: 0...2, step: 0.5)
+          Slider(value: value(\.borderWidth), in: 0...2, step: 0.5, onEditingChanged: trackSlider)
         }
         VStack(alignment: .leading) {
           Text("阴影 · \(Int(design.shadow * 100))%")
-          Slider(value: value(\.shadow), in: 0...0.4, step: 0.05)
+          Slider(value: value(\.shadow), in: 0...0.4, step: 0.05, onEditingChanged: trackSlider)
         }
         Toggle("等宽字形", isOn: value(\.monospaced))
           .accessibilityIdentifier("customSkinMonospaced")
-        Picker("背景纹理", selection: value(\.pattern)) {
-          Text("纯色").tag(0)
-          Text("网点").tag(1)
-          Text("网格").tag(2)
-          Text("波纹").tag(3)
-        }.accessibilityIdentifier("customSkinPattern")
+        ColorPicker("边框颜色", selection: Binding(get: { Color(uiColor: CustomKeyboardSkin.color(design.customBorderColor ?? design.accent)) }, set: { update(\.customBorderColor, CustomKeyboardSkin.rgb(UIColor($0))) }), supportsOpacity: false)
       }
-      Section {
-        Button("重置我的皮肤", role: .destructive) { confirmReset = true }
-      } footer: {
-        Text("修改自动保存在设备上。使用中的自定义皮肤会在下次打开键盘时更新；配色在浅色和深色模式下保持一致。功能键文字会自动选择黑色或白色。")
       }
+      if section == "我的" {
+        Section("我的皮肤 · \(saved.count)/12") {
+          if saved.isEmpty { Text("还没有命名保存的皮肤。调整满意后，点击上方“存为新皮肤”。").foregroundStyle(.secondary) }
+          ForEach(saved) { item in
+            HStack {
+              Button { apply(item.design) } label: {
+                HStack {
+                  RoundedRectangle(cornerRadius: 6).fill(Color(uiColor: CustomKeyboardSkin.color(item.design.background))).frame(width: 32, height: 32)
+                  Text(item.name)
+                }
+              }.accessibilityIdentifier("savedSkin_" + item.name)
+              Spacer()
+              Menu {
+                Button("用当前设计更新") { replacing = item }
+                Button("重命名") { renaming = item.id; name = item.name; showSave = true }
+                Button("删除", role: .destructive) { deleting = item }
+              } label: { Image(systemName: "ellipsis.circle").frame(width: 44, height: 44) }
+                .accessibilityLabel("管理" + item.name)
+            }
+          }
+        }
+      }
+        }
+      }
+    }
+    .onChange(of: scenePhase) { phase in
+      guard phase == .active else { return }
+      let current = CustomKeyboardSkinStore.current
+      if current != design { design = current; undo.removeAll(); redo.removeAll() }
+      saved = CustomSkinLibrary.designs
     }
     .navigationTitle("自定义皮肤")
     .navigationBarTitleDisplayMode(.inline)
+    .sheet(isPresented: $showPhotos) {
+      SkinPhotoPicker { data in
+        showPhotos = false
+        if let data { update(\.photo, data) }
+        else { message = "无法读取这张照片，请换一张再试。" }
+      }
+    }
+    .sheet(isPresented: $showSave) {
+      NavigationView {
+        Form {
+          TextField("皮肤名称", text: $name).accessibilityIdentifier("customSkinName")
+            .onChange(of: name) { if $0.count > 32 { name = String($0.prefix(32)) } }
+          Button("保存") {
+            let title = String(name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(32))
+            guard !saved.contains(where: { $0.id != renaming && $0.name == title }) else {
+              showSave = false; message = "已经有同名皮肤，请换一个名称。"; return
+            }
+            if let id = renaming, let index = saved.firstIndex(where: { $0.id == id }) { saved[index].name = title }
+            else if saved.count < 12 { saved.append(SavedKeyboardSkin(name: title, design: design)) }
+            else { showSave = false; message = "最多保存 12 套皮肤，请先删除不需要的设计。"; return }
+            guard CustomSkinLibrary.save(saved) else {
+              saved = CustomSkinLibrary.designs
+              showSave = false; message = "保存失败，请检查设备可用空间后重试。"; return
+            }
+            showSave = false
+            section = "我的"
+          }.disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .accessibilityIdentifier("confirmSaveCustomSkin")
+        }.navigationTitle(renaming == nil ? "保存我的皮肤" : "重命名")
+          .toolbar { ToolbarItem(placement: .cancellationAction) { Button("取消") { showSave = false } } }
+      }
+    }
+    .alert("提示", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
+      Button("好") { message = nil }
+    } message: { Text(message ?? "") }
+    .confirmationDialog("用当前设计更新“\(replacing?.name ?? "")”？", isPresented: Binding(get: { replacing != nil }, set: { if !$0 { replacing = nil } }), titleVisibility: .visible) {
+      Button("更新已保存的皮肤") {
+        if let item = replacing, let index = saved.firstIndex(where: { $0.id == item.id }) {
+          saved[index].design = design
+          if !CustomSkinLibrary.save(saved) { saved = CustomSkinLibrary.designs; message = "保存失败，请重试。" }
+        }
+        replacing = nil
+      }
+    }
+    .confirmationDialog("删除这套已保存的皮肤？", isPresented: Binding(get: { deleting != nil }, set: { if !$0 { deleting = nil } }), titleVisibility: .visible) {
+      Button("删除", role: .destructive) {
+        if let item = deleting {
+          saved.removeAll { $0.id == item.id }
+          if !CustomSkinLibrary.save(saved) { saved = CustomSkinLibrary.designs; message = "删除失败，请重试。" }
+        }
+        deleting = nil
+      }
+    }
     .confirmationDialog("恢复默认配色和键帽设计？", isPresented: $confirmReset, titleVisibility: .visible) {
       Button("重置", role: .destructive) {
         let initial = CustomKeyboardSkin()
-        CustomKeyboardSkinStore.save(initial)
-        design = initial
+        apply(initial)
       }
       Button("取消", role: .cancel) {}
+    }
+  }
+}
+
+// The system picker grants access only to the chosen image; no library-wide permission is needed.
+struct SkinPhotoPicker: UIViewControllerRepresentable {
+  let receive: (Data?) -> Void
+  @Environment(\.dismiss) private var dismiss
+  func makeCoordinator() -> Coordinator { Coordinator(receive: receive, cancel: { dismiss() }) }
+  func makeUIViewController(context: Context) -> PHPickerViewController {
+    var config = PHPickerConfiguration()
+    config.filter = .images; config.selectionLimit = 1
+    let picker = PHPickerViewController(configuration: config)
+    picker.delegate = context.coordinator
+    return picker
+  }
+  func updateUIViewController(_ view: PHPickerViewController, context: Context) {}
+  final class Coordinator: NSObject, PHPickerViewControllerDelegate {
+    let receive: (Data?) -> Void
+    let cancel: () -> Void
+    init(receive: @escaping (Data?) -> Void, cancel: @escaping () -> Void) { self.receive = receive; self.cancel = cancel }
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+      guard let item = results.first else { cancel(); return }
+      item.itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.image.identifier) { [self] url, _ in
+        let result = url.flatMap { SkinPhotoData.thumbnail(at: $0) }
+        DispatchQueue.main.async { self.receive(result) }
+      }
     }
   }
 }

--- a/platforms/ios/App/Sources/FeatureSettingsViews.swift
+++ b/platforms/ios/App/Sources/FeatureSettingsViews.swift
@@ -16,6 +16,10 @@ struct SkinSettingsView: View {
           Label("设计我的皮肤", systemImage: "slider.horizontal.3")
         }.accessibilityIdentifier("customSkinEditorLink")
       }
+      Section {
+        NavigationLink(destination: SkinCommunityView()) { Label("皮肤社区", systemImage: "person.3.fill") }
+          .accessibilityIdentifier("skinCommunityLink")
+      }
       Section("完整键盘预览") {
         Picker("键盘布局", selection: $previewsNineKey) {
           Text("26 键").tag(false)

--- a/platforms/ios/App/Sources/KeyboardSkinPreview.swift
+++ b/platforms/ios/App/Sources/KeyboardSkinPreview.swift
@@ -42,7 +42,11 @@ struct KeyboardSkinPreview: View {
         VStack(spacing: 7) {
           row(Array("qwertyuiop").map(String.init))
           row(Array("asdfghjkl").map(String.init))
-          row(Array("zxcvbnm").map(String.init))
+          HStack(spacing: 5) {
+            key("⇧").frame(width: 38)
+            row(Array("zxcvbnm").map(String.init))
+            key("⌫").frame(width: 38)
+          }
         }.frame(height: 137)
       }
       HStack(spacing: 6) {
@@ -50,7 +54,6 @@ struct KeyboardSkinPreview: View {
         key("123").frame(width: 38)
         Image(systemName: "globe").frame(width: 34, height: 40)
           .background(keySurface())
-        if !nineKey { key("⌫").frame(width: 38) }
         key("空格")
         key("换行", emphasized: true).frame(width: 52)
       }.frame(height: 40)

--- a/platforms/ios/App/Sources/KeyboardSkinPreview.swift
+++ b/platforms/ios/App/Sources/KeyboardSkinPreview.swift
@@ -54,6 +54,7 @@ struct KeyboardSkinPreview: View {
         key("123").frame(width: 38)
         Image(systemName: "globe").frame(width: 34, height: 40)
           .background(keySurface())
+        if !nineKey { key("，").frame(width: 38) }
         key("空格")
         key("换行", emphasized: true).frame(width: 52)
       }.frame(height: 40)

--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -19,9 +19,9 @@ struct SettingsView: View {
           }
         }
 
-        Section("账号与同步") {
+        Section {
           NavigationLink(destination: AccountSettingsView()) {
-            Label("水杉账号", systemImage: "person.crop.circle")
+            Label("我的 · 账号与作品", systemImage: "person.crop.circle")
           }.accessibilityIdentifier("accountSettingsLink")
         }
 

--- a/platforms/ios/App/Sources/SkinCommunityView.swift
+++ b/platforms/ios/App/Sources/SkinCommunityView.swift
@@ -1,0 +1,240 @@
+import SwiftUI
+import AuthenticationServices
+
+struct SkinCommunityView: View {
+  @State private var skins: [CommunitySkin] = []
+  @State private var more = false
+  @State private var busy = false
+  @State private var signedIn = false
+  @State private var message: String?
+  @State private var challenge: CommunityChallenge?
+  @State private var search = ""
+  @State private var showPublish = false
+  @State private var confirmDeleteAccount = false
+  private let api = SkinCommunityAPI.shared
+
+  var body: some View {
+    List {
+      Section {
+        if signedIn {
+          Button { showPublish = true } label: { Label("发布我的设计", systemImage: "square.and.arrow.up") }
+            .accessibilityIdentifier("publishCommunitySkin")
+          Menu("账号") {
+            Button("退出登录") { run { try await api.logout(); signedIn = false; await prepareLogin() } }
+            Button("重新登录") { run { try await api.clearExpiredLogin(); signedIn = false; await prepareLogin() } }
+            Button("注销账号", role: .destructive) { confirmDeleteAccount = true }
+          }
+        } else {
+          if let challenge {
+            SignInWithAppleButton(.signIn) { request in
+              request.nonce = challenge.nonce
+              request.state = challenge.challenge_id
+            } onCompletion: { result in
+              switch result {
+              case .success(let authorization):
+                guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                      credential.state == challenge.challenge_id,
+                      let data = credential.identityToken, let token = String(data: data, encoding: .utf8) else {
+                  message = "Apple 登录未返回有效凭据，请重试。"; Task { await prepareLogin() }; return
+                }
+                run {
+                  try await api.login(challenge: challenge.challenge_id, identityToken: token)
+                  signedIn = true
+                  try await load()
+                }
+              case .failure(let error):
+                if (error as? ASAuthorizationError)?.code != .canceled { message = error.localizedDescription }
+                Task { await prepareLogin() }
+              }
+            }.signInWithAppleButtonStyle(.black).frame(height: 44).disabled(busy)
+          } else {
+            Button("准备 Apple 登录") { Task { await prepareLogin() } }.disabled(busy)
+          }
+          Text("浏览无需登录。登录后可发布、下载和评分。").font(.caption).foregroundStyle(.secondary)
+          Button("清除失效登录状态") { run { try await api.clearExpiredLogin(); signedIn = false; await prepareLogin() } }
+            .font(.caption)
+        }
+      }
+      Section {
+        if skins.isEmpty && !busy { Text("暂时没有皮肤，发布你的第一款设计吧。").foregroundStyle(.secondary) }
+        ForEach(skins) { skin in
+          NavigationLink {
+            CommunitySkinDetail(initial: skin)
+          } label: {
+            VStack(alignment: .leading, spacing: 8) {
+              CommunityDesignPreview(design: skin.design, compact: true).frame(height: 95)
+              HStack { Text(skin.name).font(.headline); if skin.owned { Text("我的作品").font(.caption).foregroundStyle(.secondary) } }
+              Text(skin.author).font(.caption).foregroundStyle(.secondary)
+              Label("\(skin.downloads) 人下载 · \(skin.rating_average, specifier: "%.1f") 分（\(skin.rating_count) 人）", systemImage: "star.fill")
+                .font(.caption).foregroundStyle(.secondary)
+            }.padding(.vertical, 5)
+          }
+        }
+        if more { Button("加载更多") { run { try await load(append: true) } }.disabled(busy) }
+      } header: { Text("社区皮肤") }
+      if busy { ProgressView().frame(maxWidth: .infinity) }
+    }
+    .navigationTitle("皮肤社区")
+    .searchable(text: $search, prompt: "搜索皮肤名称")
+    .onSubmit(of: .search) { run { try await load() } }
+    .refreshable { do { try await load() } catch { message = error.localizedDescription } }
+    .task {
+      do { signedIn = try await api.signedIn(); try await load() } catch { message = error.localizedDescription }
+      if !signedIn { await prepareLogin() }
+    }
+    .sheet(isPresented: $showPublish) { CommunityPublishView { run { try await load() } } }
+    .alert("皮肤社区", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
+      Button("好", role: .cancel) {}
+    } message: { Text(message ?? "") }
+    .confirmationDialog("注销账号将删除已发布皮肤、评分及其他云端账号数据，无法撤销。", isPresented: $confirmDeleteAccount, titleVisibility: .visible) {
+      Button("注销账号", role: .destructive) { run { try await api.logout(deleteAccount: true); signedIn = false; try await load(); await prepareLogin() } }
+    }
+  }
+  @MainActor private func prepareLogin() async {
+    challenge = nil
+    do { challenge = try await api.challenge() } catch { message = error.localizedDescription }
+  }
+  @MainActor private func load(append: Bool = false) async throws {
+    let page = try await api.list(offset: append ? skins.count : 0, search: search)
+    if append { let ids = Set(skins.map(\.id)); skins += page.skins.filter { !ids.contains($0.id) } }
+    else { skins = page.skins }
+    more = page.has_more
+  }
+  private func run(_ action: @escaping @MainActor () async throws -> Void) {
+    guard !busy else { return }; busy = true
+    Task { defer { busy = false }; do { try await action() } catch { message = error.localizedDescription } }
+  }
+}
+
+struct CommunitySkinDetail: View {
+  let initial: CommunitySkin
+  @State private var updated: CommunitySkin?
+  @State private var busy = false
+  @State private var message: String?
+  @State private var confirmsRemoval = false
+  @Environment(\.dismiss) private var dismiss
+  private var skin: CommunitySkin { updated ?? initial }
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 16) {
+        CommunityDesignPreview(design: skin.design).frame(height: 235)
+        Text(skin.name).font(.title2.bold())
+        Text(skin.author).foregroundStyle(.secondary)
+        Text(skin.description)
+        Text("\(skin.downloads) 人下载 · \(skin.rating_average, specifier: "%.1f") 分 · \(skin.rating_count) 人评分")
+          .font(.subheadline).foregroundStyle(.secondary)
+        Button { run {
+          let design = try await SkinCommunityAPI.shared.download(skin.id)
+          var library = CustomSkinLibrary.designs
+          let id = UUID(uuidString: skin.id) ?? UUID()
+          if let index = library.firstIndex(where: { $0.id == id }) { library[index].design = design }
+          else {
+            guard library.count < 12 else { throw CommunityFailure(message: "本地皮肤已满，请在「我的设计」删除一款后重试。") }
+            library.append(SavedKeyboardSkin(id: id, name: skin.name, design: design))
+          }
+          guard CustomSkinLibrary.save(library) else { throw CommunityFailure(message: "无法保存皮肤，请检查设备存储。") }
+          CustomKeyboardSkinStore.save(design)
+          KeyboardFeedbackPreference.defaults.set(KeyboardSkin.custom.rawValue, forKey: KeyboardSkinPreference.key)
+          updated = try await SkinCommunityAPI.shared.detail(skin.id)
+          message = "已保存并应用，下次打开键盘即可使用。"
+        } } label: { Label("下载并使用", systemImage: "arrow.down.circle.fill").frame(maxWidth: .infinity) }
+          .buttonStyle(.borderedProminent).disabled(busy).accessibilityIdentifier("downloadCommunitySkin")
+        if !skin.owned {
+          Text("我的评分（下载后可评，可重新选择）").font(.subheadline)
+          HStack {
+            ForEach(1...5, id: \.self) { stars in
+              Button { run {
+                try await SkinCommunityAPI.shared.rate(skin.id, stars: stars)
+                updated = try await SkinCommunityAPI.shared.detail(skin.id)
+              } } label: { Image(systemName: stars <= skin.my_rating ? "star.fill" : "star").frame(width: 44, height: 44) }
+                .accessibilityLabel("评 \(stars) 星").disabled(busy)
+            }
+          }
+        } else {
+          Button("下架这款皮肤", role: .destructive) { confirmsRemoval = true }.disabled(busy)
+        }
+        if busy { ProgressView() }
+      }.padding()
+    }.navigationTitle("皮肤详情").navigationBarTitleDisplayMode(.inline)
+      .task { run { updated = try await SkinCommunityAPI.shared.detail(initial.id) } }
+      .confirmationDialog("下架后其他用户无法再下载，已下载的本地皮肤会保留。", isPresented: $confirmsRemoval, titleVisibility: .visible) {
+        Button("下架", role: .destructive) { run { try await SkinCommunityAPI.shared.unpublish(skin.id); dismiss() } }
+      }
+      .alert("皮肤社区", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) { Button("好", role: .cancel) {} } message: { Text(message ?? "") }
+  }
+  private func run(_ action: @escaping @MainActor () async throws -> Void) {
+    guard !busy else { return }; busy = true
+    Task { defer { busy = false }; do { try await action() } catch { message = error.localizedDescription } }
+  }
+}
+
+struct CommunityPublishView: View {
+  var onPublished: () -> Void
+  @Environment(\.dismiss) private var dismiss
+  @State private var library = CustomSkinLibrary.designs
+  @State private var selected = UUID()
+  @State private var publicationID = UUID().uuidString.lowercased()
+  @State private var name = ""
+  @State private var description = ""
+  @State private var agrees = false
+  @State private var busy = false
+  @State private var message: String?
+  private var design: CustomKeyboardSkin? { library.first { $0.id == selected }?.design }
+  var body: some View {
+    NavigationView {
+      Form {
+        Section("选择已保存的设计") {
+          if library.isEmpty { Text("请先在「设计我的皮肤」保存一款设计。") }
+          Picker("我的皮肤", selection: $selected) { ForEach(library) { Text($0.name).tag($0.id) } }
+            .onChange(of: selected) { id in name = library.first { $0.id == id }?.name ?? "" }
+          if let design { CommunityDesignPreview(design: design).frame(height: 210) }
+        }
+        Section("发布信息") {
+          TextField("皮肤名称（最多 32 字）", text: $name).onChange(of: name) { name = String($0.prefix(32)) }
+          TextField("设计说明（最多 280 字）", text: $description).onChange(of: description) { description = String($0.prefix(280)) }
+          Toggle("我拥有发布所用素材的权利，并同意其他用户免费下载使用", isOn: $agrees)
+          Text("发布后，设计及照片壁纸将上传并公开。请勿包含私人照片或敏感信息。作者可随时下架。").font(.caption).foregroundStyle(.secondary)
+        }
+        Button("发布到社区") {
+          guard let design else { return }; busy = true
+          Task {
+            defer { busy = false }
+            do {
+              try await SkinCommunityAPI.shared.publish(id: publicationID, name: name, description: description, design: design)
+              onPublished(); dismiss()
+            } catch { message = error.localizedDescription }
+          }
+        }.disabled(busy || !agrees || design == nil || name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        if busy { ProgressView() }
+      }.disabled(busy)
+        .navigationTitle("发布皮肤")
+        .toolbar { ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() }.disabled(busy) } }
+        .onAppear { if let first = library.first { selected = first.id; name = first.name } }
+        .alert("发布失败", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) { Button("好", role: .cancel) {} } message: { Text(message ?? "") }
+    }.interactiveDismissDisabled(busy)
+  }
+}
+
+// A value-based preview must not change the user's active custom skin while browsing.
+struct CommunityDesignPreview: View {
+  let design: CustomKeyboardSkin
+  var compact = false
+  private func color(_ rgb: UInt32) -> Color { Color(uiColor: CustomKeyboardSkin.color(rgb)) }
+  var body: some View {
+    VStack(spacing: compact ? 3 : 6) {
+      if !compact { HStack { Text("你好"); Text("你号"); Spacer(); Text("全拼") }.font(.caption).foregroundStyle(color(design.accent)).frame(height: 26) }
+      ForEach(["QWERTYUIOP", "ASDFGHJKL", "⇧ZXCVBNM⌫"], id: \.self) { row in
+        HStack(spacing: 3) { ForEach(Array(row).map(String.init), id: \.self) { key($0) } }
+      }
+      HStack(spacing: 3) { key("123"); key("，"); key("空格").frame(minWidth: 100); key("↵") }
+    }.padding(compact ? 6 : 10).background {
+      KeyboardSkinBackdrop(skin: .custom, design: design)
+    }.clipShape(RoundedRectangle(cornerRadius: 12)).accessibilityHidden(true)
+  }
+  private func key(_ text: String) -> some View {
+    Text(text).font(.system(size: compact ? 8 : 14, weight: .medium, design: design.monospaced ? .monospaced : .default))
+      .foregroundStyle(color(text == "↵" ? CustomKeyboardSkin.readableText(on: design.actionBackground) : design.keyForeground)).frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(color(text == "↵" ? design.actionBackground : design.keyBackground).opacity(text == "↵" ? 1 : design.keyOpacity ?? 1), in: RoundedRectangle(cornerRadius: min(design.cornerRadius, compact ? 4 : 12)))
+      .overlay(RoundedRectangle(cornerRadius: min(design.cornerRadius, compact ? 4 : 12)).stroke(color(design.customBorderColor ?? design.accent), lineWidth: design.borderWidth))
+  }
+}

--- a/platforms/ios/App/Sources/SkinCommunityView.swift
+++ b/platforms/ios/App/Sources/SkinCommunityView.swift
@@ -1,64 +1,29 @@
 import SwiftUI
-import AuthenticationServices
 
 struct SkinCommunityView: View {
+  var onlyMine = false
+  private var visibleSkins: [CommunitySkin] { onlyMine ? skins.filter(\.owned) : skins }
   @State private var skins: [CommunitySkin] = []
   @State private var more = false
   @State private var busy = false
   @State private var signedIn = false
   @State private var message: String?
-  @State private var challenge: CommunityChallenge?
   @State private var search = ""
   @State private var showPublish = false
-  @State private var confirmDeleteAccount = false
   private let api = SkinCommunityAPI.shared
 
   var body: some View {
     List {
-      Section {
-        if signedIn {
+      AppleAccountSection(signedIn: $signedIn)
+      if signedIn {
+        Section {
           Button { showPublish = true } label: { Label("发布我的设计", systemImage: "square.and.arrow.up") }
             .accessibilityIdentifier("publishCommunitySkin")
-          Menu("账号") {
-            Button("退出登录") { run { try await api.logout(); signedIn = false; await prepareLogin() } }
-            Button("重新登录") { run { try await api.clearExpiredLogin(); signedIn = false; await prepareLogin() } }
-            Button("注销账号", role: .destructive) { confirmDeleteAccount = true }
-          }
-        } else {
-          if let challenge {
-            SignInWithAppleButton(.signIn) { request in
-              request.nonce = challenge.nonce
-              request.state = challenge.challenge_id
-            } onCompletion: { result in
-              switch result {
-              case .success(let authorization):
-                guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
-                      credential.state == challenge.challenge_id,
-                      let data = credential.identityToken, let token = String(data: data, encoding: .utf8) else {
-                  message = "Apple 登录未返回有效凭据，请重试。"; Task { await prepareLogin() }; return
-                }
-                run {
-                  do { try await api.login(challenge: challenge.challenge_id, identityToken: token) }
-                  catch { await prepareLogin(); throw error }
-                  signedIn = true
-                  try await load()
-                }
-              case .failure(let error):
-                if (error as? ASAuthorizationError)?.code != .canceled { message = error.localizedDescription }
-                Task { await prepareLogin() }
-              }
-            }.signInWithAppleButtonStyle(.black).frame(height: 44).disabled(busy)
-          } else {
-            Button("准备 Apple 登录") { Task { await prepareLogin() } }.disabled(busy)
-          }
-          Text("浏览无需登录。登录后可发布、下载和评分。").font(.caption).foregroundStyle(.secondary)
-          Button("清除失效登录状态") { run { try await api.clearExpiredLogin(); signedIn = false; await prepareLogin() } }
-            .font(.caption)
         }
       }
       Section {
-        if skins.isEmpty && !busy { Text("暂时没有皮肤，发布你的第一款设计吧。").foregroundStyle(.secondary) }
-        ForEach(skins) { skin in
+        if visibleSkins.isEmpty && !busy { Text(onlyMine ? (more ? "当前页没有你的作品，继续加载查看更多。" : "还没有已发布的作品，分享你的第一款设计吧。") : "暂时没有皮肤，发布你的第一款设计吧。").foregroundStyle(.secondary) }
+        ForEach(visibleSkins) { skin in
           NavigationLink {
             CommunitySkinDetail(initial: skin)
           } label: {
@@ -72,28 +37,21 @@ struct SkinCommunityView: View {
           }
         }
         if more { Button("加载更多") { run { try await load(append: true) } }.disabled(busy) }
-      } header: { Text("社区皮肤") }
+      } header: { Text(onlyMine ? "我的作品" : "社区皮肤") }
       if busy { ProgressView().frame(maxWidth: .infinity) }
     }
-    .navigationTitle("皮肤社区")
+    .navigationTitle(onlyMine ? "已发布作品" : "皮肤社区")
     .searchable(text: $search, prompt: "搜索皮肤名称")
     .onSubmit(of: .search) { run { try await load() } }
     .refreshable { do { try await load() } catch { message = error.localizedDescription } }
-    .task {
-      do { signedIn = try await api.signedIn(); try await load() } catch { message = error.localizedDescription }
-      if !signedIn { await prepareLogin() }
+    .task { run { try await load() } }
+    .onChange(of: signedIn) { _ in
+      Task { do { try await load() } catch { message = error.localizedDescription } }
     }
     .sheet(isPresented: $showPublish) { CommunityPublishView { run { try await load() } } }
     .alert("皮肤社区", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
       Button("好", role: .cancel) {}
     } message: { Text(message ?? "") }
-    .confirmationDialog("注销账号将删除已发布皮肤、评分及其他云端账号数据，无法撤销。", isPresented: $confirmDeleteAccount, titleVisibility: .visible) {
-      Button("注销账号", role: .destructive) { run { try await api.logout(deleteAccount: true); signedIn = false; try await load(); await prepareLogin() } }
-    }
-  }
-  @MainActor private func prepareLogin() async {
-    challenge = nil
-    do { challenge = try await api.challenge() } catch { message = error.localizedDescription }
   }
   @MainActor private func load(append: Bool = false) async throws {
     let page = try await api.list(offset: append ? skins.count : 0, search: search)

--- a/platforms/ios/App/Sources/SkinCommunityView.swift
+++ b/platforms/ios/App/Sources/SkinCommunityView.swift
@@ -38,7 +38,8 @@ struct SkinCommunityView: View {
                   message = "Apple 登录未返回有效凭据，请重试。"; Task { await prepareLogin() }; return
                 }
                 run {
-                  try await api.login(challenge: challenge.challenge_id, identityToken: token)
+                  do { try await api.login(challenge: challenge.challenge_id, identityToken: token) }
+                  catch { await prepareLogin(); throw error }
                   signedIn = true
                   try await load()
                 }
@@ -186,12 +187,12 @@ struct CommunityPublishView: View {
         Section("选择已保存的设计") {
           if library.isEmpty { Text("请先在「设计我的皮肤」保存一款设计。") }
           Picker("我的皮肤", selection: $selected) { ForEach(library) { Text($0.name).tag($0.id) } }
-            .onChange(of: selected) { id in name = library.first { $0.id == id }?.name ?? "" }
+            .onChange(of: selected) { id in name = library.first { $0.id == id }?.name ?? ""; publicationID = UUID().uuidString.lowercased() }
           if let design { CommunityDesignPreview(design: design).frame(height: 210) }
         }
         Section("发布信息") {
-          TextField("皮肤名称（最多 32 字）", text: $name).onChange(of: name) { name = String($0.prefix(32)) }
-          TextField("设计说明（最多 280 字）", text: $description).onChange(of: description) { description = String($0.prefix(280)) }
+          TextField("皮肤名称（最多 32 字）", text: $name).onChange(of: name) { name = String($0.prefix(32)); publicationID = UUID().uuidString.lowercased() }
+          TextField("设计说明（最多 280 字）", text: $description).onChange(of: description) { description = String($0.prefix(280)); publicationID = UUID().uuidString.lowercased() }
           Toggle("我拥有发布所用素材的权利，并同意其他用户免费下载使用", isOn: $agrees)
           Text("发布后，设计及照片壁纸将上传并公开。请勿包含私人照片或敏感信息。作者可随时下架。").font(.caption).foregroundStyle(.secondary)
         }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardClipboardView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardClipboardView.swift
@@ -1,0 +1,128 @@
+import UIKit
+
+final class KeyboardClipboardView: UIView, UITableViewDataSource, UITableViewDelegate {
+  private let store: ClipboardHistoryStore
+  private var items: [ClipboardHistoryItem] = []
+  private let table = UITableView(frame: .zero, style: .plain)
+  private let status = UILabel()
+  private let onInsert: (String) -> Void
+  private var confirmingClear = false
+
+  init(hasFullAccess: Bool, store: ClipboardHistoryStore = ClipboardHistoryStore(),
+       onInsert: @escaping (String) -> Void, onClose: @escaping () -> Void) {
+    self.store = store
+    self.onInsert = onInsert
+    super.init(frame: .zero)
+    accessibilityIdentifier = "keyboardClipboardHistory"
+    backgroundColor = .systemBackground
+    let title = UILabel()
+    title.text = "剪贴板历史"
+    title.font = .boldSystemFont(ofSize: 16)
+    let close = UIButton(type: .system)
+    close.setTitle("返回", for: .normal)
+    close.addAction(UIAction { _ in onClose() }, for: .primaryActionTriggered)
+    let clear = UIButton(type: .system)
+    clear.setTitle("清空", for: .normal)
+    clear.accessibilityIdentifier = "clearClipboardHistory"
+    clear.addAction(UIAction { [weak self, weak clear] _ in
+      guard let self else { return }
+      if !confirmingClear {
+        confirmingClear = true
+        clear?.setTitle("确认清空", for: .normal)
+        status.text = "再次点按清空将删除全部历史，包括固定项。"
+      } else {
+        perform { try store.save([]) }
+        confirmingClear = false
+        clear?.setTitle("清空", for: .normal)
+      }
+    }, for: .primaryActionTriggered)
+    let header = UIStackView(arrangedSubviews: [title, clear, close])
+    header.spacing = 8
+    let capture = UIButton(type: .system)
+    var config = UIButton.Configuration.tinted()
+    config.title = "保存当前剪贴板"
+    config.image = UIImage(systemName: "doc.on.clipboard")
+    config.imagePadding = 8
+    capture.configuration = config
+    capture.accessibilityIdentifier = "captureClipboard"
+    capture.isEnabled = hasFullAccess
+    clear.isEnabled = hasFullAccess
+    capture.addAction(UIAction { [weak self] _ in
+      guard let self else { return }
+      perform { try store.add(UIPasteboard.general.string ?? "") }
+    }, for: .primaryActionTriggered)
+    status.font = .systemFont(ofSize: 12)
+    status.textColor = .secondaryLabel
+    status.numberOfLines = 2
+    table.dataSource = self
+    table.delegate = self
+    table.rowHeight = 68
+    table.accessibilityIdentifier = "clipboardHistoryList"
+    table.keyboardDismissMode = .none
+    for child in [header, capture, status, table] {
+      child.translatesAutoresizingMaskIntoConstraints = false
+      addSubview(child)
+    }
+    NSLayoutConstraint.activate([
+      header.topAnchor.constraint(equalTo: topAnchor), header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+      header.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12), header.heightAnchor.constraint(equalToConstant: 44),
+      close.widthAnchor.constraint(equalToConstant: 44), clear.widthAnchor.constraint(equalToConstant: 76),
+      capture.topAnchor.constraint(equalTo: header.bottomAnchor), capture.leadingAnchor.constraint(equalTo: header.leadingAnchor),
+      capture.trailingAnchor.constraint(equalTo: header.trailingAnchor), capture.heightAnchor.constraint(equalToConstant: 44),
+      status.topAnchor.constraint(equalTo: capture.bottomAnchor, constant: 4), status.leadingAnchor.constraint(equalTo: header.leadingAnchor),
+      status.trailingAnchor.constraint(equalTo: header.trailingAnchor), status.heightAnchor.constraint(equalToConstant: 34),
+      table.topAnchor.constraint(equalTo: status.bottomAnchor, constant: 4), table.leadingAnchor.constraint(equalTo: leadingAnchor),
+      table.trailingAnchor.constraint(equalTo: trailingAnchor), table.bottomAnchor.constraint(equalTo: bottomAnchor)
+    ])
+    if hasFullAccess { reload() }
+    else { status.text = "请在系统键盘设置中开启「允许完全访问」，再使用剪贴板历史。" }
+  }
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+  private func reload() {
+    do {
+      items = try store.load()
+      status.text = items.isEmpty ? "暂无历史。保存后点按插入；记录仅保存在本机。" : "\(items.count)/50 条 · 点按插入 · 右侧菜单可固定或删除"
+      table.reloadData()
+    } catch { status.text = error.localizedDescription }
+  }
+  private func perform(_ action: () throws -> Void) {
+    do { try action(); reload() }
+    catch { status.text = error.localizedDescription }
+  }
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { items.count }
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
+    let item = items[indexPath.row]
+    cell.textLabel?.text = item.text
+    cell.textLabel?.numberOfLines = 2
+    cell.textLabel?.font = .systemFont(ofSize: 15)
+    cell.detailTextLabel?.text = (item.pinned ? "已固定 · " : "") + item.date.formatted(date: .abbreviated, time: .shortened)
+    let menu = UIButton(type: .system)
+    menu.frame = CGRect(x: 0, y: 0, width: 44, height: 44)
+    menu.setImage(UIImage(systemName: item.pinned ? "pin.fill" : "ellipsis"), for: .normal)
+    menu.accessibilityLabel = "管理记录"
+    menu.showsMenuAsPrimaryAction = true
+    menu.menu = UIMenu(children: [
+      UIAction(title: item.pinned ? "取消固定" : "固定", image: UIImage(systemName: "pin")) { [weak self] _ in
+        self?.change(item.id, delete: false)
+      },
+      UIAction(title: "删除", image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
+        self?.change(item.id, delete: true)
+      }
+    ])
+    cell.accessoryView = menu
+    return cell
+  }
+  private func change(_ id: UUID, delete: Bool) {
+    perform {
+      var latest = try store.load()
+      if delete { latest.removeAll { $0.id == id } }
+      else if let index = latest.firstIndex(where: { $0.id == id }) { latest[index].pinned.toggle() }
+      try store.save(latest)
+    }
+  }
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: true)
+    onInsert(items[indexPath.row].text)
+  }
+}

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardKeyButton.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardKeyButton.swift
@@ -44,3 +44,21 @@ final class KeyboardKeyButton: UIButton {
     }
   }
 }
+
+/// Candidate chips highlight immediately, but a drag still belongs to the strip.
+final class CandidateScrollView: UIScrollView {
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    delaysContentTouches = false
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    delaysContentTouches = false
+  }
+
+  override func touchesShouldCancel(in view: UIView) -> Bool {
+    if view is KeyboardKeyButton { return true }
+    return super.touchesShouldCancel(in: view)
+  }
+}

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
@@ -16,6 +16,41 @@ final class KeyboardSkinPickerView: UIView {
     let rows = UIStackView()
     rows.axis = .vertical
     rows.spacing = 10
+    let saved = CustomSkinLibrary.designs
+    if !saved.isEmpty {
+      let label = UILabel()
+      label.text = "我的设计"
+      label.font = .systemFont(ofSize: 13, weight: .semibold)
+      label.textColor = .secondaryLabel
+      rows.addArrangedSubview(label)
+      for index in stride(from: 0, to: saved.count, by: 2) {
+        let row = UIStackView()
+        row.spacing = 10; row.distribution = .fillEqually
+        for item in saved[index..<min(index + 2, saved.count)] {
+          let card = KeyboardKeyButton()
+          var config = UIButton.Configuration.filled()
+          config.title = item.name
+          config.subtitle = "A  S  D    ↵"
+          config.titleLineBreakMode = .byTruncatingTail
+          config.baseForegroundColor = CustomKeyboardSkin.color(item.design.keyForeground)
+          config.baseBackgroundColor = CustomKeyboardSkin.color(item.design.keyBackground)
+          config.background.cornerRadius = item.design.cornerRadius
+          config.background.strokeWidth = max(1, item.design.borderWidth)
+          config.background.strokeColor = CustomKeyboardSkin.color(item.design.customBorderColor ?? item.design.accent)
+          card.configuration = config
+          card.heightAnchor.constraint(equalToConstant: 72).isActive = true
+          card.accessibilityIdentifier = "savedSkinCard-" + item.id.uuidString
+          card.accessibilityLabel = item.name
+          let active = selected == .custom && item.design == CustomKeyboardSkinStore.current
+          card.accessibilityValue = active ? "已选中" : ""
+          if active { card.accessibilityTraits.insert(.selected) }
+          card.addAction(UIAction { _ in CustomKeyboardSkinStore.save(item.design); onSelect(.custom) }, for: .primaryActionTriggered)
+          row.addArrangedSubview(card)
+        }
+        if row.arrangedSubviews.count == 1 { row.addArrangedSubview(UIView()) }
+        rows.addArrangedSubview(row)
+      }
+    }
     for index in stride(from: 0, to: KeyboardSkin.allCases.count, by: 2) {
       let row = UIStackView()
       row.spacing = 10

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -29,6 +29,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var candidateContent: UIStackView?
   private let scriptShortcut = UIButton()
   private let skinShortcut = UIButton()
+  private var clipboardPanel: KeyboardClipboardView?
   private var skinPicker: KeyboardSkinPickerView?
   private let moreShortcut = UIButton()
   private let dismissShortcut = UIButton()
@@ -529,6 +530,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     skinShortcut.accessibilityValue = KeyboardSkinPreference.selected.title
     configure(moreShortcut, title: nil, symbol: "ellipsis.circle", label: "更多快捷设置", id: "moreShortcut")
     moreShortcut.menu = UIMenu(children: [
+      UIAction(title: "剪贴板历史", image: UIImage(systemName: "doc.on.clipboard")) { [weak self] _ in
+        self?.showClipboardHistory()
+      },
       UIAction(title: "AI 润色", image: UIImage(systemName: "sparkles")) { [weak self] _ in
         self?.showKeyboardAI()
       },
@@ -1766,6 +1770,28 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     updateShadows(view)
   }
 
+  private func showClipboardHistory() {
+    closeKeyboardService()
+    closeSkinPicker()
+    let panel = KeyboardClipboardView(hasFullAccess: hasFullAccess, onInsert: { [weak self] text in
+      guard let self else { return }
+      render(session.finishComposition())
+      insertOwnText(text)
+      closeSkinPicker()
+    }, onClose: { [weak self] in self?.closeSkinPicker() })
+    panel.accessibilityViewIsModal = true
+    panel.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(panel)
+    NSLayoutConstraint.activate([
+      panel.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      panel.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      panel.topAnchor.constraint(equalTo: view.topAnchor),
+      panel.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+    clipboardPanel = panel
+    UIAccessibility.post(notification: .screenChanged, argument: panel)
+  }
+
   private func showSkinPicker() {
     guard skinPicker == nil else { return }
     let picker = KeyboardSkinPickerView(selected: KeyboardSkinPreference.selected, onSelect: { [weak self] skin in
@@ -1789,6 +1815,11 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   }
 
   private func closeSkinPicker() {
+    if let panel = clipboardPanel {
+      panel.removeFromSuperview()
+      clipboardPanel = nil
+      UIAccessibility.post(notification: .screenChanged, argument: moreShortcut)
+    }
     guard let picker = skinPicker else { return }
     picker.removeFromSuperview()
     skinPicker = nil

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -454,13 +454,13 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private func installShortcutBar(in container: UIView) {
     shortcutBar.axis = .horizontal
     shortcutBar.distribution = .fill
-    shortcutBar.spacing = 1
+    shortcutBar.spacing = 0
     shortcutBar.accessibilityIdentifier = "keyboardShortcutBar"
     shortcutBar.translatesAutoresizingMaskIntoConstraints = false
     let brand = UIView()
     let icon = UIImageView()
     if let path = Bundle(for: KeyboardViewController.self).path(forResource: "KeyboardBrand", ofType: "png") {
-      icon.image = UIImage(contentsOfFile: path)?.preparingThumbnail(of: CGSize(width: 66, height: 66))
+      icon.image = UIImage(contentsOfFile: path)?.preparingThumbnail(of: CGSize(width: 72, height: 72))
     }
     icon.accessibilityIdentifier = "keyboardBrandIcon"
     icon.contentMode = .scaleAspectFit
@@ -470,9 +470,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     brand.addSubview(icon)
     shortcutBar.addArrangedSubview(brand)
     NSLayoutConstraint.activate([
-      brand.widthAnchor.constraint(equalToConstant: 22),
-      icon.widthAnchor.constraint(equalToConstant: 22),
-      icon.heightAnchor.constraint(equalToConstant: 22),
+      brand.widthAnchor.constraint(equalToConstant: 36),
+      icon.widthAnchor.constraint(equalToConstant: 24),
+      icon.heightAnchor.constraint(equalToConstant: 24),
       icon.centerXAnchor.constraint(equalTo: brand.centerXAnchor),
       icon.centerYAnchor.constraint(equalTo: brand.centerYAnchor),
     ])

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -1212,6 +1212,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
 
     playInputClick()
     candidatePageStart = target
+    candidateScrollView.setContentOffset(.zero, animated: false)
     renderCandidateStrip()
   }
 
@@ -1556,6 +1557,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     // Any new candidate list is a different composition or a different set of matches, so the page
     // it was showing no longer describes anything.
     candidatePageStart = 0
+    // A horizontal offset belongs to the previous matches, just like the page index.
+    // Cancel deceleration as well so it cannot hide the new leading candidate.
+    candidateScrollView.setContentOffset(.zero, animated: false)
     renderCandidateStrip()
   }
 

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -57,6 +57,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var nineKeyHeight: NSLayoutConstraint!
   private var nineKeySymbolsButton: UIButton!
   private let punctuationStack = UIStackView()
+  private var symbolDeleteWidth: NSLayoutConstraint?
   private var standardActionWidths: [NSLayoutConstraint] = []
   private var nineKeyActionWidths: [NSLayoutConstraint] = []
   private let nineKeyContainer = UIStackView()
@@ -630,6 +631,19 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       letterButtons.append((button: button, lowercase: text, hint: attachHintLabel(to: button)))
       row.addArrangedSubview(button)
     }
+    if includesShift {
+      let delete = makeDeleteKey()
+      delete.accessibilityIdentifier = "letterDeleteKey"
+      row.addArrangedSubview(delete)
+      row.distribution = .fill
+      // Keep Shift and Delete easy to hit; distribute the seven letters evenly between them.
+      let shift = row.arrangedSubviews[0]
+      let keys = Array(row.arrangedSubviews.dropFirst().dropLast())
+      NSLayoutConstraint.activate([
+        shift.widthAnchor.constraint(equalToConstant: 44),
+        delete.widthAnchor.constraint(equalTo: shift.widthAnchor),
+      ] + keys.dropFirst().map { $0.widthAnchor.constraint(equalTo: keys[0].widthAnchor) })
+    }
     if letters == letterRows[1] {
       let key = makeKey(title: ";", accessibilityLabel: "微软双拼 ing") { [weak self] in self?.handleCharacter(";") }
       key.accessibilityIdentifier = "microsoftFinalKey"
@@ -719,6 +733,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     row.addArrangedSubview(globe)
 
     let delete = makeDeleteKey()
+    delete.accessibilityIdentifier = "symbolDeleteKey"
     actionDeleteButton = delete
     row.addArrangedSubview(delete)
 
@@ -750,11 +765,11 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     row.addArrangedSubview(enter)
 
     standardActionWidths = [
-      layoutToggle.widthAnchor.constraint(equalTo: delete.widthAnchor, multiplier: 1.1),
-      space.widthAnchor.constraint(greaterThanOrEqualTo: delete.widthAnchor, multiplier: 1.8),
-      enter.widthAnchor.constraint(equalTo: delete.widthAnchor, multiplier: 1.35),
-      delete.widthAnchor.constraint(equalToConstant: 44),
+      layoutToggle.widthAnchor.constraint(equalToConstant: 48.4),
+      space.widthAnchor.constraint(greaterThanOrEqualToConstant: 79.2),
+      enter.widthAnchor.constraint(equalToConstant: 59.4),
     ]
+    symbolDeleteWidth = delete.widthAnchor.constraint(equalToConstant: 44)
     nineKeyActionWidths = [
       nineKeySymbolsButton.widthAnchor.constraint(equalTo: nineKeyContainer.widthAnchor, multiplier: 0.14),
       layoutToggle.widthAnchor.constraint(equalTo: nineKeySymbolsButton.widthAnchor),
@@ -1348,6 +1363,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
         actionRow.insertArrangedSubview(actionGlobeButton, at: globeIndex)
       }
       NSLayoutConstraint.deactivate(standardActionWidths + nineKeyActionWidths)
+      symbolDeleteWidth?.isActive = false
       globeWidthConstraint?.isActive = false
       actionGlobeButton.isHidden = !needsInputModeSwitchKey
       if needsInputModeSwitchKey {
@@ -1355,7 +1371,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
         globeWidthConstraint?.isActive = true
       }
       nineKeySymbolsButton.isHidden = !usesNineKeyLayout
-      actionDeleteButton.isHidden = usesNineKeyLayout
+      actionDeleteButton.isHidden = !showsSymbols
+      symbolDeleteWidth?.isActive = showsSymbols
       NSLayoutConstraint.activate(usesNineKeyLayout ? nineKeyActionWidths : standardActionWidths)
     }
     symbolRowViews.forEach { $0.isHidden = !showsSymbols }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -57,6 +57,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var nineKeyHeight: NSLayoutConstraint!
   private var nineKeySymbolsButton: UIButton!
   private let punctuationStack = UIStackView()
+  private var quickPunctuationButton: UIButton!
+  private var quickPunctuationWidth: NSLayoutConstraint?
   private var symbolDeleteWidth: NSLayoutConstraint?
   private var standardActionWidths: [NSLayoutConstraint] = []
   private var nineKeyActionWidths: [NSLayoutConstraint] = []
@@ -737,6 +739,16 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     actionDeleteButton = delete
     row.addArrangedSubview(delete)
 
+    let punctuation = makeKey(title: ",", accessibilityLabel: "常用标点") { [weak self] in
+      guard let self else { return }
+      handleSymbol(quickPunctuationSymbols[0])
+    }
+    punctuation.accessibilityIdentifier = "quickPunctuationKey"
+    punctuation.accessibilityHint = "轻点输入，长按选择常用标点"
+    quickPunctuationButton = punctuation
+    quickPunctuationWidth = punctuation.widthAnchor.constraint(equalToConstant: 44)
+    row.addArrangedSubview(punctuation)
+
     let space = makeKey(title: "空格", accessibilityLabel: "空格") { [weak self] in
       self?.handleSpace()
     }
@@ -1343,6 +1355,12 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     updateKeyboardLayout()
   }
 
+  private var quickPunctuationSymbols: [String] {
+    guard isChineseMode, !session.isInLocalMode else { return [",", ".", "?", "!", ":", ";", "@"] }
+    if inputScheme == .japanese { return ["、", "。", "？", "！", "「", "」", "・"] }
+    return ["，", "。", "？", "！", "、", "；", "："]
+  }
+
   private func updateKeyboardLayout() {
     standardRowHeights.forEach { $0.1.isActive = false }
     microsoftFinalKey?.isHidden = !(isChineseMode && inputScheme == .microsoft && !session.isInLocalMode)
@@ -1356,7 +1374,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     if actionRow != nil {
       let usesNineKeyLayout = nineKey && !showsSymbols
       nineKeyHeight.isActive = usesNineKeyLayout
-      let globeIndex = usesNineKeyLayout ? 4 : 2
+      let globeIndex = usesNineKeyLayout ? 5 : 2
       if actionRow.arrangedSubviews.firstIndex(of: actionGlobeButton) != globeIndex {
         actionRow.removeArrangedSubview(actionGlobeButton)
         actionGlobeButton.removeFromSuperview()
@@ -1364,6 +1382,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       }
       NSLayoutConstraint.deactivate(standardActionWidths + nineKeyActionWidths)
       symbolDeleteWidth?.isActive = false
+      quickPunctuationWidth?.isActive = false
       globeWidthConstraint?.isActive = false
       actionGlobeButton.isHidden = !needsInputModeSwitchKey
       if needsInputModeSwitchKey {
@@ -1371,6 +1390,14 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
         globeWidthConstraint?.isActive = true
       }
       nineKeySymbolsButton.isHidden = !usesNineKeyLayout
+      quickPunctuationButton.isHidden = usesNineKeyLayout || showsSymbols
+      quickPunctuationWidth?.isActive = !quickPunctuationButton.isHidden
+      let punctuation = quickPunctuationSymbols
+      quickPunctuationButton.configuration?.title = punctuation[0]
+      quickPunctuationButton.accessibilityValue = punctuation[0]
+      quickPunctuationButton.menu = UIMenu(children: punctuation.map { symbol in
+        UIAction(title: symbol) { [weak self] _ in self?.handleSymbol(symbol) }
+      })
       actionDeleteButton.isHidden = !showsSymbols
       symbolDeleteWidth?.isActive = showsSymbols
       NSLayoutConstraint.activate(usesNineKeyLayout ? nineKeyActionWidths : standardActionWidths)

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -17,7 +17,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private let exitLocalModeButton = UIButton()
   private var localModeTrigger: String?
   private var standardRowHeights: [(UIView, NSLayoutConstraint)] = []
-  private let candidateScrollView = UIScrollView()
+  private let candidateScrollView = CandidateScrollView()
   private let diagnosticLabel = UILabel()
   private let previousPageButton = UIButton()
   private let nextPageButton = UIButton()

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -479,13 +479,13 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     for button in [languageModeButton, schemeButton, scriptShortcut, skinShortcut, moreShortcut, dismissShortcut] {
       shortcutBar.addArrangedSubview(button)
       if button !== languageModeButton {
-        button.widthAnchor.constraint(equalTo: languageModeButton.widthAnchor).isActive = true
+        button.widthAnchor.constraint(equalTo: languageModeButton.widthAnchor, constant: button === schemeButton ? 6 : 0).isActive = true
       }
     }
     container.addSubview(shortcutBar)
     NSLayoutConstraint.activate([
-      shortcutBar.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 4),
-      shortcutBar.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -4),
+      shortcutBar.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 2),
+      shortcutBar.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -2),
       shortcutBar.topAnchor.constraint(equalTo: container.topAnchor),
       shortcutBar.bottomAnchor.constraint(equalTo: container.bottomAnchor),
     ])
@@ -1303,6 +1303,12 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     configuration.background.strokeColor = KeyboardSkinPreference.selected.accent.withAlphaComponent(0.35)
     configuration.background.strokeWidth = 1
     configuration.background.cornerRadius = 8
+    configuration.background.backgroundInsets = NSDirectionalEdgeInsets(top: 3, leading: 2, bottom: 3, trailing: 2)
+    configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attributes in
+      var attributes = attributes
+      attributes.font = .systemFont(ofSize: 16, weight: .medium)
+      return attributes
+    }
     schemeButton.configuration = configuration
     schemeButton.accessibilityIdentifier = "schemeButton"
     schemeButton.accessibilityLabel = "选择输入方案"

--- a/platforms/ios/KeyboardTests/ClipboardHistoryTests.swift
+++ b/platforms/ios/KeyboardTests/ClipboardHistoryTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import UIKit
+
+final class ClipboardHistoryTests: XCTestCase {
+  private func temporaryStore() throws -> ClipboardHistoryStore {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+    return ClipboardHistoryStore(directory: directory)
+  }
+  func testDeduplicationPersistenceAndPinnedEviction() throws {
+    let store = try temporaryStore()
+    try store.add("  保留空格\n")
+    var items = try store.load()
+    let id = items[0].id
+    items[0].pinned = true
+    try store.save(items)
+    for number in 0..<60 { try store.add("记录 \(number)") }
+    XCTAssertEqual(try store.load().count, 50)
+    XCTAssertEqual(try store.load().first?.id, id)
+    XCTAssertFalse(try store.load().contains { $0.text == "记录 0" })
+    try store.add("  保留空格\n")
+    XCTAssertEqual(try store.load().first?.text, "  保留空格\n")
+    XCTAssertEqual(try store.load().filter { $0.id == id }.count, 1)
+    items = try store.load().map { var item = $0; item.pinned = true; return item }
+    try store.save(items)
+    XCTAssertThrowsError(try store.add("满了"))
+    XCTAssertEqual(try store.load(), items)
+    try store.save([])
+    XCTAssertTrue(try store.load().isEmpty)
+  }
+  func testInvalidInputAndCorruptHistoryDoNotOverwriteData() throws {
+    let store = try temporaryStore()
+    XCTAssertThrowsError(try store.add(" \n"))
+    XCTAssertThrowsError(try store.add(String(repeating: "字", count: 10_001)))
+    try store.add("原文")
+    try Data("invalid".utf8).write(to: store.file)
+    XCTAssertThrowsError(try store.add("新的"))
+    XCTAssertEqual(try Data(contentsOf: store.file), Data("invalid".utf8))
+    try store.save([])
+    XCTAssertTrue(try store.load().isEmpty)
+  }
+  @MainActor func testPanelSelectionAccessGateAndNarrowLayout() throws {
+    let store = try temporaryStore()
+    try store.add("测试粘贴\n第二行")
+    var inserted = ""
+    let panel = KeyboardClipboardView(hasFullAccess: true, store: store, onInsert: { inserted = $0 }, onClose: {})
+    panel.frame = CGRect(x: 0, y: 0, width: 320, height: 260)
+    panel.layoutIfNeeded()
+    let table = try XCTUnwrap(panel.subviews.compactMap { $0 as? UITableView }.first)
+    XCTAssertEqual(table.numberOfRows(inSection: 0), 1)
+    panel.tableView(table, didSelectRowAt: IndexPath(row: 0, section: 0))
+    XCTAssertEqual(inserted, "测试粘贴\n第二行")
+    XCTAssertGreaterThan(table.bounds.height, 60)
+    let header = try XCTUnwrap(panel.subviews.compactMap { $0 as? UIStackView }.first)
+    let clear = try XCTUnwrap(header.arrangedSubviews.compactMap { $0 as? UIButton }.first)
+    clear.sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(try store.load().count, 1)
+    clear.sendActions(for: .primaryActionTriggered)
+    XCTAssertTrue(try store.load().isEmpty)
+    let gated = KeyboardClipboardView(hasFullAccess: false, store: store, onInsert: { _ in XCTFail() }, onClose: {})
+    let capture = try XCTUnwrap(gated.subviews.compactMap { $0 as? UIButton }.first)
+    XCTAssertFalse(capture.isEnabled)
+    let hidden = try XCTUnwrap(gated.subviews.compactMap { $0 as? UITableView }.first)
+    XCTAssertEqual(hidden.numberOfRows(inSection: 0), 0)
+  }
+}

--- a/platforms/ios/KeyboardTests/KeyboardSkinTests.swift
+++ b/platforms/ios/KeyboardTests/KeyboardSkinTests.swift
@@ -31,6 +31,99 @@ final class KeyboardSkinTests: XCTestCase {
       XCTAssertGreaterThanOrEqual(CustomKeyboardSkin.contrast(CustomKeyboardSkin.readableText(on: background), background), 4.5)
     }
   }
+  func testLegacyDesignsAndLibraryRoundTrip() throws {
+    let legacy = Data(#"{"background":15266027,"keyBackground":16777215,"keyForeground":1516829,"accent":1596487,"actionBackground":1596487,"cornerRadius":8,"borderWidth":0,"shadow":0,"pattern":0,"monospaced":false}"#.utf8)
+    let old = try JSONDecoder().decode(CustomKeyboardSkin.self, from: legacy)
+    XCTAssertNil(old.gradientEnd)
+    XCTAssertNil(old.photo)
+    let previous = CustomSkinLibrary.designs
+    defer { CustomSkinLibrary.save(previous) }
+    var design = CustomKeyboardSkin.templates[2].1
+    design.photoShade = .infinity
+    design.photoPosition = -4
+    design.photo = Data(repeating: 0, count: 512_001)
+    design.patternOpacity = 2
+    let item = SavedKeyboardSkin(name: "  我的夜色  ", design: design)
+    CustomSkinLibrary.save([item])
+    let restored = try XCTUnwrap(CustomSkinLibrary.designs.first)
+    XCTAssertEqual(restored.id, item.id)
+    XCTAssertEqual(restored.name, "我的夜色")
+    XCTAssertEqual(restored.design.gradientEnd, design.gradientEnd)
+    XCTAssertEqual(restored.design.photoShade, 0.25)
+    XCTAssertEqual(restored.design.photoPosition, 0)
+    XCTAssertNil(restored.design.photo)
+    XCTAssertEqual(restored.design.patternOpacity, 0.5)
+    CustomSkinLibrary.save([])
+    XCTAssertTrue(CustomSkinLibrary.designs.isEmpty)
+  }
+
+  @MainActor
+  func testGradientAndPhotoRenderInKeyboardBackdrop() throws {
+    let previous = KeyboardFeedbackPreference.defaults.object(forKey: CustomKeyboardSkinStore.key)
+    defer {
+      if let previous { KeyboardFeedbackPreference.defaults.set(previous, forKey: CustomKeyboardSkinStore.key) }
+      else { KeyboardFeedbackPreference.defaults.removeObject(forKey: CustomKeyboardSkinStore.key) }
+    }
+    let view = KeyboardSkinBackgroundView(frame: CGRect(x: 0, y: 0, width: 320, height: 260))
+    func render(_ design: CustomKeyboardSkin) -> UIImage {
+      CustomKeyboardSkinStore.save(design)
+      view.skin = .custom
+      return UIGraphicsImageRenderer(bounds: view.bounds).image { view.layer.render(in: $0.cgContext) }
+    }
+    var design = CustomKeyboardSkin()
+    let plain = render(design)
+    design.gradientEnd = 0x224466
+    let gradient = render(design)
+    XCTAssertNotEqual(plain.pngData(), gradient.pngData())
+    let photo = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 100)).image { context in
+      UIColor.red.setFill(); context.fill(CGRect(x: 0, y: 0, width: 100, height: 100))
+    }
+    design.photo = try XCTUnwrap(photo.jpegData(compressionQuality: 0.8))
+    let wallpaper = render(design)
+    XCTAssertNotEqual(gradient.pngData(), wallpaper.pngData())
+    design.photoShade = 0.8
+    XCTAssertNotEqual(wallpaper.pngData(), render(design).pngData())
+    design.photo = nil
+    design.photoShade = nil
+    XCTAssertEqual(gradient.pngData(), render(design).pngData())
+  }
+
+  @MainActor
+  func testPhotoImportBoundsAndSavedKeyboardSelection() throws {
+    let defaults = KeyboardFeedbackPreference.defaults
+    let old = defaults.object(forKey: CustomKeyboardSkinStore.key)
+    let library = CustomSkinLibrary.designs
+    defer {
+      if let old { defaults.set(old, forKey: CustomKeyboardSkinStore.key) } else { defaults.removeObject(forKey: CustomKeyboardSkinStore.key) }
+      CustomSkinLibrary.save(library)
+    }
+    let format = UIGraphicsImageRendererFormat(); format.scale = 1
+    let original = UIGraphicsImageRenderer(size: CGSize(width: 2400, height: 800), format: format).image {
+      UIColor.blue.setFill(); $0.fill(CGRect(x: 0, y: 0, width: 2400, height: 800))
+    }
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".png")
+    defer { try? FileManager.default.removeItem(at: url) }
+    try XCTUnwrap(original.pngData()).write(to: url)
+    let data = try XCTUnwrap(SkinPhotoData.thumbnail(at: url))
+    let image = try XCTUnwrap(UIImage(data: data))
+    XCTAssertLessThanOrEqual(max(image.size.width, image.size.height), 1024)
+    XCTAssertLessThanOrEqual(data.count, 512_000)
+    try Data("not an image".utf8).write(to: url)
+    XCTAssertNil(SkinPhotoData.thumbnail(at: url))
+    var design = CustomKeyboardSkin.templates[2].1
+    design.photo = data; design.keyOpacity = 0.45
+    let item = SavedKeyboardSkin(name: "照片夜色", design: design)
+    CustomSkinLibrary.save([item])
+    var selection: KeyboardSkin?
+    let picker = KeyboardSkinPickerView(selected: .forest, onSelect: { selection = $0 }, onClose: {})
+    func descendants(_ view: UIView) -> [UIView] { [view] + view.subviews.flatMap { descendants($0) } }
+    let button = try XCTUnwrap(descendants(picker).first { $0.accessibilityIdentifier == "savedSkinCard-" + item.id.uuidString } as? UIButton)
+    button.sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(selection, .custom)
+    XCTAssertEqual(CustomKeyboardSkinStore.current, design)
+    XCTAssertEqual(KeyboardSkin.custom.keyBackground.cgColor.alpha, 0.45, accuracy: 0.001)
+  }
+
   private func luminance(_ color: UIColor, style: UIUserInterfaceStyle) -> Double {
     let resolved = color.resolvedColor(with: UITraitCollection(userInterfaceStyle: style))
     var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -399,7 +399,17 @@ final class NineKeyKeyboardTests: XCTestCase {
               add(attachment)
             }
           }
+          XCTAssertEqual(try button("symbolDeleteKey", in: controller).isHidden, !symbols)
           if !symbols && scheme != .nineKey {
+            let delete = try button("letterDeleteKey", in: controller)
+            let shift = try button("shiftButton", in: controller)
+            let m = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityLabel == "字母 M" } as? UIButton)
+            XCTAssertEqual(delete.superview, m.superview)
+            XCTAssertGreaterThan(delete.frame.minX, m.frame.maxX)
+            XCTAssertEqual(delete.bounds.width, 44, accuracy: 0.5)
+            XCTAssertEqual(shift.bounds.width, 44, accuracy: 0.5)
+            XCTAssertEqual(delete.bounds.height, reference, accuracy: 0.5)
+            XCTAssertLessThanOrEqual(delete.convert(delete.bounds, to: controller.view).maxX, width - 4.5)
             for label in ["Q", "A", "Z", "P", "L", "M"] {
               let key = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityLabel == "字母 \(label)" } as? UIButton)
               XCTAssertEqual(key.bounds.height, reference, accuracy: 0.5)

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -279,6 +279,11 @@ final class NineKeyKeyboardTests: XCTestCase {
       XCTAssertFalse(toolbar.isHidden)
       let brand = try XCTUnwrap(descendants(toolbar).first { $0.accessibilityIdentifier == "keyboardBrandIcon" } as? UIImageView)
       XCTAssertNotNil(brand.image)
+      XCTAssertEqual(brand.bounds.width, 24, accuracy: 0.1)
+      XCTAssertEqual(brand.bounds.height, 24, accuracy: 0.1)
+      let brandSlot = try XCTUnwrap(brand.superview)
+      XCTAssertGreaterThanOrEqual(brand.frame.minX, 6)
+      XCTAssertGreaterThanOrEqual(brandSlot.bounds.width - brand.frame.maxX, 6)
       XCTAssertLessThan(brand.convert(brand.bounds, to: toolbar).maxX,
                         try button("languageModeButton", in: controller).convert(try button("languageModeButton", in: controller).bounds, to: toolbar).minX)
       for id in ["languageModeButton", "schemeButton", "scriptShortcut", "skinShortcut", "moreShortcut", "dismissShortcut"] {

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -336,10 +336,31 @@ final class NineKeyKeyboardTests: XCTestCase {
           controller.view.layoutIfNeeded()
           XCTAssertEqual(try button("returnKey", in: controller).bounds.height, reference, accuracy: 0.5)
           XCTAssertEqual(controller.view.constraints.first { $0.identifier == "keyboardHeight" }?.constant, 260)
+          if !symbols && [.nineKey, .quanpin].contains(scheme) {
+            let selector = try button("schemeButton", in: controller)
+            XCTAssertGreaterThanOrEqual(selector.bounds.width, 50)
+            let label = try XCTUnwrap(selector.titleLabel)
+            let insets = try XCTUnwrap(selector.configuration).contentInsets
+            XCTAssertLessThanOrEqual(label.intrinsicContentSize.width + insets.leading + insets.trailing, selector.bounds.width)
+            for id in ["languageModeButton", "scriptShortcut", "skinShortcut", "moreShortcut", "dismissShortcut"] {
+              XCTAssertGreaterThanOrEqual(try button(id, in: controller).bounds.width, 44)
+            }
+            if width == 320 {
+              let attachment = XCTAttachment(image: UIGraphicsImageRenderer(bounds: controller.view.bounds).image { context in
+                controller.view.layer.render(in: context.cgContext)
+              })
+              attachment.name = "Narrow \(scheme.rawValue) keyboard and toolbar"
+              attachment.lifetime = .keepAlways
+              add(attachment)
+            }
+          }
           if !symbols && scheme != .nineKey {
-            for label in ["Q", "A", "Z"] {
+            for label in ["Q", "A", "Z", "P", "L", "M"] {
               let key = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityLabel == "字母 \(label)" } as? UIButton)
               XCTAssertEqual(key.bounds.height, reference, accuracy: 0.5)
+              let frame = key.convert(key.bounds, to: controller.view)
+              XCTAssertGreaterThanOrEqual(frame.minX, 4.5)
+              XCTAssertLessThanOrEqual(frame.maxX, controller.view.bounds.width - 4.5, "\(scheme) \(label) frame \(frame)")
             }
           }
           if symbols { try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered) }
@@ -360,7 +381,7 @@ final class NineKeyKeyboardTests: XCTestCase {
         controller.openLocalInputMode(trigger)
         controller.view.layoutIfNeeded()
         let returnKey = try button("returnKey", in: controller)
-        for label in ["Q", "A", "Z"] {
+        for label in ["Q", "A", "Z", "P", "L", "M"] {
           let key = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityLabel == "字母 \(label)" } as? UIButton)
           XCTAssertEqual(key.bounds.height, returnKey.bounds.height, accuracy: 0.5)
           XCTAssertGreaterThanOrEqual(key.bounds.height, 44)

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -318,6 +318,48 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
+  func testNewCandidatesAndPagesReturnToLeadingCandidate() throws {
+    let previous = InputSchemePreference.scheme
+    defer { InputSchemePreference.scheme = previous }
+    for scheme in [ChineseInputScheme.nineKey, .quanpin] {
+      InputSchemePreference.scheme = scheme
+      let controller = KeyboardViewController()
+      controller.loadViewIfNeeded()
+      controller.view.frame = CGRect(x: 0, y: 0, width: 320, height: 260)
+      func type(_ text: String) throws {
+        for character in text {
+          let key: UIButton
+          if scheme == .nineKey {
+            key = try button("nineKey\(character)", in: controller)
+          } else {
+            key = try XCTUnwrap(descendants(controller.view).first {
+              $0.accessibilityLabel == "字母 \(String(character).uppercased())"
+            } as? UIButton)
+          }
+          key.sendActions(for: .primaryActionTriggered)
+        }
+        controller.view.layoutIfNeeded()
+      }
+      try type(scheme == .nineKey ? "6" : "n")
+      let candidate = try button("candidate-1", in: controller)
+      var ancestor = candidate.superview
+      while ancestor != nil && !(ancestor is UIScrollView) { ancestor = ancestor?.superview }
+      let scroll = try XCTUnwrap(ancestor as? UIScrollView)
+      XCTAssertGreaterThan(scroll.contentSize.width, scroll.bounds.width + 40)
+      scroll.setContentOffset(CGPoint(x: 40, y: 0), animated: false)
+      try type(scheme == .nineKey ? "4" : "i")
+      XCTAssertEqual(scroll.contentOffset.x, 0, accuracy: 0.5)
+      let next = try button("nextCandidatePage", in: controller)
+      XCTAssertFalse(next.isHidden)
+      scroll.setContentOffset(CGPoint(x: 40, y: 0), animated: false)
+      next.sendActions(for: .primaryActionTriggered)
+      controller.view.layoutIfNeeded()
+      XCTAssertEqual(scroll.contentOffset.x, 0, accuracy: 0.5)
+      let leading = try button("candidate-1", in: controller)
+      XCTAssertGreaterThanOrEqual(leading.convert(leading.bounds, to: scroll).minX, 0)
+    }
+  }
+
   func testAllLayoutsKeepNineKeyHeight() throws {
     let previous = InputSchemePreference.scheme
     defer { InputSchemePreference.scheme = previous }

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -345,6 +345,9 @@ final class NineKeyKeyboardTests: XCTestCase {
       var ancestor = candidate.superview
       while ancestor != nil && !(ancestor is UIScrollView) { ancestor = ancestor?.superview }
       let scroll = try XCTUnwrap(ancestor as? UIScrollView)
+      XCTAssertFalse(scroll.delaysContentTouches)
+      XCTAssertTrue(scroll.canCancelContentTouches)
+      XCTAssertTrue(scroll.touchesShouldCancel(in: candidate))
       XCTAssertGreaterThan(scroll.contentSize.width, scroll.bounds.width + 40)
       scroll.setContentOffset(CGPoint(x: 40, y: 0), animated: false)
       try type(scheme == .nineKey ? "4" : "i")

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -43,6 +43,7 @@ final class NineKeyKeyboardTests: XCTestCase {
         XCTAssertEqual(q.bounds.height, try button("returnKey", in: controller).bounds.height, accuracy: 0.5)
         XCTAssertGreaterThanOrEqual(q.bounds.height, 44)
         if type != .asciiCapable { XCTAssertEqual(q.configuration?.title, "q") }
+        XCTAssertEqual(try button("quickPunctuationKey", in: controller).configuration?.title, ",")
         q.sendActions(for: .primaryActionTriggered)
         XCTAssertEqual(try button("preeditButton", in: controller).configuration?.title, "英文输入")
         try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
@@ -398,6 +399,14 @@ final class NineKeyKeyboardTests: XCTestCase {
               attachment.lifetime = .keepAlways
               add(attachment)
             }
+          }
+          let punctuation = try button("quickPunctuationKey", in: controller)
+          XCTAssertEqual(punctuation.isHidden, symbols || scheme == .nineKey)
+          if !punctuation.isHidden {
+            XCTAssertEqual(punctuation.configuration?.title, scheme == .japanese ? "、" : "，")
+            XCTAssertEqual(punctuation.bounds.width, 44, accuracy: 0.5)
+            XCTAssertGreaterThanOrEqual(try button("spaceKey", in: controller).bounds.width, 79.2)
+            XCTAssertEqual(punctuation.menu?.children.count, 7)
           }
           XCTAssertEqual(try button("symbolDeleteKey", in: controller).isHidden, !symbols)
           if !symbols && scheme != .nineKey {

--- a/platforms/ios/KeyboardTests/SkinCommunityTests.swift
+++ b/platforms/ios/KeyboardTests/SkinCommunityTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import UIKit
+
+private final class CommunityMemoryCredentials: @unchecked Sendable {
+  private let lock = NSLock()
+  private var tokens: CommunityTokens?
+  func read() -> CommunityTokens? { lock.lock(); defer { lock.unlock() }; return tokens }
+  func write(_ value: CommunityTokens?) { lock.lock(); defer { lock.unlock() }; tokens = value }
+}
+
+private final class CommunityFixtureProtocol: URLProtocol, @unchecked Sendable {
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+  override func startLoading() {
+    let path = request.url!.path
+    let body: String
+    let status: Int
+    if path == "/v1/auth/challenges" {
+      body = #"{"challenge_id":"fixture-id","nonce":"server-nonce"}"#; status = 200
+    } else if path == "/v1/auth/login" || path == "/v1/auth/refresh" {
+      let token = path.hasSuffix("refresh") ? "fresh" : "expired"
+      body = "{\"access_token\":\"\(token)\",\"refresh_token\":\"refresh-fixture\",\"user\":{\"id\":\"fixture-user\",\"display_name\":\"测试\"}}"
+      status = 200
+    } else if path == "/v1/auth/logout" {
+      body = ""; status = 204
+    } else if request.value(forHTTPHeaderField: "Authorization") == "Bearer expired" {
+      body = #"{"error":{"code":"invalid_credentials"}}"#; status = 401
+    } else if request.url?.query?.contains("offset=20") == true {
+      body = #"{"error":{"code":"rate_limit_exceeded","message":"internal"}}"#; status = 429
+    } else {
+      body = #"{"skins":[{"id":"a1234567-1234-1234-1234-123456789abc","name":"测试","description":"示例","author":"作者","design":{"background":15266027,"keyBackground":16777215,"keyForeground":1516829,"accent":1596487,"actionBackground":1596487,"cornerRadius":8,"borderWidth":0,"shadow":0,"pattern":0,"monospaced":false},"downloads":2,"rating_count":1,"rating_average":4,"owned":false,"my_rating":0}],"has_more":false}"#
+      status = 200
+    }
+    client?.urlProtocol(self, didReceive: HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: Data(body.utf8))
+    client?.urlProtocolDidFinishLoading(self)
+  }
+  override func stopLoading() {}
+}
+
+final class SkinCommunityTests: XCTestCase {
+  func testCommunityWireFormatAndErrors() async throws {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [CommunityFixtureProtocol.self]
+    let api = SkinCommunityAPI(configuration: configuration, readCredentials: { nil }, writeCredentials: { _ in })
+    let page = try await api.list(search: "纸感 & 星光")
+    XCTAssertEqual(page.skins.first?.downloads, 2)
+    XCTAssertEqual(page.skins.first?.rating_average, 4)
+    XCTAssertNil(page.skins.first?.design.photo)
+    XCTAssertFalse(page.has_more)
+    let challenge = try await api.challenge()
+    XCTAssertEqual(challenge.nonce, "server-nonce")
+    do { _ = try await api.list(offset: 20); XCTFail("expected limit error") }
+    catch { XCTAssertEqual(error.localizedDescription, "操作较频繁，请稍后重试。") }
+  }
+  func testLoginConcurrentRefreshAndEmptyLogoutResponse() async throws {
+    let memory = CommunityMemoryCredentials()
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [CommunityFixtureProtocol.self]
+    let api = SkinCommunityAPI(configuration: configuration, readCredentials: { memory.read() }, writeCredentials: { memory.write($0) })
+    try await api.login(challenge: "fixture", identityToken: "synthetic")
+    let signedIn = try await api.signedIn()
+    XCTAssertTrue(signedIn)
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for _ in 0..<8 { group.addTask { _ = try await api.list() } }
+      try await group.waitForAll()
+    }
+    XCTAssertEqual(memory.read()?.access_token, "fresh")
+    try await api.logout()
+    let signedOut = try await api.signedIn()
+    XCTAssertFalse(signedOut)
+  }
+  @MainActor func testCommunityPreviewDoesNotChangeActiveDesign() throws {
+    let previous = CustomKeyboardSkinStore.current
+    let backdrop = KeyboardSkinBackgroundView(frame: CGRect(x: 0, y: 0, width: 320, height: 240))
+    var design = CustomKeyboardSkin.templates[2].1
+    design.pattern = 2
+    backdrop.designOverride = design
+    backdrop.skin = .custom
+    let before = UIGraphicsImageRenderer(bounds: backdrop.bounds).image { backdrop.layer.render(in: $0.cgContext) }.pngData()
+    design.background = 0xEEFFFF
+    design.gradientEnd = nil
+    backdrop.designOverride = design
+    backdrop.skin = .custom
+    let after = UIGraphicsImageRenderer(bounds: backdrop.bounds).image { backdrop.layer.render(in: $0.cgContext) }.pngData()
+    XCTAssertNotEqual(before, after)
+    XCTAssertEqual(CustomKeyboardSkinStore.current, previous)
+    XCTAssertEqual(CustomKeyboardSkin.rgb(try XCTUnwrap(backdrop.backgroundColor)), design.background)
+  }
+}

--- a/platforms/ios/KeyboardTests/SkinCommunityTests.swift
+++ b/platforms/ios/KeyboardTests/SkinCommunityTests.swift
@@ -61,6 +61,8 @@ final class SkinCommunityTests: XCTestCase {
     try await api.login(challenge: "fixture", identityToken: "synthetic")
     let signedIn = try await api.signedIn()
     XCTAssertTrue(signedIn)
+    let profile = try await api.currentUser()
+    XCTAssertEqual(profile?.display_name, "测试")
     try await withThrowingTaskGroup(of: Void.self) { group in
       for _ in 0..<8 { group.addTask { _ = try await api.list() } }
       try await group.waitForAll()
@@ -69,6 +71,8 @@ final class SkinCommunityTests: XCTestCase {
     try await api.logout()
     let signedOut = try await api.signedIn()
     XCTAssertFalse(signedOut)
+    let profileAfterLogout = try await api.currentUser()
+    XCTAssertNil(profileAfterLogout)
   }
   @MainActor func testCommunityPreviewDoesNotChangeActiveDesign() throws {
     let previous = CustomKeyboardSkinStore.current

--- a/platforms/ios/KeyboardTests/SkinCommunityTests.swift
+++ b/platforms/ios/KeyboardTests/SkinCommunityTests.swift
@@ -23,6 +23,11 @@ private final class CommunityFixtureProtocol: URLProtocol, @unchecked Sendable {
       status = 200
     } else if path == "/v1/auth/logout" {
       body = ""; status = 204
+    } else if path == "/v1/users/me" && request.httpMethod == "PATCH" {
+      body = ""; status = 204
+    } else if path == "/v1/users/me" {
+      body = #"{"user":{"id":"fixture-user","display_name":"新昵称","created_at":"2026-09-08T00:00:00Z"},"identities":[{"provider":"apple","subject":"not-displayed"}]}"#
+      status = 200
     } else if request.value(forHTTPHeaderField: "Authorization") == "Bearer expired" {
       body = #"{"error":{"code":"invalid_credentials"}}"#; status = 401
     } else if request.url?.query?.contains("offset=20") == true {
@@ -73,6 +78,26 @@ final class SkinCommunityTests: XCTestCase {
     XCTAssertFalse(signedOut)
     let profileAfterLogout = try await api.currentUser()
     XCTAssertNil(profileAfterLogout)
+  }
+  func testProfileFetchUpdateAndValidation() async throws {
+    let memory = CommunityMemoryCredentials()
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [CommunityFixtureProtocol.self]
+    let api = SkinCommunityAPI(configuration: configuration, readCredentials: { memory.read() }, writeCredentials: { memory.write($0) })
+    try await api.login(challenge: "fixture", identityToken: "synthetic")
+    for invalid in ["  ", String(repeating: "字", count: 65), "名字\n换行"] {
+      do { _ = try await api.updateProfile(name: invalid); XCTFail("invalid name accepted") }
+      catch { XCTAssertTrue(error.localizedDescription.contains("1–64")) }
+    }
+    XCTAssertEqual(memory.read()?.user.display_name, "测试")
+    let profile = try await api.updateProfile(name: " 新昵称 ")
+    XCTAssertEqual(profile.user.display_name, "新昵称")
+    XCTAssertEqual(profile.identities.first?.provider, "apple")
+    XCTAssertEqual(profile.user.created_at, "2026-09-08T00:00:00Z")
+    XCTAssertEqual(memory.read()?.user.display_name, "新昵称")
+    try await api.logout()
+    do { _ = try await api.profile(); XCTFail("signed-out profile must require authentication") }
+    catch { XCTAssertEqual(error.localizedDescription, "请先使用 Apple 登录。") }
   }
   @MainActor func testCommunityPreviewDoesNotChangeActiveDesign() throws {
     let previous = CustomKeyboardSkinStore.current

--- a/platforms/ios/KeyboardTests/SkinCommunityTests.swift
+++ b/platforms/ios/KeyboardTests/SkinCommunityTests.swift
@@ -1,11 +1,12 @@
 import XCTest
 import UIKit
 
-private final class CommunityMemoryCredentials: @unchecked Sendable {
+private final class CommunityMemoryCredentials: BackendSessionStorage, @unchecked Sendable {
   private let lock = NSLock()
-  private var tokens: CommunityTokens?
-  func read() -> CommunityTokens? { lock.lock(); defer { lock.unlock() }; return tokens }
-  func write(_ value: CommunityTokens?) { lock.lock(); defer { lock.unlock() }; tokens = value }
+  private var value: BackendSavedSession?
+  func load() throws -> BackendSavedSession? { lock.lock(); defer { lock.unlock() }; return value }
+  func save(_ session: BackendSavedSession) throws { lock.lock(); defer { lock.unlock() }; value = session }
+  func clear() throws { lock.lock(); defer { lock.unlock() }; value = nil }
 }
 
 private final class CommunityFixtureProtocol: URLProtocol, @unchecked Sendable {
@@ -16,10 +17,10 @@ private final class CommunityFixtureProtocol: URLProtocol, @unchecked Sendable {
     let body: String
     let status: Int
     if path == "/v1/auth/challenges" {
-      body = #"{"challenge_id":"fixture-id","nonce":"server-nonce"}"#; status = 200
+      body = #"{"challenge_id":"fixture-id","nonce":"server-nonce","expires_in":300}"#; status = 200
     } else if path == "/v1/auth/login" || path == "/v1/auth/refresh" {
-      let token = path.hasSuffix("refresh") ? "fresh" : "expired"
-      body = "{\"access_token\":\"\(token)\",\"refresh_token\":\"refresh-fixture\",\"user\":{\"id\":\"fixture-user\",\"display_name\":\"测试\"}}"
+      let token = String(repeating: path.hasSuffix("refresh") ? "b" : "a", count: 64)
+      body = "{\"access_token\":\"\(token)\",\"refresh_token\":\"\(String(repeating: "f", count: 64))\",\"token_type\":\"Bearer\",\"expires_in\":900,\"user\":{\"id\":\"fixture-user\",\"display_name\":\"测试\",\"created_at\":\"2026-09-08T00:00:00Z\"}}"
       status = 200
     } else if path == "/v1/auth/logout" {
       body = ""; status = 204
@@ -28,7 +29,7 @@ private final class CommunityFixtureProtocol: URLProtocol, @unchecked Sendable {
     } else if path == "/v1/users/me" {
       body = #"{"user":{"id":"fixture-user","display_name":"新昵称","created_at":"2026-09-08T00:00:00Z"},"identities":[{"provider":"apple","subject":"not-displayed"}]}"#
       status = 200
-    } else if request.value(forHTTPHeaderField: "Authorization") == "Bearer expired" {
+    } else if request.value(forHTTPHeaderField: "Authorization") == "Bearer " + String(repeating: "a", count: 64) {
       body = #"{"error":{"code":"invalid_credentials"}}"#; status = 401
     } else if request.url?.query?.contains("offset=20") == true {
       body = #"{"error":{"code":"rate_limit_exceeded","message":"internal"}}"#; status = 429
@@ -47,7 +48,8 @@ final class SkinCommunityTests: XCTestCase {
   func testCommunityWireFormatAndErrors() async throws {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [CommunityFixtureProtocol.self]
-    let api = SkinCommunityAPI(configuration: configuration, readCredentials: { nil }, writeCredentials: { _ in })
+    let client = BackendAccountClient(configuration: configuration)
+    let api = SkinCommunityAPI(client: client, account: BackendAccountSession(api: client, storage: CommunityMemoryCredentials()))
     let page = try await api.list(search: "纸感 & 星光")
     XCTAssertEqual(page.skins.first?.downloads, 2)
     XCTAssertEqual(page.skins.first?.rating_average, 4)
@@ -62,7 +64,8 @@ final class SkinCommunityTests: XCTestCase {
     let memory = CommunityMemoryCredentials()
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [CommunityFixtureProtocol.self]
-    let api = SkinCommunityAPI(configuration: configuration, readCredentials: { memory.read() }, writeCredentials: { memory.write($0) })
+    let client = BackendAccountClient(configuration: configuration)
+    let api = SkinCommunityAPI(client: client, account: BackendAccountSession(api: client, storage: memory))
     try await api.login(challenge: "fixture", identityToken: "synthetic")
     let signedIn = try await api.signedIn()
     XCTAssertTrue(signedIn)
@@ -72,7 +75,7 @@ final class SkinCommunityTests: XCTestCase {
       for _ in 0..<8 { group.addTask { _ = try await api.list() } }
       try await group.waitForAll()
     }
-    XCTAssertEqual(memory.read()?.access_token, "fresh")
+    XCTAssertEqual(try memory.load()?.tokens.access_token, String(repeating: "b", count: 64))
     try await api.logout()
     let signedOut = try await api.signedIn()
     XCTAssertFalse(signedOut)
@@ -83,21 +86,22 @@ final class SkinCommunityTests: XCTestCase {
     let memory = CommunityMemoryCredentials()
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [CommunityFixtureProtocol.self]
-    let api = SkinCommunityAPI(configuration: configuration, readCredentials: { memory.read() }, writeCredentials: { memory.write($0) })
+    let client = BackendAccountClient(configuration: configuration)
+    let api = SkinCommunityAPI(client: client, account: BackendAccountSession(api: client, storage: memory))
     try await api.login(challenge: "fixture", identityToken: "synthetic")
     for invalid in ["  ", String(repeating: "字", count: 65), "名字\n换行"] {
       do { _ = try await api.updateProfile(name: invalid); XCTFail("invalid name accepted") }
       catch { XCTAssertTrue(error.localizedDescription.contains("1–64")) }
     }
-    XCTAssertEqual(memory.read()?.user.display_name, "测试")
+    XCTAssertEqual(try memory.load()?.tokens.user.display_name, "测试")
     let profile = try await api.updateProfile(name: " 新昵称 ")
     XCTAssertEqual(profile.user.display_name, "新昵称")
     XCTAssertEqual(profile.identities.first?.provider, "apple")
     XCTAssertEqual(profile.user.created_at, "2026-09-08T00:00:00Z")
-    XCTAssertEqual(memory.read()?.user.display_name, "新昵称")
+    XCTAssertEqual(try memory.load()?.tokens.user.display_name, "新昵称")
     try await api.logout()
     do { _ = try await api.profile(); XCTFail("signed-out profile must require authentication") }
-    catch { XCTAssertEqual(error.localizedDescription, "请先使用 Apple 登录。") }
+    catch let error as BackendAccountClient.Failure { XCTAssertEqual(error.status, 401) }
   }
   @MainActor func testCommunityPreviewDoesNotChangeActiveDesign() throws {
     let previous = CustomKeyboardSkinStore.current

--- a/platforms/ios/SharedUI/ClipboardHistoryStore.swift
+++ b/platforms/ios/SharedUI/ClipboardHistoryStore.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+struct ClipboardHistoryItem: Codable, Equatable, Identifiable {
+  var id = UUID()
+  var text: String
+  var date = Date()
+  var pinned = false
+}
+
+struct ClipboardHistoryStore {
+  static let limit = 50
+  let file: URL
+  init(directory: URL? = nil) {
+    let root = directory ?? FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: InputSchemePreference.appGroupIdentifier)
+      ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    file = root.appendingPathComponent("Clipboard/history.json")
+  }
+  func load() throws -> [ClipboardHistoryItem] {
+    guard FileManager.default.fileExists(atPath: file.path) else { return [] }
+    let size = try file.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+    guard size <= 4_000_000 else { throw Failure.invalidFile }
+    let items = try JSONDecoder().decode([ClipboardHistoryItem].self, from: Data(contentsOf: file))
+    guard items.count <= Self.limit, items.allSatisfy({ $0.text.count <= 10_000 && $0.text.utf8.count <= 40_000 }) else { throw Failure.invalidFile }
+    return items.sorted { $0.pinned != $1.pinned ? $0.pinned : $0.date > $1.date }
+  }
+  func save(_ items: [ClipboardHistoryItem]) throws {
+    guard items.count <= Self.limit else { throw Failure.full }
+    try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+    var directory = file.deletingLastPathComponent()
+    var values = URLResourceValues()
+    values.isExcludedFromBackup = true
+    try directory.setResourceValues(values)
+    try JSONEncoder().encode(items).write(to: file, options: [.atomic, .completeFileProtection])
+  }
+  func add(_ text: String) throws {
+    guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { throw Failure.empty }
+    guard text.count <= 10_000, text.utf8.count <= 40_000 else { throw Failure.tooLong }
+    var items = try load()
+    if let index = items.firstIndex(where: { $0.text == text }) {
+      items[index].date = Date()
+    } else {
+      if items.count == Self.limit {
+        guard let index = items.lastIndex(where: { !$0.pinned }) else { throw Failure.full }
+        items.remove(at: index)
+      }
+      items.insert(ClipboardHistoryItem(text: text), at: 0)
+    }
+    try save(items)
+  }
+  enum Failure: Error, LocalizedError {
+    case empty, tooLong, full, invalidFile
+    var errorDescription: String? {
+      switch self {
+      case .empty: "剪贴板中没有可保存的文本，或尚未允许粘贴。"
+      case .tooLong: "单条最多保存 10,000 字，请缩短后重试。"
+      case .full: "50 条历史均已固定，请先取消固定或删除一条。"
+      case .invalidFile: "历史记录无法读取，请清空后重试。"
+      }
+    }
+  }
+}

--- a/platforms/ios/SharedUI/CustomKeyboardSkin.swift
+++ b/platforms/ios/SharedUI/CustomKeyboardSkin.swift
@@ -1,4 +1,5 @@
 import UIKit
+import ImageIO
 
 struct CustomKeyboardSkin: Codable, Equatable, Hashable {
   var background: UInt32 = 0xE8F0EB
@@ -11,6 +12,16 @@ struct CustomKeyboardSkin: Codable, Equatable, Hashable {
   var shadow: Double = 0
   var pattern: Int = 0
   var monospaced = false
+  // Optional fields preserve decoding of existing v1 designs.
+  var keyOpacity: Double?
+  var gradientEnd: UInt32?
+  var gradientHorizontal: Bool?
+  var patternOpacity: Double?
+  var customBorderColor: UInt32?
+  var photo: Data?
+  var photoShade: Double?
+  var photoPosition: Double?
+
 
   var normalized: Self {
     var result = self
@@ -22,6 +33,13 @@ struct CustomKeyboardSkin: Codable, Equatable, Hashable {
     result.cornerRadius = cornerRadius.isFinite ? min(20, max(0, cornerRadius)) : 8
     result.borderWidth = borderWidth.isFinite ? min(2, max(0, borderWidth)) : 0
     result.shadow = shadow.isFinite ? min(0.4, max(0, shadow)) : 0
+    result.keyOpacity = keyOpacity.map { $0.isFinite ? min(1, max(0.25, $0)) : 1 }
+    result.gradientEnd = gradientEnd.map { $0 & 0xFFFFFF }
+    result.customBorderColor = customBorderColor.map { $0 & 0xFFFFFF }
+    result.patternOpacity = patternOpacity.map { $0.isFinite ? min(0.5, max(0, $0)) : 0.15 }
+    result.photoShade = photoShade.map { $0.isFinite ? min(0.8, max(0, $0)) : 0.25 }
+    result.photoPosition = photoPosition.map { $0.isFinite ? min(1, max(0, $0)) : 0.5 }
+    if let photo, photo.count > 512_000 { result.photo = nil }
     result.pattern = (0...3).contains(pattern) ? pattern : 0
     return result
   }
@@ -60,6 +78,7 @@ struct CustomKeyboardSkin: Codable, Equatable, Hashable {
     Self.contrast(keyForeground, keyBackground) >= 4.5
       && Self.contrast(accent, background) >= 4.5
       && Self.contrast(accent, keyBackground) >= 4.5
+      && (gradientEnd.map { Self.contrast(accent, $0) >= 4.5 } ?? true)
   }
 }
 
@@ -87,5 +106,89 @@ enum CustomKeyboardSkinStore {
       }
       return value
     }
+  }
+}
+
+struct SavedKeyboardSkin: Codable, Identifiable, Equatable {
+  var id = UUID()
+  var name: String
+  var design: CustomKeyboardSkin
+}
+
+enum CustomSkinLibrary {
+  // Keep the multi-photo library out of preferences, which the keyboard reads on each key.
+  private static var file: URL {
+    let root = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: InputSchemePreference.appGroupIdentifier)
+      ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    return root.appendingPathComponent("CustomSkins", isDirectory: true).appendingPathComponent("library.json")
+  }
+  static var designs: [SavedKeyboardSkin] {
+    guard let size = try? file.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+          size <= 9_000_000,
+          let data = try? Data(contentsOf: file),
+          let items = try? JSONDecoder().decode([SavedKeyboardSkin].self, from: data) else { return [] }
+    return Array(items.prefix(12)).map { item in
+      var item = item
+      item.design = item.design.normalized
+      return item
+    }
+  }
+  @discardableResult
+  static func save(_ items: [SavedKeyboardSkin]) -> Bool {
+    let items = items.prefix(12).map { item in
+      var item = item
+      item.name = String(item.name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(32))
+      item.design = item.design.normalized
+      return item
+    }
+    do {
+      let data = try JSONEncoder().encode(items)
+      try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try data.write(to: file, options: .atomic)
+      return true
+    } catch { return false }
+  }
+}
+
+extension CustomKeyboardSkin {
+  static var templates: [(String, CustomKeyboardSkin)] {
+    var paper = Self()
+    paper.background = 0xE3D6BD; paper.keyBackground = 0xFFF5DF; paper.keyForeground = 0x382A1C
+    paper.accent = 0x53391F; paper.actionBackground = 0x53391F
+    paper.cornerRadius = 4; paper.borderWidth = 1; paper.shadow = 0.3; paper.monospaced = true; paper.pattern = 1
+    var night = Self()
+    night.background = 0x151022; night.gradientEnd = 0x30224A; night.keyBackground = 0x291E40
+    night.keyForeground = 0xFFFFFF; night.accent = 0xD4BBFF; night.actionBackground = 0x69469B
+    night.borderWidth = 1; night.customBorderColor = 0xA987E8; night.pattern = 1
+    var peach = Self()
+    peach.background = 0xFFE0D0; peach.gradientEnd = 0xF9D6E5; peach.keyBackground = 0xFFF8EE
+    peach.keyForeground = 0x51283A; peach.accent = 0x84334F; peach.actionBackground = 0x84334F
+    peach.cornerRadius = 18; peach.shadow = 0.15; peach.pattern = 3
+    var blue = Self()
+    blue.background = 0xDCEAF8; blue.gradientEnd = 0xDDEFE9; blue.gradientHorizontal = true
+    blue.accent = 0x224E75; blue.actionBackground = 0x224E75; blue.borderWidth = 0.5
+    var grid = night
+    grid.background = 0x102438; grid.gradientEnd = nil; grid.keyBackground = 0x17354F
+    grid.accent = 0xA2D8FA; grid.actionBackground = 0x285D84; grid.cornerRadius = 2
+    grid.monospaced = true; grid.pattern = 2; grid.customBorderColor = 0x548CAA
+    return [("水杉留白", Self()), ("复古纸感", paper), ("紫夜星光", night), ("奶油桃桃", peach), ("海盐渐变", blue), ("工程蓝图", grid)]
+  }
+}
+
+// Decode only a bounded thumbnail, even when the chosen original is a large panorama.
+enum SkinPhotoData {
+  static func thumbnail(at url: URL) -> Data? {
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let cg = CGImageSourceCreateThumbnailAtIndex(source, 0, [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: 1024,
+            kCGImageSourceShouldCacheImmediately: true
+          ] as CFDictionary) else { return nil }
+    let image = UIImage(cgImage: cg)
+    for quality in [0.8, 0.6, 0.4, 0.2] {
+      if let data = image.jpegData(compressionQuality: quality), data.count <= 512_000 { return data }
+    }
+    return nil
   }
 }

--- a/platforms/ios/SharedUI/CustomKeyboardSkin.swift
+++ b/platforms/ios/SharedUI/CustomKeyboardSkin.swift
@@ -1,7 +1,7 @@
 import UIKit
 import ImageIO
 
-struct CustomKeyboardSkin: Codable, Equatable, Hashable {
+struct CustomKeyboardSkin: Codable, Equatable, Hashable, Sendable {
   var background: UInt32 = 0xE8F0EB
   var keyBackground: UInt32 = 0xFFFFFF
   var keyForeground: UInt32 = 0x17251D

--- a/platforms/ios/SharedUI/KeyboardSkinBackgroundView.swift
+++ b/platforms/ios/SharedUI/KeyboardSkinBackgroundView.swift
@@ -2,8 +2,15 @@ import UIKit
 import SwiftUI
 
 final class KeyboardSkinBackgroundView: UIView {
+  private var photoData: Data?
+  private var photoImage: UIImage?
   var skin: KeyboardSkin = .forest {
-    didSet { backgroundColor = skin.background; setNeedsDisplay() }
+    didSet {
+      backgroundColor = skin.background
+      let data = skin == .custom ? CustomKeyboardSkinStore.current.photo : nil
+      if data != photoData { photoData = data; photoImage = data.flatMap { UIImage(data: $0) } }
+      setNeedsDisplay()
+    }
   }
 
   override init(frame: CGRect) {
@@ -16,8 +23,23 @@ final class KeyboardSkinBackgroundView: UIView {
   required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
   override func draw(_ rect: CGRect) {
-    guard let context = UIGraphicsGetCurrentContext(), skin.pattern != 0 else { return }
-    let tint = skin.accent.resolvedColor(with: traitCollection).withAlphaComponent(0.15)
+    guard let context = UIGraphicsGetCurrentContext() else { return }
+    let design = skin == .custom ? CustomKeyboardSkinStore.current : nil
+    if let end = design?.gradientEnd,
+       let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: [skin.background.cgColor, CustomKeyboardSkin.color(end).cgColor] as CFArray, locations: [0, 1]) {
+      let endPoint = design?.gradientHorizontal == true ? CGPoint(x: bounds.width, y: 0) : CGPoint(x: 0, y: bounds.height)
+      context.drawLinearGradient(gradient, start: .zero, end: endPoint, options: [])
+    }
+    if let photoImage, photoImage.size.width > 0, photoImage.size.height > 0 {
+      let scale = max(bounds.width / photoImage.size.width, bounds.height / photoImage.size.height)
+      let size = CGSize(width: photoImage.size.width * scale, height: photoImage.size.height * scale)
+      let position = CGFloat(design?.photoPosition ?? 0.5)
+      photoImage.draw(in: CGRect(x: (bounds.width - size.width) * position, y: (bounds.height - size.height) * position, width: size.width, height: size.height))
+      UIColor.black.withAlphaComponent(CGFloat(design?.photoShade ?? 0.25)).setFill()
+      context.fill(bounds)
+    }
+    guard skin.pattern != 0 else { return }
+    let tint = skin.accent.resolvedColor(with: traitCollection).withAlphaComponent(CGFloat(design?.patternOpacity ?? 0.15))
     context.setStrokeColor(tint.cgColor)
     context.setFillColor(tint.cgColor)
     context.setLineWidth(0.5)

--- a/platforms/ios/SharedUI/KeyboardSkinBackgroundView.swift
+++ b/platforms/ios/SharedUI/KeyboardSkinBackgroundView.swift
@@ -4,10 +4,11 @@ import SwiftUI
 final class KeyboardSkinBackgroundView: UIView {
   private var photoData: Data?
   private var photoImage: UIImage?
+  var designOverride: CustomKeyboardSkin?
   var skin: KeyboardSkin = .forest {
     didSet {
-      backgroundColor = skin.background
-      let data = skin == .custom ? CustomKeyboardSkinStore.current.photo : nil
+      backgroundColor = skin == .custom ? CustomKeyboardSkin.color((designOverride ?? CustomKeyboardSkinStore.current).background) : skin.background
+      let data = skin == .custom ? (designOverride ?? CustomKeyboardSkinStore.current).photo : nil
       if data != photoData { photoData = data; photoImage = data.flatMap { UIImage(data: $0) } }
       setNeedsDisplay()
     }
@@ -24,9 +25,9 @@ final class KeyboardSkinBackgroundView: UIView {
 
   override func draw(_ rect: CGRect) {
     guard let context = UIGraphicsGetCurrentContext() else { return }
-    let design = skin == .custom ? CustomKeyboardSkinStore.current : nil
+    let design = skin == .custom ? (designOverride ?? CustomKeyboardSkinStore.current) : nil
     if let end = design?.gradientEnd,
-       let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: [skin.background.cgColor, CustomKeyboardSkin.color(end).cgColor] as CFArray, locations: [0, 1]) {
+       let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(), colors: [CustomKeyboardSkin.color(design!.background).cgColor, CustomKeyboardSkin.color(end).cgColor] as CFArray, locations: [0, 1]) {
       let endPoint = design?.gradientHorizontal == true ? CGPoint(x: bounds.width, y: 0) : CGPoint(x: 0, y: bounds.height)
       context.drawLinearGradient(gradient, start: .zero, end: endPoint, options: [])
     }
@@ -38,12 +39,13 @@ final class KeyboardSkinBackgroundView: UIView {
       UIColor.black.withAlphaComponent(CGFloat(design?.photoShade ?? 0.25)).setFill()
       context.fill(bounds)
     }
-    guard skin.pattern != 0 else { return }
-    let tint = skin.accent.resolvedColor(with: traitCollection).withAlphaComponent(CGFloat(design?.patternOpacity ?? 0.15))
+    let pattern = design?.pattern ?? skin.pattern
+    guard pattern != 0 else { return }
+    let tint = (design.map { CustomKeyboardSkin.color($0.accent) } ?? skin.accent).resolvedColor(with: traitCollection).withAlphaComponent(CGFloat(design?.patternOpacity ?? 0.15))
     context.setStrokeColor(tint.cgColor)
     context.setFillColor(tint.cgColor)
     context.setLineWidth(0.5)
-    switch skin.pattern {
+    switch pattern {
     case 1:
       for y in stride(from: CGFloat(8), to: bounds.height, by: 16) {
         for x in stride(from: CGFloat(8), to: bounds.width, by: 16) {
@@ -78,10 +80,12 @@ final class KeyboardSkinBackgroundView: UIView {
 
 struct KeyboardSkinBackdrop: UIViewRepresentable {
   let skin: KeyboardSkin
+  var design: CustomKeyboardSkin? = nil
   @Environment(\.colorScheme) private var colorScheme
   func makeUIView(context: Context) -> KeyboardSkinBackgroundView { KeyboardSkinBackgroundView() }
   func updateUIView(_ view: KeyboardSkinBackgroundView, context: Context) {
     view.overrideUserInterfaceStyle = colorScheme == .dark ? .dark : .light
+    view.designOverride = design
     view.skin = skin
   }
 }

--- a/platforms/ios/SharedUI/KeyboardSkinPreference.swift
+++ b/platforms/ios/SharedUI/KeyboardSkinPreference.swift
@@ -62,7 +62,7 @@ enum KeyboardSkin: String, CaseIterable {
   }
   var keyBackground: UIColor {
     switch self {
-    case .custom: CustomKeyboardSkin.color(CustomKeyboardSkinStore.current.keyBackground)
+    case .custom: CustomKeyboardSkin.color(CustomKeyboardSkinStore.current.keyBackground).withAlphaComponent(CGFloat(CustomKeyboardSkinStore.current.keyOpacity ?? 1))
     case .forest: adaptive((1, 1, 1), (0.19, 0.24, 0.21))
     case .ocean: adaptive((1, 1, 1), (0.18, 0.22, 0.29))
     case .rose: adaptive((1, 1, 1), (0.27, 0.19, 0.23))
@@ -108,7 +108,10 @@ enum KeyboardSkin: String, CaseIterable {
     default: 0
     }
   }
-  var borderColor: UIColor { accent.withAlphaComponent(self == .midnight ? 0.65 : 0.28) }
+  var borderColor: UIColor {
+    if self == .custom, let rgb = CustomKeyboardSkinStore.current.customBorderColor { return CustomKeyboardSkin.color(rgb) }
+    return accent.withAlphaComponent(self == .midnight ? 0.65 : 0.28)
+  }
   var shadowOpacity: Float {
     if self == .custom { return Float(CustomKeyboardSkinStore.current.shadow) }
     return self == .typewriter ? 0.30 : (self == .candy ? 0.16 : 0)

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -177,6 +177,7 @@ final class OnboardingUITests: XCTestCase {
     func openEditor() {
       app.buttons["skinSettingsLink"].tap()
       app.buttons["customSkinEditorLink"].tap()
+      app.segmentedControls["customSkinSections"].buttons["键帽"].tap()
     }
     app.launch()
     openEditor()
@@ -207,6 +208,7 @@ final class OnboardingUITests: XCTestCase {
     attachment.lifetime = .keepAlways
     add(attachment)
     XCTAssertTrue(app.buttons["applyCustomSkin"].label.contains("正在使用"))
+    app.segmentedControls["customSkinSections"].buttons["设计"].tap()
     // Exercise explicit reset after checking persistence, using simulator-only settings.
     for _ in 0..<5 {
       if app.buttons["重置我的皮肤"].isHittable { break }
@@ -214,11 +216,65 @@ final class OnboardingUITests: XCTestCase {
     }
     app.buttons["重置我的皮肤"].tap()
     app.buttons["重置"].tap()
+    app.segmentedControls["customSkinSections"].buttons["键帽"].tap()
     for _ in 0..<5 {
       if radius.isHittable { break }
       app.swipeDown()
     }
     XCTAssertEqual(radius.value as? String, "8")
+  }
+
+  @MainActor
+  func testCustomSkinTemplatesLibraryAndUndo() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-hasCompletedOnboarding", "YES"]
+    app.launch()
+    app.buttons["skinSettingsLink"].tap()
+    app.buttons["customSkinEditorLink"].tap()
+    let sections = app.segmentedControls["customSkinSections"]
+    app.buttons["skinTemplate_紫夜星光"].tap()
+    XCTAssertTrue(app.buttons["undoSkinDesign"].isEnabled)
+    app.buttons["saveCustomSkin"].tap()
+    let name = "夜色测试-" + String(UUID().uuidString.prefix(4))
+    let field = app.textFields["customSkinName"]
+    field.tap()
+    if let current = field.value as? String { field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: current.count)) }
+    field.typeText(name)
+    app.buttons["confirmSaveCustomSkin"].tap()
+    XCTAssertTrue(app.buttons["savedSkin_" + name].waitForExistence(timeout: 5))
+    sections.buttons["设计"].tap()
+    app.buttons["skinTemplate_水杉留白"].tap()
+    app.buttons["undoSkinDesign"].tap()
+    sections.buttons["背景"].tap()
+    XCTAssertEqual(app.switches["customSkinGradient"].value as? String, "1")
+    XCTAssertTrue(app.buttons["customSkinPhoto"].exists)
+    let image = XCTAttachment(screenshot: app.screenshot())
+    image.name = "Skin studio gradient and fixed preview"
+    image.lifetime = .keepAlways
+    add(image)
+    app.terminate()
+    app.launch()
+    app.buttons["skinSettingsLink"].tap()
+    app.buttons["customSkinEditorLink"].tap()
+    app.segmentedControls["customSkinSections"].buttons["我的"].tap()
+    XCTAssertTrue(app.buttons["savedSkin_" + name].exists)
+    app.segmentedControls["customSkinSections"].buttons["设计"].tap()
+    app.buttons["skinTemplate_水杉留白"].tap()
+    app.segmentedControls["customSkinSections"].buttons["我的"].tap()
+    app.buttons["管理" + name].tap()
+    app.buttons["用当前设计更新"].tap()
+    app.buttons["更新已保存的皮肤"].tap()
+    app.segmentedControls["customSkinSections"].buttons["设计"].tap()
+    app.buttons["skinTemplate_紫夜星光"].tap()
+    app.segmentedControls["customSkinSections"].buttons["我的"].tap()
+    app.buttons["savedSkin_" + name].tap()
+    app.segmentedControls["customSkinSections"].buttons["背景"].tap()
+    XCTAssertEqual(app.switches["customSkinGradient"].value as? String, "0")
+    app.segmentedControls["customSkinSections"].buttons["我的"].tap()
+    app.buttons["管理" + name].tap()
+    app.buttons["删除"].tap()
+    app.buttons["删除"].tap()
+    XCTAssertFalse(app.buttons["savedSkin_" + name].exists)
   }
 
   @MainActor

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -9,8 +9,8 @@ final class OnboardingUITests: XCTestCase {
     let account = app.buttons["accountSettingsLink"]
     XCTAssertTrue(account.waitForExistence(timeout: 5))
     account.tap()
-    XCTAssertTrue(app.navigationBars["账号"].waitForExistence(timeout: 5))
-    XCTAssertTrue(app.staticTexts["登录本身不会上传输入内容、个人词库或系统剪贴板。"].exists)
+    XCTAssertTrue(app.navigationBars["我的"].waitForExistence(timeout: 5))
+    XCTAssertTrue(app.buttons["accountLocalDesigns"].exists)
   }
 
   @MainActor

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -207,6 +207,7 @@ targets:
     platform: iOS
     sources:
       - path: platforms/ios/KeyboardTests
+      - path: platforms/ios/App/Services/SkinCommunityAPI.swift
       - path: platforms/ios/KeyboardExtension/Sources
       - path: platforms/ios/App/Services/CustomService.swift
       - path: platforms/ios/App/Services/KeyboardAIService.swift

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -208,6 +208,8 @@ targets:
     sources:
       - path: platforms/ios/KeyboardTests
       - path: platforms/ios/App/Services/SkinCommunityAPI.swift
+      - path: shared/backend/BackendAccountClient.swift
+      - path: shared/backend/BackendAccountSession.swift
       - path: platforms/ios/KeyboardExtension/Sources
       - path: platforms/ios/App/Services/CustomService.swift
       - path: platforms/ios/App/Services/KeyboardAIService.swift

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -605,7 +605,7 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
         self.assertIn(
-            "space.widthAnchor.constraint(greaterThanOrEqualTo: delete.widthAnchor, multiplier: 1.8)",
+            "space.widthAnchor.constraint(greaterThanOrEqualToConstant: 79.2)",
             controller,
         )
         self.assertIn(
@@ -613,9 +613,13 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
             controller,
         )
         self.assertIn(
-            "enter.widthAnchor.constraint(equalTo: delete.widthAnchor, multiplier: 1.35)",
+            "enter.widthAnchor.constraint(equalToConstant: 59.4)",
             controller,
         )
+        # Alphabetic Delete lives in the letter row; hiding symbol Delete must not
+        # collapse Space/Return or leave a required width on a hidden stack item.
+        self.assertIn("symbolDeleteWidth?.isActive = showsSymbols", controller)
+        self.assertNotIn("equalTo: delete.widthAnchor", controller)
         self.assertNotIn("layoutToggle.widthAnchor.constraint(equalToConstant: 56)", controller)
         self.assertNotIn("space.widthAnchor.constraint(greaterThanOrEqualToConstant: 110)", controller)
         self.assertNotIn("enter.widthAnchor.constraint(equalToConstant: 72)", controller)

--- a/shared/backend/BackendAccountSession.swift
+++ b/shared/backend/BackendAccountSession.swift
@@ -29,10 +29,34 @@ struct BackendKeychain: BackendSessionStorage {
     query[kSecMatchLimit as String] = kSecMatchLimitOne
     var result: CFTypeRef?
     let status = SecItemCopyMatching(query as CFDictionary, &result)
-    if status == errSecItemNotFound { return nil }
+    if status == errSecItemNotFound { return try migrateCommunitySession() }
     guard status == errSecSuccess, let data = result as? Data else { throw BackendAccountClient.Failure(status: 0) }
     do { return try JSONDecoder().decode(BackendSavedSession.self, from: data) }
     catch { throw BackendAccountClient.Failure(status: 0) }
+  }
+  private func migrateCommunitySession() throws -> BackendSavedSession? {
+    let legacy: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: "app.msime.ios.community", kSecAttrAccount as String: "api.msime.app"]
+    var lookup = legacy
+    lookup[kSecReturnData as String] = true
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(lookup as CFDictionary, &result)
+    if status == errSecItemNotFound { return nil }
+    guard status == errSecSuccess, let data = result as? Data else { throw BackendAccountClient.Failure(status: 0) }
+    struct Legacy: Decodable {
+      struct User: Decodable { let id: String; let display_name: String; let created_at: String? }
+      let access_token: String; let refresh_token: String; let user: User
+      let saved_at: Date?; let expires_in: Int?
+    }
+    let old = try JSONDecoder().decode(Legacy.self, from: data)
+    let seconds = old.expires_in ?? 900
+    let tokens = BackendAccountClient.Tokens(access_token: old.access_token, refresh_token: old.refresh_token,
+      token_type: "Bearer", expires_in: seconds,
+      user: .init(id: old.user.id, display_name: old.user.display_name, created_at: old.user.created_at ?? ""))
+    let value = BackendSavedSession(tokens: tokens, expiresAt: (old.saved_at ?? .distantPast).addingTimeInterval(TimeInterval(seconds)))
+    try save(value)
+    SecItemDelete(legacy as CFDictionary)
+    return value
   }
   func save(_ session: BackendSavedSession) throws {
     let data = try JSONEncoder().encode(session)
@@ -43,8 +67,15 @@ struct BackendKeychain: BackendSessionStorage {
       status = SecItemAdd(query.merging(attributes) { _, new in new } as CFDictionary, nil)
     }
     guard status == errSecSuccess else { throw BackendAccountClient.Failure(status: 0) }
+    try clearLegacy()
+  }
+  private func clearLegacy() throws {
+    let status = SecItemDelete([kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: "app.msime.ios.community", kSecAttrAccount as String: "api.msime.app"] as CFDictionary)
+    guard status == errSecSuccess || status == errSecItemNotFound else { throw BackendAccountClient.Failure(status: 0) }
   }
   func clear() throws {
+    try clearLegacy()
     let status = SecItemDelete(query as CFDictionary)
     guard status == errSecSuccess || status == errSecItemNotFound else { throw BackendAccountClient.Failure(status: 0) }
   }
@@ -84,10 +115,10 @@ actor BackendAccountSession {
     try storage.save(value)
     saved = value; loaded = true
   }
-  func accessToken() async throws -> String {
+  func accessToken(retrying rejectedToken: String? = nil) async throws -> String {
     try load()
     guard let current = saved else { throw BackendAccountClient.Failure(status: 401) }
-    if current.expiresAt.timeIntervalSinceNow > 30 { return current.tokens.access_token }
+    if current.expiresAt.timeIntervalSinceNow > 30 && rejectedToken != current.tokens.access_token { return current.tokens.access_token }
     if let refreshing { return try await refreshing.value }
     let version = generation
     let task = Task<String, Error> {
@@ -105,6 +136,17 @@ actor BackendAccountSession {
       }
       throw error
     }
+  }
+  func updateUser(_ user: BackendAccountClient.User, matching token: String) throws {
+    try load()
+    guard let current = saved, current.tokens.access_token == token, current.tokens.user.id == user.id else {
+      throw CancellationError()
+    }
+    let old = current.tokens
+    let tokens = BackendAccountClient.Tokens(access_token: old.access_token, refresh_token: old.refresh_token,
+      token_type: old.token_type, expires_in: old.expires_in, user: user)
+    let value = BackendSavedSession(tokens: tokens, expiresAt: current.expiresAt)
+    try storage.save(value); saved = value
   }
   func forget() throws {
     generation += 1

--- a/shared/backend/Tests/BackendAccountSessionTests.swift
+++ b/shared/backend/Tests/BackendAccountSessionTests.swift
@@ -49,6 +49,19 @@ final class BackendAccountSessionTests: XCTestCase {
     XCTAssertEqual(count, 1)
     XCTAssertEqual(try storage.load()?.tokens.access_token, a)
   }
+  func testProfileCacheUpdatePreservesSessionAndRejectsLateResult() async throws {
+    let original = BackendSavedSession(tokens: RefreshAPI.tokens(), expiresAt: Date().addingTimeInterval(600))
+    let storage = MemorySessions(original)
+    let session = BackendAccountSession(api: RefreshAPI(), storage: storage)
+    let renamed = BackendAccountClient.User(id: "synthetic-user", display_name: "新昵称", created_at: "2026-09-08")
+    try await session.updateUser(renamed, matching: original.tokens.access_token)
+    XCTAssertEqual(try storage.load()?.tokens.user, renamed)
+    XCTAssertEqual(try storage.load()?.expiresAt, original.expiresAt)
+    try await session.forget()
+    do { try await session.updateUser(renamed, matching: original.tokens.access_token); XCTFail("late profile resurrected logout") }
+    catch is CancellationError { }
+    XCTAssertNil(try storage.load())
+  }
   func testLogoutGenerationRejectsLateRefresh() async throws {
     let storage = MemorySessions(.init(tokens: RefreshAPI.tokens(), expiresAt: .distantPast))
     let api = RefreshAPI()


### PR DESCRIPTION
Add an Apple-authenticated skin community alongside the custom skin studio, clipboard history, and keyboard layout fixes.

Add a persistent clipboard-history panel, expand the custom skin editor into a reusable design library, and fix cramped keyboard layouts on narrow screens.

- Add clipboard history under the keyboard More menu: explicitly save the current text clipboard, tap to insert, pin/unpin, delete, and confirm clearing all entries. Keep up to 50 deduplicated entries, evict only unpinned entries, preserve text exactly, and commit any pending composition before insertion. Gate access on Full Access; storage is file-protected and excluded from backups. No background clipboard polling.
- Add six editable design templates, photo wallpapers with crop position and dimming, horizontal/vertical gradients, texture strength, translucent keycaps, independent border colors, and existing key shape/shadow controls.
- Keep a complete nine-key or alphabetic preview visible while editing. Add undo/redo and up to 12 named designs with load, overwrite, rename, and delete actions. Saved designs are also available from keyboard skin cards.
- Preserve existing v1 skin settings. Downsample selected photos to at most 1024 pixels and 512 KB, cache the active decoded image, and store the multi-photo library atomically outside preferences.
- Give the toolbar logo padding and scheme labels room, retain 44-point shortcut targets, place alphabetic Delete opposite Shift, add punctuation tap/hold actions, and reset candidate scrolling when input changes.

Validation: 44 keyboard tests and both custom-skin UI flows pass on the final source, including old-data compatibility, photo sizing/rendering, saved-card selection, undo, relaunch persistence, and overwriting/deleting a saved design. All 46 iOS configuration tests pass. A separate local diagnostic passed an actual system photo-picker import and translucent full-keyboard preview. Release archive builds successfully.

Earlier layout validation covered 320- and 414-point widths, both keyboard layouts, symbol/Latin/local modes, candidate scrolling, Delete, punctuation, and cursor dragging. The previous commit passed all six CI checks; fresh CI is triggered for this update.

Clipboard validation: all 47 keyboard tests and 46 configuration/packaging tests pass. Tests cover persistence, deduplication, pinned eviction/all-pinned capacity, invalid/corrupt data, insertion callback, two-step clear, access gating, and a 320-point panel. Signed Release archive built for the XR.

Community: browse without login, publish saved designs after confirming public sharing, download and apply, rate 1–5 stars, and withdraw your own work. Apple sessions live in device-only Keychain; refresh requests are coalesced. Browsing previews use passed design values and never change the active keyboard. Backend API and PostgreSQL migration are in MSIME-Backend PR #8; production GitOps rollout is yldm-platform PR #3885. Apple bundle capability and replacement XR/TestFlight profiles have been provisioned, and the TestFlight profile secret refreshed under the existing name.

Community validation: all 50 keyboard and 7 service tests pass, including wire-format decoding, isolated preview rendering, login, concurrent refresh, and 204 logout. Both iOS Python suites pass (46 tests). Signed Release archive builds successfully.

Production verification: backend-v0.4.0 was published by the standard release workflow and deployed through GitOps PR #3888 (merge192ff11). Effective image is the official 0.4.0 multi-architecture index f98ec8bc. Public community listing and Apple provider availability return200; unauthenticated publication/rating return401. A read-only live iOS UI diagnostic passed community navigation and Apple button availability; no real Apple account was authorized and no fixture content was published. Latest signed Release (f96bac5) is installed on the XR.



### Account hub

The settings home now opens a dedicated 我的 page with native Apple login, the stored account display name, local design count and editor, publication sheet, owned-work browsing, community and typing statistics. Community and account screens share login/logout/account deletion UI; recovery is only shown after credential-read errors. Owned-work browsing filters validated ownership across explicitly paginated catalog pages (it does not claim a server-side account-wide total).

Validation: iOS Release archive and strict distribution signature verification passed; installed on the XR (not the physical iPhone 17). Signed simulator UI navigation reached the live Apple login button without alerts; screenshot inspected. All 3 SkinCommunityTests passed, including profile availability after login and removal after logout. Real Apple authorization has not been completed by the agent. The live diagnostic was removed from CI sources.



### Profile editing and integration with develop

Account and community use the shared BackendAccountClient/BackendAccountSession introduced by #349, with one refresh coordinator and Keychain store. Existing community sessions migrate to the canonical store; logout also removes the legacy record. Preserve logout-all, account deletion, and nonce/state validation. Personal details read GET /v1/users/me and update via PATCH: nickname, selectable account ID, actual linked login provider and registration date. Successful edits update the stored profile; delayed responses cannot restore a logged-out session. Empty nicknames now prompt setup instead of posing as a real username.

Rebased onto develop e655173, including #350. Preserve enabled email/phone code-login channels, resend/expiry handling and explicit cloud clipboard operations alongside the account hub and profile editor. Code login, Apple login, community and cloud clipboard share BackendAccountSession.shared.

Latest validation: 10 shared backend tests; 4 community tests plus account-entry UI test; 46 iOS configuration/packaging tests all pass. The preceding profile integration passed iOS Release archiving/signature verification and was installed on the XR; the latest #350 conflict resolution was built and tested in the simulator. No real user's nickname, Apple authorization or cloud clipboard was changed by the agent.

