### PR TITLE
feat(ios): expand keyboard customization and input settings

### DIFF
--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -101,8 +101,7 @@ struct AppleAccountSection: View {
   private let api = SkinCommunityAPI.shared
 
   private var displayName: String {
-    guard let name = user?.display_name, !name.isEmpty else { return "尚未设置昵称" }
-    return name
+    user?.preferredDisplayName ?? "水杉用户"
   }
 
   var body: some View {
@@ -122,7 +121,7 @@ struct AppleAccountSection: View {
           HStack {
             Label("个人资料", systemImage: "person.text.rectangle")
             Spacer()
-            Text(user?.display_name.isEmpty == false ? "查看与编辑" : "设置昵称")
+            Text("查看与编辑")
               .font(.subheadline).foregroundStyle(.secondary)
             Image(systemName: "chevron.right").font(.caption).foregroundStyle(.secondary)
           }
@@ -257,10 +256,18 @@ struct AccountProfileEditor: View {
         }
         if let profile {
           Section("账号信息") {
-            VStack(alignment: .leading, spacing: 6) {
-              Text("账号 ID")
-              Text(profile.user.id).font(.footnote.monospaced()).foregroundStyle(.secondary).textSelection(.enabled)
-            }
+            Button {
+              UIPasteboard.general.string = profile.user.id
+              message = "完整账号 ID 已复制。"
+            } label: {
+              HStack {
+                Text("账号 ID").foregroundStyle(.primary)
+                Spacer()
+                Text("#" + profile.user.id.prefix(6).uppercased()).font(.subheadline.monospaced())
+                Image(systemName: "doc.on.doc").font(.subheadline)
+              }
+            }.accessibilityLabel("复制完整账号 ID")
+              .accessibilityIdentifier("copyAccountID")
             HStack {
               Text("登录方式")
               Spacer()
@@ -289,7 +296,7 @@ struct AccountProfileEditor: View {
                 dismiss()
               } catch { message = error.localizedDescription }
             }
-          }.disabled(busy || profile == nil || !validName || normalizedName == profile?.user.display_name)
+          }.disabled(busy || profile == nil || !validName || normalizedName == profile?.user.preferredDisplayName)
             .accessibilityIdentifier("saveAccountProfile")
         }
       }
@@ -305,7 +312,7 @@ struct AccountProfileEditor: View {
       defer { busy = false }
       do {
         let result = try await SkinCommunityAPI.shared.profile()
-        profile = result; name = result.user.display_name
+        profile = result; name = result.user.preferredDisplayName
         onSaved(result.user)
       } catch { message = error.localizedDescription }
     }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardMorePickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardMorePickerView.swift
@@ -1,0 +1,107 @@
+import UIKit
+
+final class KeyboardMorePickerView: UIView {
+  private let rows = UIStackView()
+
+  init(menu: UIMenu, onClose: @escaping () -> Void) {
+    super.init(frame: .zero)
+    accessibilityIdentifier = "keyboardMorePicker"
+    backgroundColor = .secondarySystemBackground
+    let header = UILabel()
+    header.text = "更多"
+    header.font = .systemFont(ofSize: 17, weight: .semibold)
+    let close = UIButton(type: .system)
+    close.setTitle("完成", for: .normal)
+    close.accessibilityIdentifier = "closeMorePicker"
+    close.addAction(UIAction { _ in onClose() }, for: .primaryActionTriggered)
+    let scroll = UIScrollView()
+    rows.axis = .vertical
+    rows.spacing = 10
+    for child in [header, close, scroll] {
+      child.translatesAutoresizingMaskIntoConstraints = false
+      addSubview(child)
+    }
+    rows.translatesAutoresizingMaskIntoConstraints = false
+    scroll.addSubview(rows)
+    NSLayoutConstraint.activate([
+      header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+      header.topAnchor.constraint(equalTo: topAnchor),
+      header.heightAnchor.constraint(equalToConstant: 40),
+      close.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+      close.topAnchor.constraint(equalTo: topAnchor),
+      close.heightAnchor.constraint(equalToConstant: 40),
+      close.widthAnchor.constraint(equalToConstant: 56),
+      scroll.topAnchor.constraint(equalTo: header.bottomAnchor),
+      scroll.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+      scroll.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+      scroll.bottomAnchor.constraint(equalTo: bottomAnchor),
+      rows.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+      rows.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+      rows.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+      rows.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor, constant: -10),
+      rows.widthAnchor.constraint(equalTo: scroll.frameLayoutGuide.widthAnchor),
+    ])
+    update(menu: menu)
+  }
+
+  func update(menu: UIMenu) {
+    rows.arrangedSubviews.forEach { rows.removeArrangedSubview($0); $0.removeFromSuperview() }
+    append(menu: menu)
+  }
+
+  private func append(menu: UIMenu) {
+    if !menu.title.isEmpty {
+      let label = UILabel()
+      label.text = menu.title
+      label.font = .systemFont(ofSize: 13, weight: .semibold)
+      label.textColor = .secondaryLabel
+      rows.addArrangedSubview(label)
+    }
+    let actions = menu.children.compactMap { $0 as? UIAction }
+    let skin = KeyboardSkinPreference.selected
+    for index in stride(from: 0, to: actions.count, by: 2) {
+      let row = UIStackView()
+      row.spacing = 10
+      row.distribution = .fillEqually
+      for action in actions[index..<min(index + 2, actions.count)] {
+        let active = action.state == .on
+        let state = menu.title == "按键反馈" ? (active ? "已开启" : "已关闭")
+          : (menu.title == "振动强度" ? (active ? "已选中" : "点击选择") : "点击打开")
+        let card = KeyboardKeyButton()
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = action.title
+        let descriptions = ["剪贴板历史": "最近保存的内容", "AI 润色": "润色选中的文字", "语音结果": "插入识别结果"]
+        configuration.subtitle = descriptions[action.title] ?? (menu.title == "本地输入" ? "离线输入工具" : state)
+        configuration.image = action.image ?? UIImage(systemName: "keyboard")
+        configuration.imagePlacement = .top
+        configuration.imagePadding = 8
+        configuration.preferredSymbolConfigurationForImage = .init(pointSize: 24)
+        configuration.baseForegroundColor = skin.keyForeground
+        configuration.baseBackgroundColor = skin.keyBackground
+        configuration.background.cornerRadius = 12
+        configuration.background.strokeWidth = active ? 2 : 1
+        configuration.background.strokeColor = active ? skin.accent : .separator
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { value in
+          var value = value; value.font = .systemFont(ofSize: 13, weight: .semibold); return value
+        }
+        configuration.subtitleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { value in
+          var value = value; value.font = .systemFont(ofSize: 11); value.foregroundColor = skin.keyForeground.withAlphaComponent(0.7); return value
+        }
+        card.configuration = configuration
+        card.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        card.accessibilityIdentifier = "moreCard-" + action.title
+        card.accessibilityLabel = action.title
+        card.accessibilityValue = state
+        card.isEnabled = !action.attributes.contains(.disabled)
+        if active { card.accessibilityTraits.insert(.selected) }
+        card.addAction(action, for: .primaryActionTriggered)
+        row.addArrangedSubview(card)
+      }
+      if row.arrangedSubviews.count == 1 { row.addArrangedSubview(UIView()) }
+      rows.addArrangedSubview(row)
+    }
+    menu.children.compactMap { $0 as? UIMenu }.forEach { append(menu: $0) }
+  }
+
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
@@ -1,0 +1,90 @@
+import UIKit
+
+final class KeyboardSchemePickerView: UIView {
+  init(selected: ChineseInputScheme, onSelect: @escaping (ChineseInputScheme) -> Void, onClose: @escaping () -> Void) {
+    super.init(frame: .zero)
+    accessibilityIdentifier = "keyboardSchemePicker"
+    backgroundColor = .secondarySystemBackground
+    let skin = KeyboardSkinPreference.selected
+    let header = UILabel()
+    header.text = "选择输入方案"
+    header.font = .systemFont(ofSize: 17, weight: .semibold)
+    let close = UIButton(type: .system)
+    close.setTitle("完成", for: .normal)
+    close.accessibilityIdentifier = "closeSchemePicker"
+    close.addAction(UIAction { _ in onClose() }, for: .primaryActionTriggered)
+    let scroll = UIScrollView()
+    let rows = UIStackView()
+    rows.axis = .vertical
+    rows.spacing = 10
+    for index in stride(from: 0, to: ChineseInputScheme.allCases.count, by: 2) {
+      let row = UIStackView()
+      row.spacing = 10
+      row.distribution = .fillEqually
+      for scheme in ChineseInputScheme.allCases[index..<min(index + 2, ChineseInputScheme.allCases.count)] {
+        let card = KeyboardKeyButton()
+        card.accessibilityIdentifier = "schemeCard-\(scheme.rawValue)"
+        card.accessibilityLabel = scheme.title
+        card.accessibilityValue = scheme == selected ? "已选中" : ""
+        if scheme == selected { card.accessibilityTraits.insert(.selected) }
+        card.backgroundColor = skin.background
+        card.layer.cornerRadius = 12
+        card.layer.borderWidth = scheme == selected ? 2 : 1
+        card.layer.borderColor = (scheme == selected ? UIColor.label : UIColor.separator).resolvedColor(with: traitCollection).cgColor
+        card.clipsToBounds = true
+        let title = UILabel()
+        title.text = scheme.title + (scheme == selected ? "  ✓" : "")
+        title.font = .systemFont(ofSize: 13, weight: .semibold)
+        title.textColor = skin.keyForeground
+        title.adjustsFontSizeToFitWidth = true
+        title.minimumScaleFactor = 0.75
+        let preview = KeyboardSkinMiniature(skin: skin, nineKey: scheme == .nineKey)
+        for child in [title, preview] {
+          child.isUserInteractionEnabled = false
+          child.translatesAutoresizingMaskIntoConstraints = false
+          card.addSubview(child)
+        }
+        NSLayoutConstraint.activate([
+          card.heightAnchor.constraint(equalToConstant: 100),
+          title.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 10),
+          title.topAnchor.constraint(equalTo: card.topAnchor, constant: 7),
+          title.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -8),
+          preview.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 7),
+          preview.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -7),
+          preview.topAnchor.constraint(equalTo: card.topAnchor, constant: 29),
+          preview.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -7),
+        ])
+        card.addAction(UIAction { _ in onSelect(scheme) }, for: .primaryActionTriggered)
+        row.addArrangedSubview(card)
+      }
+      if row.arrangedSubviews.count == 1 { row.addArrangedSubview(UIView()) }
+      rows.addArrangedSubview(row)
+    }
+    for child in [header, close, scroll] {
+      child.translatesAutoresizingMaskIntoConstraints = false
+      addSubview(child)
+    }
+    rows.translatesAutoresizingMaskIntoConstraints = false
+    scroll.addSubview(rows)
+    NSLayoutConstraint.activate([
+      header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+      header.topAnchor.constraint(equalTo: topAnchor),
+      header.heightAnchor.constraint(equalToConstant: 40),
+      close.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+      close.topAnchor.constraint(equalTo: topAnchor),
+      close.heightAnchor.constraint(equalToConstant: 40),
+      close.widthAnchor.constraint(equalToConstant: 56),
+      scroll.topAnchor.constraint(equalTo: header.bottomAnchor),
+      scroll.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+      scroll.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+      scroll.bottomAnchor.constraint(equalTo: bottomAnchor),
+      rows.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+      rows.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+      rows.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+      rows.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor, constant: -10),
+      rows.widthAnchor.constraint(equalTo: scroll.frameLayoutGuide.widthAnchor),
+    ])
+  }
+
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
@@ -121,9 +121,11 @@ final class KeyboardSkinPickerView: UIView {
   required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 }
 
-private final class KeyboardSkinMiniature: UIView {
+final class KeyboardSkinMiniature: UIView {
   let skin: KeyboardSkin
-  init(skin: KeyboardSkin) {
+  let nineKey: Bool
+  init(skin: KeyboardSkin, nineKey: Bool = false) {
+    self.nineKey = nineKey
     self.skin = skin
     super.init(frame: .zero)
     isOpaque = false
@@ -139,11 +141,13 @@ private final class KeyboardSkinMiniature: UIView {
     let top = "QWERTYUIOP".map { String($0) }
     let middle = "ASDFGHJKL".map { String($0) }
     let bottom = ["⇧"] + "ZXCVBNM".map { String($0) } + ["⌫"]
-    let rows: [[String]] = [top, middle, bottom, ["123", "空格", "↵"]]
+    let rows: [[String]] = nineKey
+      ? [["1", "ABC", "DEF"], ["GHI", "JKL", "MNO"], ["PQRS", "TUV", "WXYZ"], ["123", "空格", "↵"]]
+      : [top, middle, bottom, ["123", "空格", "↵"]]
     let gap: CGFloat = 2
     let height = (bounds.height - gap * 3) / 4
     for (rowIndex, row) in rows.enumerated() {
-      let inset: CGFloat = rowIndex == 1 ? bounds.width * 0.04 : 0
+      let inset: CGFloat = !nineKey && rowIndex == 1 ? bounds.width * 0.04 : 0
       let width = (bounds.width - inset * 2 - gap * CGFloat(row.count - 1)) / CGFloat(row.count)
       for (index, title) in row.enumerated() {
         let key = CGRect(x: inset + CGFloat(index) * (width + gap), y: CGFloat(rowIndex) * (height + gap), width: width, height: height)

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -31,6 +31,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private let skinShortcut = UIButton()
   private var clipboardPanel: KeyboardClipboardView?
   private var skinPicker: KeyboardSkinPickerView?
+  private var schemePicker: KeyboardSchemePickerView?
   private let moreShortcut = UIButton()
   private let dismissShortcut = UIButton()
   private var letterButtons: [(button: UIButton, lowercase: String, hint: UILabel)] = []
@@ -205,7 +206,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     closeKeyboardService()
     personalDictionaryTimer?.invalidate()
     personalDictionaryTimer = nil
-    closeSkinPicker()
+    closeKeyboardPicker()
     cursorMovement.cancel()
     spaceButton?.configuration?.title = "空格"
     // Putting the keyboard away used to drop whatever was composed. macOS commits in
@@ -385,7 +386,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
 
 
     updateSchemeButton()
-    schemeButton.showsMenuAsPrimaryAction = true
+    schemeButton.addAction(UIAction { [weak self] _ in self?.showSchemePicker() }, for: .primaryActionTriggered)
 
 
     candidateStack.axis = .horizontal
@@ -1112,7 +1113,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
           let selected = textDocumentProxy.selectedText, !selected.isEmpty, selected.count <= 10_000 else {
       showDiagnostic("请先完成输入，再选中要润色的文字（最多一万字）。"); return
     }
-    closeSkinPicker()
+    closeKeyboardPicker()
     closeKeyboardService()
     let selection = KeyboardDocumentContext(document: document, before: textDocumentProxy.documentContextBeforeInput,
                                          selected: selected, after: textDocumentProxy.documentContextAfterInput)
@@ -1146,7 +1147,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       let context = document.map { KeyboardDocumentContext(document: $0,
         before: textDocumentProxy.documentContextBeforeInput, selected: textDocumentProxy.selectedText,
         after: textDocumentProxy.documentContextAfterInput) }
-      closeSkinPicker()
+      closeKeyboardPicker()
       closeKeyboardService()
       let panel = UIHostingController(rootView: KeyboardVoiceView(entry: entry, insert: { [weak self] in
         guard let self, hasFullAccess, servicePanel != nil, let context, let entry,
@@ -1345,11 +1346,6 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     schemeButton.accessibilityIdentifier = "schemeButton"
     schemeButton.accessibilityLabel = "选择输入方案"
     schemeButton.accessibilityValue = inputScheme.title
-    schemeButton.menu = UIMenu(children: ChineseInputScheme.allCases.map { scheme in
-      UIAction(title: scheme.title, state: scheme == inputScheme ? .on : .off) { [weak self] _ in
-        self?.selectInputScheme(scheme)
-      }
-    })
     updateKeyboardLayout()
   }
 
@@ -1772,13 +1768,13 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
 
   private func showClipboardHistory() {
     closeKeyboardService()
-    closeSkinPicker()
+    closeKeyboardPicker()
     let panel = KeyboardClipboardView(hasFullAccess: hasFullAccess, onInsert: { [weak self] text in
       guard let self else { return }
       render(session.finishComposition())
       insertOwnText(text)
-      closeSkinPicker()
-    }, onClose: { [weak self] in self?.closeSkinPicker() })
+      closeKeyboardPicker()
+    }, onClose: { [weak self] in self?.closeKeyboardPicker() })
     panel.accessibilityViewIsModal = true
     panel.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(panel)
@@ -1792,15 +1788,38 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     UIAccessibility.post(notification: .screenChanged, argument: panel)
   }
 
+  private func showSchemePicker() {
+    closeKeyboardService()
+    closeKeyboardPicker()
+    let picker = KeyboardSchemePickerView(selected: inputScheme, onSelect: { [weak self] scheme in
+      guard let self else { return }
+      closeKeyboardPicker()
+      selectInputScheme(scheme)
+    }, onClose: { [weak self] in self?.closeKeyboardPicker() })
+    picker.accessibilityViewIsModal = true
+    picker.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(picker)
+    NSLayoutConstraint.activate([
+      picker.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      picker.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      picker.topAnchor.constraint(equalTo: view.topAnchor),
+      picker.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+    schemePicker = picker
+    UIAccessibility.post(notification: .screenChanged, argument: picker)
+  }
+
   private func showSkinPicker() {
     guard skinPicker == nil else { return }
+    closeKeyboardService()
+    closeKeyboardPicker()
     let picker = KeyboardSkinPickerView(selected: KeyboardSkinPreference.selected, onSelect: { [weak self] skin in
       guard let self else { return }
       KeyboardFeedbackPreference.defaults.set(skin.rawValue, forKey: KeyboardSkinPreference.key)
-      closeSkinPicker()
+      closeKeyboardPicker()
       applyKeyboardSkin()
       playInputClick()
-    }, onClose: { [weak self] in self?.closeSkinPicker() })
+    }, onClose: { [weak self] in self?.closeKeyboardPicker() })
     picker.accessibilityViewIsModal = true
     picker.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(picker)
@@ -1814,7 +1833,12 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     UIAccessibility.post(notification: .screenChanged, argument: picker)
   }
 
-  private func closeSkinPicker() {
+  private func closeKeyboardPicker() {
+    if let picker = schemePicker {
+      picker.removeFromSuperview()
+      schemePicker = nil
+      UIAccessibility.post(notification: .screenChanged, argument: schemeButton)
+    }
     if let panel = clipboardPanel {
       panel.removeFromSuperview()
       clipboardPanel = nil

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -33,6 +33,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var skinPicker: KeyboardSkinPickerView?
   private var schemePicker: KeyboardSchemePickerView?
   private let moreShortcut = UIButton()
+  private var morePicker: KeyboardMorePickerView?
+  private var moreMenu: UIMenu?
   private let dismissShortcut = UIButton()
   private var letterButtons: [(button: UIButton, lowercase: String, hint: UILabel)] = []
   private var microsoftFinalKey: UIButton?
@@ -462,7 +464,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     shortcutBar.spacing = 0
     shortcutBar.accessibilityIdentifier = "keyboardShortcutBar"
     shortcutBar.translatesAutoresizingMaskIntoConstraints = false
-    let brand = UIView()
+    let brand = moreShortcut
     let icon = UIImageView()
     if let path = Bundle(for: KeyboardViewController.self).path(forResource: "KeyboardBrand", ofType: "png") {
       icon.image = UIImage(contentsOfFile: path)?.preparingThumbnail(of: CGSize(width: 72, height: 72))
@@ -475,13 +477,13 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     brand.addSubview(icon)
     shortcutBar.addArrangedSubview(brand)
     NSLayoutConstraint.activate([
-      brand.widthAnchor.constraint(equalToConstant: 36),
+      brand.widthAnchor.constraint(equalToConstant: 44),
       icon.widthAnchor.constraint(equalToConstant: 24),
       icon.heightAnchor.constraint(equalToConstant: 24),
       icon.centerXAnchor.constraint(equalTo: brand.centerXAnchor),
       icon.centerYAnchor.constraint(equalTo: brand.centerYAnchor),
     ])
-    for button in [languageModeButton, schemeButton, scriptShortcut, skinShortcut, moreShortcut, dismissShortcut] {
+    for button in [languageModeButton, schemeButton, scriptShortcut, skinShortcut, dismissShortcut] {
       shortcutBar.addArrangedSubview(button)
       if button !== languageModeButton {
         button.widthAnchor.constraint(equalTo: languageModeButton.widthAnchor, constant: button === schemeButton ? 6 : 0).isActive = true
@@ -502,7 +504,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       updateShortcutButtons()
     }, for: .primaryActionTriggered)
     skinShortcut.addAction(UIAction { [weak self] _ in self?.showSkinPicker() }, for: .primaryActionTriggered)
-    moreShortcut.showsMenuAsPrimaryAction = true
+    moreShortcut.addAction(UIAction { [weak self] _ in self?.showMorePicker() }, for: .primaryActionTriggered)
     dismissShortcut.addAction(UIAction { [weak self] _ in self?.dismissKeyboard() }, for: .primaryActionTriggered)
     updateShortcutButtons()
   }
@@ -529,15 +531,17 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     scriptShortcut.accessibilityValue = scriptShortcut.isEnabled ? (usesTraditionalOutput ? "繁体" : "简体") : "日语不使用简繁转换"
     configure(skinShortcut, title: nil, symbol: "tshirt", label: "切换皮肤", id: "skinShortcut")
     skinShortcut.accessibilityValue = KeyboardSkinPreference.selected.title
-    configure(moreShortcut, title: nil, symbol: "ellipsis.circle", label: "更多快捷设置", id: "moreShortcut")
-    moreShortcut.menu = UIMenu(children: [
+    configure(moreShortcut, title: nil, symbol: nil, label: "更多快捷设置", id: "moreShortcut")
+    moreMenu = UIMenu(children: [
       UIAction(title: "剪贴板历史", image: UIImage(systemName: "doc.on.clipboard")) { [weak self] _ in
         self?.showClipboardHistory()
       },
       UIAction(title: "AI 润色", image: UIImage(systemName: "sparkles")) { [weak self] _ in
+        self?.closeKeyboardPicker()
         self?.showKeyboardAI()
       },
       UIAction(title: "语音结果", image: UIImage(systemName: "waveform")) { [weak self] _ in
+        self?.closeKeyboardPicker()
         self?.showKeyboardVoice()
       },
       UIMenu(title: "按键反馈", options: .displayInline, children: [
@@ -569,10 +573,12 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       }),
       UIMenu(title: "本地输入", children: Self.localInputModes.map { mode in
         UIAction(title: mode.title, attributes: supportsLocalTools ? [] : .disabled) { [weak self] _ in
+          self?.closeKeyboardPicker()
           self?.openLocalInputMode(mode.trigger)
         }
       }),
     ])
+    if let moreMenu { morePicker?.update(menu: moreMenu) }
     configure(dismissShortcut, title: nil, symbol: "keyboard.chevron.compact.down", label: "收起键盘", id: "dismissShortcut")
   }
 
@@ -1788,6 +1794,25 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     UIAccessibility.post(notification: .screenChanged, argument: panel)
   }
 
+  private func showMorePicker() {
+    closeKeyboardService()
+    closeKeyboardPicker()
+    updateShortcutButtons()
+    guard let moreMenu else { return }
+    let picker = KeyboardMorePickerView(menu: moreMenu, onClose: { [weak self] in self?.closeKeyboardPicker() })
+    picker.accessibilityViewIsModal = true
+    picker.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(picker)
+    NSLayoutConstraint.activate([
+      picker.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      picker.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      picker.topAnchor.constraint(equalTo: view.topAnchor),
+      picker.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+    morePicker = picker
+    UIAccessibility.post(notification: .screenChanged, argument: picker)
+  }
+
   private func showSchemePicker() {
     closeKeyboardService()
     closeKeyboardPicker()
@@ -1834,6 +1859,11 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   }
 
   private func closeKeyboardPicker() {
+    if let picker = morePicker {
+      picker.removeFromSuperview()
+      morePicker = nil
+      UIAccessibility.post(notification: .screenChanged, argument: moreShortcut)
+    }
     if let picker = schemePicker {
       picker.removeFromSuperview()
       schemePicker = nil

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -184,6 +184,48 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
+  func testBrandOpensMoreCardsAndUpdatesFeedbackState() throws {
+    let previous = KeyboardFeedbackPreference.soundEnabled
+    defer { KeyboardFeedbackPreference.defaults.set(previous, forKey: KeyboardFeedbackPreference.soundKey) }
+    for width in [320.0, 414.0] {
+      KeyboardFeedbackPreference.defaults.set(true, forKey: KeyboardFeedbackPreference.soundKey)
+      let controller = KeyboardViewController()
+      controller.loadViewIfNeeded()
+      controller.view.frame = CGRect(x: 0, y: 0, width: width, height: 260)
+      controller.view.layoutIfNeeded()
+      let toolbar = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityIdentifier == "keyboardShortcutBar" } as? UIStackView)
+      let more = try button("moreShortcut", in: controller)
+      XCTAssertTrue(toolbar.arrangedSubviews.first === more)
+      XCTAssertNil(more.menu)
+      XCTAssertNotNil(descendants(more).first { $0.accessibilityIdentifier == "keyboardBrandIcon" })
+      more.sendActions(for: .primaryActionTriggered)
+      controller.view.layoutIfNeeded()
+      let panel = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityIdentifier == "keyboardMorePicker" })
+      XCTAssertEqual(panel.bounds.height, 260)
+      for title in ["剪贴板历史", "AI 润色", "语音结果", "按键音", "按键振动", "日期时间", "Unicode 码点"] {
+        let card = try button("moreCard-" + title, in: controller)
+        XCTAssertGreaterThan(card.bounds.width, 140)
+        XCTAssertEqual(card.bounds.height, 100)
+      }
+      let attachment = XCTAttachment(image: UIGraphicsImageRenderer(bounds: controller.view.bounds).image { context in
+        controller.view.layer.render(in: context.cgContext)
+      })
+      attachment.name = "More cards \(Int(width))pt"
+      attachment.lifetime = .keepAlways
+      add(attachment)
+      XCTAssertEqual(try button("moreCard-按键音", in: controller).accessibilityValue, "已开启")
+      try button("moreCard-按键音", in: controller).sendActions(for: .primaryActionTriggered)
+      XCTAssertFalse(KeyboardFeedbackPreference.soundEnabled)
+      XCTAssertEqual(try button("moreCard-按键音", in: controller).accessibilityValue, "已关闭")
+      try button("closeMorePicker", in: controller).sendActions(for: .primaryActionTriggered)
+      XCTAssertNil(panel.superview)
+      more.sendActions(for: .primaryActionTriggered)
+      try button("moreCard-AI 润色", in: controller).sendActions(for: .primaryActionTriggered)
+      XCTAssertFalse(descendants(controller.view).contains { $0.accessibilityIdentifier == "keyboardMorePicker" })
+      XCTAssertEqual(controller.view.constraints.first { $0.identifier == "keyboardHeight" }?.constant, 260)
+    }
+  }
+
   func testSchemeCardsSelectAndKeepKeyboardHeight() throws {
     let previous = InputSchemePreference.scheme
     defer { InputSchemePreference.scheme = previous }

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -184,6 +184,45 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
+  func testSchemeCardsSelectAndKeepKeyboardHeight() throws {
+    let previous = InputSchemePreference.scheme
+    defer { InputSchemePreference.scheme = previous }
+    for width in [320.0, 414.0] {
+      InputSchemePreference.scheme = .nineKey
+      let controller = KeyboardViewController()
+      controller.loadViewIfNeeded()
+      controller.view.frame = CGRect(x: 0, y: 0, width: width, height: 260)
+      controller.view.layoutIfNeeded()
+      try button("schemeButton", in: controller).sendActions(for: .primaryActionTriggered)
+      controller.view.layoutIfNeeded()
+      let picker = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityIdentifier == "keyboardSchemePicker" })
+      XCTAssertEqual(picker.bounds.height, 260)
+      for scheme in ChineseInputScheme.allCases {
+        let card = try button("schemeCard-\(scheme.rawValue)", in: controller)
+        XCTAssertGreaterThan(card.bounds.width, 140)
+        XCTAssertEqual(card.bounds.height, 100)
+      }
+      XCTAssertEqual(try button("schemeCard-nineKey", in: controller).accessibilityValue, "已选中")
+      let attachment = XCTAttachment(image: UIGraphicsImageRenderer(bounds: controller.view.bounds).image { context in
+        controller.view.layer.render(in: context.cgContext)
+      })
+      attachment.name = "Input scheme cards \(Int(width))pt"
+      attachment.lifetime = .keepAlways
+      add(attachment)
+      try button("schemeCard-quanpin", in: controller).sendActions(for: .primaryActionTriggered)
+      XCTAssertNil(picker.superview)
+      XCTAssertEqual(InputSchemePreference.scheme, .quanpin)
+      XCTAssertEqual(try button("schemeButton", in: controller).accessibilityValue, ChineseInputScheme.quanpin.title)
+      controller.view.layoutIfNeeded()
+      XCTAssertEqual(controller.view.constraints.first { $0.identifier == "keyboardHeight" }?.constant, 260)
+      try button("schemeButton", in: controller).sendActions(for: .primaryActionTriggered)
+      XCTAssertEqual(try button("schemeCard-quanpin", in: controller).accessibilityValue, "已选中")
+      try button("closeSchemePicker", in: controller).sendActions(for: .primaryActionTriggered)
+      XCTAssertFalse(descendants(controller.view).contains { $0.accessibilityIdentifier == "keyboardSchemePicker" })
+      XCTAssertEqual(InputSchemePreference.scheme, .quanpin)
+    }
+  }
+
   func testVisibleInputViewReflectsSoundPreference() throws {
     let defaults = KeyboardFeedbackPreference.defaults
     let previous = defaults.object(forKey: KeyboardFeedbackPreference.soundKey)
@@ -618,7 +657,9 @@ final class NineKeyKeyboardTests: XCTestCase {
 
     let nine = try button("nineKey6", in: controller)
     XCTAssertFalse(try XCTUnwrap(nine.superview).isHidden)
-    XCTAssertEqual(try button("schemeButton", in: controller).menu?.children.count, ChineseInputScheme.allCases.count)
+    try button("schemeButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(descendants(controller.view).filter { $0.accessibilityIdentifier?.hasPrefix("schemeCard-") == true }.count, ChineseInputScheme.allCases.count)
+    try button("closeSchemePicker", in: controller).sendActions(for: .primaryActionTriggered)
     for digit in "64426" {
       try button("nineKey\(digit)", in: controller).sendActions(for: .primaryActionTriggered)
     }

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -187,7 +187,20 @@ final class OnboardingUITests: XCTestCase {
       app.swipeUp()
     }
     XCTAssertTrue(radius.isHittable)
-    radius.adjust(toNormalizedSliderPosition: 0.9)
+    // XCTest's normalized drag is approximate, and Slider.value can be a
+    // percentage on one runtime and a domain value on another. Verify the
+    // actual displayed setting changes, then survives a process restart.
+    let radiusLabel = app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "圆角 · ")).firstMatch
+    XCTAssertTrue(radiusLabel.exists)
+    let before = radiusLabel.label
+    let initial = Int(before.replacingOccurrences(of: "圆角 · ", with: "")) ?? 0
+    radius.adjust(toNormalizedSliderPosition: initial < 10 ? 0.9 : 0.1)
+    let changed = XCTNSPredicateExpectation(predicate: NSPredicate(format: "label != %@", before), object: radiusLabel)
+    XCTAssertEqual(XCTWaiter.wait(for: [changed], timeout: 5), .completed)
+    let edited = radiusLabel.label
+    let editedRadius = Int(edited.replacingOccurrences(of: "圆角 · ", with: ""))
+    XCTAssertNotNil(editedRadius)
+    XCTAssertTrue((0...20).contains(editedRadius ?? -1))
     app.terminate()
     app.launch()
     openEditor()
@@ -195,9 +208,7 @@ final class OnboardingUITests: XCTestCase {
       if radius.isHittable { break }
       app.swipeUp()
     }
-    let value = (radius.value as? String ?? "").replacingOccurrences(of: "%", with: "")
-    XCTAssertGreaterThan(Double(value) ?? 0, 16)
-    XCTAssertLessThanOrEqual(Double(value) ?? 100, 20)
+    XCTAssertEqual(radiusLabel.label, edited, "The edited corner radius must survive restarting the app")
     for _ in 0..<5 {
       if app.buttons["applyCustomSkin"].isHittable { break }
       app.swipeDown()

--- a/shared/backend/BackendAccountClient.swift
+++ b/shared/backend/BackendAccountClient.swift
@@ -6,6 +6,10 @@ struct BackendAccountClient: Sendable {
     let id: String
     let display_name: String
     let created_at: String
+    var preferredDisplayName: String {
+      display_name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        ? "水杉小鹿·" + id.prefix(6).uppercased() : display_name
+    }
   }
   struct Tokens: Codable, Sendable {
     let access_token: String

--- a/shared/backend/Tests/BackendAccountClientTests.swift
+++ b/shared/backend/Tests/BackendAccountClientTests.swift
@@ -39,6 +39,15 @@ private final class AccountProtocol: URLProtocol {
   override func stopLoading() {}
 }
 final class BackendAccountClientTests: XCTestCase {
+  func testDefaultNicknameIsStableAndPreservesChosenName() {
+    let empty = BackendAccountClient.User(id: "a7c2ef123456", display_name: "", created_at: "")
+    XCTAssertEqual(empty.preferredDisplayName, "水杉小鹿·A7C2EF")
+    let whitespace = BackendAccountClient.User(id: empty.id, display_name: " \n", created_at: "")
+    XCTAssertEqual(whitespace.preferredDisplayName, empty.preferredDisplayName)
+    let renamed = BackendAccountClient.User(id: empty.id, display_name: "我的昵称", created_at: "")
+    XCTAssertEqual(renamed.preferredDisplayName, "我的昵称")
+  }
+
   private func client() -> BackendAccountClient {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [AccountProtocol.self]


### PR DESCRIPTION
The custom skin editor now follows the supplied reference: Background/Keys/Text/Sound tabs, a three-column material grid and album/template actions, top-right Save, and a pinned full 26/9-key preview with equal height. Portrait controls scroll independently; landscape uses two columns. Existing gradients, textures, photo adjustments, colors, geometry, undo/redo and named skins remain available.

Input settings let users enable individual schemes. The keyboard card picker shows only enabled schemes; at least one is retained, and disabling the current scheme selects an enabled fallback without interrupting composition. Preferences persist across app/keyboard processes.

Add a desktop download guide for macOS/Windows/Linux and a dedicated About page with the real app icon, version/build, documentation, source, feedback and privacy links. Add grouped fuzzy-pinyin preferences and persistence; this UI commit explicitly marks matching unavailable until the separate Engine implementation and bridge integration land.

The leading keyboard brand icon now opens More as a two-column card panel, matching the skin and input-scheme pickers. Remove the separate ellipsis shortcut, preserve a 44-point brand tap target and the 24-point logo. Keep clipboard, AI, voice, feedback toggles, vibration strength and local modes; card states update after toggles. Navigation closes the panel before presenting another feature or diagnostic.

The keyboard input-scheme shortcut now opens the same two-column preview-card layout as the skin picker. All eight schemes are available, nine-key has its own miniature, and the current scheme has a border/checkmark and accessible selection state. Selecting a card uses the existing engine switch path and closes the panel without changing keyboard height. Picker/service overlays close consistently.

Blank account names display a stable default such as 水杉小鹿·A7C2EF; chosen nicknames stay unchanged. The profile editor shows a compact account ID with an explicit copy-full-ID action. Backend registration/profile/community defaults: https://github.com/metasequoiaime/MSIME-Backend/pull/11.

Also correct the existing skin persistence UI test: record the actual displayed edited radius and require exact equality after app restart, rather than infer a domain value from a normalized XCTest drag.

Validation:
- 22 native keyboard tests pass, including card geometry/selection/closing and fixed keyboard height at 320 and 414 points. Rendered card screenshots inspected.
- 11 shared backend Swift tests pass.
- Skin persistence UI test passes on iOS 18.4 and 26.5; template/library/undo UI test passes on 26.5.
- iOS Release archive and strict distribution signature verification pass. Latest combined build installed on the XR. More-card toggle/navigation regression also passed after the final changes; screenshots inspected at narrow width.

Additional validation: skin persistence/template/library/undo/pinned-preview UI tests, scheme visibility/restart/fallback UI and native keyboard tests, and fuzzy-preference/download/About navigation tests pass. All 45 project configuration tests pass. Release archive and signature verification pass; UI build installed on the XR at 19:47 JST.
