### PR TITLE
feat(ios): 接入账号设置同步并保留跨平台字段

### DIFF
--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -38,6 +38,9 @@ struct AccountSettingsView: View {
 
       if signedIn {
         Section("云端数据") {
+          NavigationLink(destination: SettingsSyncView(session: .shared, client: BackendAccountClient())) {
+            Label("设置同步", systemImage: "arrow.triangle.2.circlepath")
+          }.accessibilityIdentifier("accountSettingsSync")
           NavigationLink(destination: CloudClipboardView(session: .shared, client: BackendAccountClient())) {
             Label("云剪贴板", systemImage: "doc.on.clipboard")
           }.accessibilityIdentifier("accountCloudClipboard")

--- a/platforms/ios/App/Sources/SettingsSyncView.swift
+++ b/platforms/ios/App/Sources/SettingsSyncView.swift
@@ -67,7 +67,7 @@ struct SettingsSyncView: View {
     .alert("上传本机设置？", isPresented: $uploading) {
       Button("取消", role: .cancel) { }
       Button("上传") { pending = Task { await upload() } }
-    } message: { Text("更新云端对应设置，保留其他平台专属设置。版本冲突时需刷新后重新确认。") }
+    } message: { Text("更新云端对应设置，包括自定义皮肤的背景图片；保留其他平台专属设置。版本冲突时需刷新后重新确认。") }
     .alert("应用云端设置？", isPresented: $applying) {
       Button("取消", role: .cancel) { }
       Button("应用") {

--- a/platforms/ios/App/Sources/SettingsSyncView.swift
+++ b/platforms/ios/App/Sources/SettingsSyncView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+private enum IOSCloudSettings {
+  static func snapshot() throws -> [String: BackendPreferenceValue] {
+    let scheme = InputSchemePreference.scheme
+    let name = scheme.shuangpinProfile != nil ? "shuangpin" : (scheme == .nineKey ? "quanpin" : scheme.rawValue)
+    let skinData = try JSONEncoder().encode(CustomKeyboardSkinStore.current)
+    var settings: [String: BackendPreferenceValue] = [
+      "input.schema": .string(name),
+      "input.character_set": .string(ChineseOutputPreference.usesTraditional ? "traditional" : "simplified"),
+      "platform.ios.nine_key": .boolean(scheme == .nineKey),
+      "platform.ios.sound_enabled": .boolean(KeyboardFeedbackPreference.soundEnabled),
+      "platform.ios.haptics_enabled": .boolean(KeyboardFeedbackPreference.hapticsEnabled),
+      "platform.ios.haptic_strength": .string(KeyboardFeedbackPreference.hapticStrength.rawValue),
+      "platform.ios.dictionary_learning": .boolean(DictionaryLearningPreference.enabled),
+      "platform.ios.keyboard_skin": .string(KeyboardSkinPreference.selected.rawValue),
+      "platform.ios.custom_keyboard_skin": .string(String(decoding: skinData, as: UTF8.self))
+    ]
+    if let profile = scheme.shuangpinProfile { settings["input.shuangpin_schema"] = .string(profile) }
+    return settings
+  }
+  static func apply(_ values: [String: BackendPreferenceValue]) throws {
+    let plan = try IOSPreferencePlan(values)
+    let custom = try plan.customSkinJSON.map { try JSONDecoder().decode(CustomKeyboardSkin.self, from: Data($0.utf8)).normalized }
+    // Validate everything before writing. Unknown platforms' values stay in the
+    // cloud and are never assigned to local defaults.
+    if let scheme = plan.scheme.flatMap(ChineseInputScheme.init(rawValue:)) { InputSchemePreference.scheme = scheme }
+    if let traditional = plan.traditional { ChineseOutputPreference.usesTraditional = traditional }
+    let defaults = KeyboardFeedbackPreference.defaults
+    if let sound = plan.sound { defaults.set(sound, forKey: KeyboardFeedbackPreference.soundKey) }
+    if let haptics = plan.haptics { defaults.set(haptics, forKey: KeyboardFeedbackPreference.hapticsKey) }
+    if let strength = plan.strength { defaults.set(strength, forKey: KeyboardFeedbackPreference.strengthKey) }
+    if let learning = plan.learning { defaults.set(learning, forKey: DictionaryLearningPreference.key) }
+    if let custom { CustomKeyboardSkinStore.save(custom) }
+    if let skin = plan.skin { defaults.set(skin, forKey: KeyboardSkinPreference.key) }
+  }
+}
+
+struct SettingsSyncView: View {
+  let session: BackendAccountSession
+  let client: BackendAccountClient
+  @State private var loadedUserID: String?
+  @State private var cloud: BackendAccountClient.Preferences?
+  @State private var schema: BackendAccountClient.PreferenceSchema?
+  @State private var busy = false
+  @State private var message: String?
+  @State private var applying = false
+  @State private var uploading = false
+  @State private var pending: Task<Void, Never>?
+
+  var body: some View {
+    Form {
+      Section {
+        Text("同步输入方案、简繁体、键盘声音与触感、词库学习开关和皮肤。凭据、联网授权及输入内容不会随设置上传。")
+        if let cloud { Text("云端版本：\(cloud.revision)") }
+        Button("刷新云端设置") { pending = Task { await load() } }
+        Button("上传本机设置") { uploading = true }.disabled(cloud == nil || schema == nil)
+        Button("下载并应用云端设置") { applying = true }.disabled(cloud?.settings.isEmpty != false)
+      }
+      if busy { ProgressView("正在处理…") }
+      if let message { Text(message).foregroundStyle(.secondary) }
+    }
+    .disabled(busy)
+    .navigationTitle("设置同步")
+    .task { await load() }
+    .onDisappear { pending?.cancel(); cloud = nil }
+    .alert("上传本机设置？", isPresented: $uploading) {
+      Button("取消", role: .cancel) { }
+      Button("上传") { pending = Task { await upload() } }
+    } message: { Text("更新云端对应设置，保留其他平台专属设置。版本冲突时需刷新后重新确认。") }
+    .alert("应用云端设置？", isPresented: $applying) {
+      Button("取消", role: .cancel) { }
+      Button("应用") {
+        pending = Task { await apply() }
+      }
+    } message: { Text("将替换本机对应设置，包括词库学习开关；不会下载词库或开启数据上传。") }
+  }
+  @MainActor private func load() async {
+    guard !busy else { return }
+    busy = true; message = nil
+    defer { busy = false }
+    do {
+      let identity = try await session.credentials()
+      let fields = try await client.preferenceSchema(token: identity.token)
+      let values = try await client.preferences(token: identity.token)
+      guard try await session.user()?.id == identity.userID else { throw CancellationError() }
+      try Task.checkCancellation()
+      schema = fields; cloud = values; loadedUserID = identity.userID
+    } catch is CancellationError { }
+    catch { message = "无法读取云端设置，请稍后重试。" }
+  }
+  @MainActor private func apply() async {
+    do {
+      guard let cloud, let loadedUserID, try await session.user()?.id == loadedUserID else { throw BackendAccountClient.Failure(status: 401) }
+      try Task.checkCancellation()
+      try IOSCloudSettings.apply(cloud.settings)
+      message = "已应用云端设置。"
+    } catch is CancellationError { }
+    catch { message = "账号已变化或云端设置不兼容，本机设置未更改，请重新读取。" }
+  }
+  @MainActor private func upload() async {
+    guard !busy, let cloud, let schema else { return }
+    busy = true; message = nil
+    defer { busy = false }
+    do {
+      let values = try BackendAccountClient.mergedPreferences(cloud, replacing: IOSCloudSettings.snapshot(), schema: schema)
+      let identity = try await session.credentials()
+      guard identity.userID == loadedUserID else { throw BackendAccountClient.Failure(status: 401) }
+      try Task.checkCancellation()
+      self.cloud = try await client.putPreferences(values, token: identity.token)
+      message = "本机设置已上传。"
+    } catch is CancellationError { }
+    catch let error as BackendAccountClient.Failure {
+      message = error.status == 409 ? "云端设置已被其他设备更新，请刷新后重新确认。" : error.localizedDescription
+    } catch { message = "上传未完成，请稍后重试。" }
+  }
+}

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -94,6 +94,8 @@ targets:
       - path: shared/backend/BackendAccountClient.swift
       - path: shared/backend/BackendAccountSession.swift
       - path: shared/backend/BackendClipboardClient.swift
+      - path: shared/backend/BackendPreferencesClient.swift
+      - path: shared/backend/IOSPreferencePlan.swift
       - path: platforms/ios/App/Services
       - path: vendor/MetasequoiaImeEngine/voice/src/provider_protocol.cpp
       - path: platforms/ios/KeyboardExtension/Resources/dictionary-manifest.json
@@ -260,6 +262,8 @@ targets:
       - path: shared/backend/BackendAccountClient.swift
       - path: shared/backend/BackendAccountSession.swift
       - path: shared/backend/BackendClipboardClient.swift
+      - path: shared/backend/BackendPreferencesClient.swift
+      - path: shared/backend/IOSPreferencePlan.swift
       - path: platforms/ios/App/Services/CustomService.swift
       - path: platforms/ios/App/Services/AppServicesBridge.mm
       - path: vendor/MetasequoiaImeEngine/voice/src/provider_protocol.cpp

--- a/shared/backend/BackendAccountSession.swift
+++ b/shared/backend/BackendAccountSession.swift
@@ -148,6 +148,11 @@ actor BackendAccountSession {
     let value = BackendSavedSession(tokens: tokens, expiresAt: current.expiresAt)
     try storage.save(value); saved = value
   }
+  func credentials() async throws -> (userID: String, token: String) {
+    let token = try await accessToken()
+    guard let saved, saved.tokens.access_token == token else { throw CancellationError() }
+    return (saved.tokens.user.id, token)
+  }
   func forget() throws {
     generation += 1
     refreshing?.cancel(); refreshing = nil

--- a/shared/backend/BackendPreferencesClient.swift
+++ b/shared/backend/BackendPreferencesClient.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum BackendPreferenceValue: Codable, Equatable, Sendable {
+  case boolean(Bool), integer(Int64), number(Double), string(String)
+  init(from decoder: Decoder) throws {
+    let value = try decoder.singleValueContainer()
+    if let bool = try? value.decode(Bool.self) { self = .boolean(bool) }
+    else if let integer = try? value.decode(Int64.self) { self = .integer(integer) }
+    else if let number = try? value.decode(Double.self) { self = .number(number) }
+    else { self = .string(try value.decode(String.self)) }
+  }
+  func encode(to encoder: Encoder) throws {
+    var value = encoder.singleValueContainer()
+    switch self {
+    case .boolean(let v): try value.encode(v)
+    case .integer(let v): try value.encode(v)
+    case .number(let v): try value.encode(v)
+    case .string(let v): try value.encode(v)
+    }
+  }
+  var kind: String {
+    switch self { case .boolean: return "boolean"; case .integer: return "integer"; case .number: return "number"; case .string: return "string" }
+  }
+}
+extension BackendAccountClient {
+  struct Preferences: Codable, Sendable {
+    let revision: Int64
+    let settings: [String: BackendPreferenceValue]
+  }
+  struct PreferenceSchema: Decodable, Sendable {
+    struct Field: Decodable, Sendable { let type: String }
+    let fields: [String: Field]
+    let maximum_bytes: Int
+    let update_mode: String
+    let revision_required: Bool
+  }
+  func preferences(token: String) async throws -> Preferences {
+    try await json("GET", "/v1/users/me/preferences", token: token)
+  }
+  func preferenceSchema(token: String) async throws -> PreferenceSchema {
+    try await json("GET", "/v1/users/me/preferences/schema", token: token)
+  }
+  static func mergedPreferences(_ base: Preferences, replacing values: [String: BackendPreferenceValue], schema: PreferenceSchema) throws -> Preferences {
+    guard base.revision >= 0, schema.update_mode == "replace", schema.revision_required else { throw Failure(status: 0) }
+    for (key, value) in values {
+      guard let field = schema.fields[key], field.type == value.kind || (field.type == "number" && value.kind == "integer") else { throw Failure(status: 503) }
+    }
+    // Preserve every other platform's fields. A revision conflict is returned to
+    // the user, never resolved by an automatic last-writer-wins retry.
+    let merged = Preferences(revision: base.revision, settings: base.settings.merging(values) { _, new in new })
+    guard try JSONEncoder().encode(merged).count <= min(schema.maximum_bytes, 65536) else { throw Failure(status: 400) }
+    return merged
+  }
+  func putPreferences(_ preferences: Preferences, token: String) async throws -> Preferences {
+    try await json("PUT", "/v1/users/me/preferences", token: token, body: JSONEncoder().encode(preferences))
+  }
+}

--- a/shared/backend/BackendPreferencesClient.swift
+++ b/shared/backend/BackendPreferencesClient.swift
@@ -48,7 +48,7 @@ extension BackendAccountClient {
     // Preserve every other platform's fields. A revision conflict is returned to
     // the user, never resolved by an automatic last-writer-wins retry.
     let merged = Preferences(revision: base.revision, settings: base.settings.merging(values) { _, new in new })
-    guard try JSONEncoder().encode(merged).count <= min(schema.maximum_bytes, 65536) else { throw Failure(status: 400) }
+    guard try JSONEncoder().encode(merged).count <= min(schema.maximum_bytes, 1024 * 1024) else { throw Failure(status: 400) }
     return merged
   }
   func putPreferences(_ preferences: Preferences, token: String) async throws -> Preferences {

--- a/shared/backend/IOSPreferencePlan.swift
+++ b/shared/backend/IOSPreferencePlan.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Validated values only; the platform applies this plan through its existing setters.
+struct IOSPreferencePlan {
+  let scheme: String?
+  let traditional: Bool?
+  let sound: Bool?
+  let haptics: Bool?
+  let learning: Bool?
+  let strength: String?
+  let skin: String?
+  let customSkinJSON: String?
+
+  init(_ values: [String: BackendPreferenceValue]) throws {
+    func string(_ key: String) throws -> String? {
+      guard let value = values[key] else { return nil }
+      guard case .string(let text) = value else { throw BackendAccountClient.Failure(status: 400) }
+      return text
+    }
+    func bool(_ key: String) throws -> Bool? {
+      guard let value = values[key] else { return nil }
+      guard case .boolean(let value) = value else { throw BackendAccountClient.Failure(status: 400) }
+      return value
+    }
+    let nineKey = try bool("platform.ios.nine_key")
+    if let value = try string("input.schema") {
+      switch value {
+      case "quanpin": scheme = nineKey == true ? "nineKey" : "quanpin"
+      case "shuangpin":
+        let profile = try string("input.shuangpin_schema") ?? "xiaohe"
+        guard ["xiaohe", "ziranma", "microsoft", "shoudao"].contains(profile) else { throw BackendAccountClient.Failure(status: 400) }
+        scheme = profile == "xiaohe" ? "shuangpin" : profile
+      case "wubi":
+        guard try string("input.wubi_schema") ?? "wubi86" == "wubi86" else { throw BackendAccountClient.Failure(status: 400) }
+        scheme = "wubi"
+      case "japanese":
+        guard try string("input.japanese_schema") ?? "romaji" == "romaji" else { throw BackendAccountClient.Failure(status: 400) }
+        scheme = "japanese"
+      default: throw BackendAccountClient.Failure(status: 400)
+      }
+    } else { scheme = nil }
+    if let charset = try string("input.character_set") {
+      guard ["simplified", "traditional"].contains(charset) else { throw BackendAccountClient.Failure(status: 400) }
+      traditional = charset == "traditional"
+    } else { traditional = nil }
+    sound = try bool("platform.ios.sound_enabled")
+    haptics = try bool("platform.ios.haptics_enabled")
+    learning = try bool("platform.ios.dictionary_learning")
+    strength = try string("platform.ios.haptic_strength")
+    guard strength == nil || ["light", "medium", "strong"].contains(strength!) else { throw BackendAccountClient.Failure(status: 400) }
+    skin = try string("platform.ios.keyboard_skin")
+    guard skin == nil || ["forest", "ocean", "rose", "porcelain", "typewriter", "candy", "midnight", "blueprint", "custom"].contains(skin!) else { throw BackendAccountClient.Failure(status: 400) }
+    customSkinJSON = try string("platform.ios.custom_keyboard_skin")
+  }
+}

--- a/shared/backend/Package.swift
+++ b/shared/backend/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
   name: "MSIMEBackend", platforms: [.macOS(.v12), .iOS(.v15)],
   products: [.library(name: "MSIMEBackend", targets: ["MSIMEBackend"])],
   targets: [
-    .target(name: "MSIMEBackend", path: ".", exclude: ["Tests", "README.md"], sources: ["BackendAccountClient.swift", "BackendAccountSession.swift", "BackendClipboardClient.swift"]),
+    .target(name: "MSIMEBackend", path: ".", exclude: ["Tests", "README.md"], sources: ["BackendAccountClient.swift", "BackendAccountSession.swift", "BackendClipboardClient.swift", "BackendPreferencesClient.swift", "IOSPreferencePlan.swift"]),
     .testTarget(name: "MSIMEBackendTests", dependencies: ["MSIMEBackend"], path: "Tests")
   ])

--- a/shared/backend/Tests/BackendPreferencesTests.swift
+++ b/shared/backend/Tests/BackendPreferencesTests.swift
@@ -11,6 +11,17 @@ final class BackendPreferencesTests: XCTestCase {
     XCTAssertEqual(merged.settings["input.schema"], .string("wubi"))
     XCTAssertThrowsError(try BackendAccountClient.mergedPreferences(base, replacing: ["platform.ios.nine_key": .boolean(true)], schema: schema))
   }
+  func testPhotoSizedPrivateSettingsStayIntactWithinNegotiatedLimit() throws {
+    let photo = String(repeating: "A", count: 4 * ((512000 + 2) / 3))
+    let json = "{\"photo\":\"" + photo + "\"}"
+    let base = BackendAccountClient.Preferences(revision: 1, settings: [:])
+    let key = "platform.ios.custom_keyboard_skin"
+    let schema = BackendAccountClient.PreferenceSchema(fields: [key: .init(type: "string")], maximum_bytes: 1024 * 1024, update_mode: "replace", revision_required: true)
+    let merged = try BackendAccountClient.mergedPreferences(base, replacing: [key: .string(json)], schema: schema)
+    XCTAssertEqual(merged.settings[key], .string(json))
+    let old = BackendAccountClient.PreferenceSchema(fields: schema.fields, maximum_bytes: 65536, update_mode: "replace", revision_required: true)
+    XCTAssertThrowsError(try BackendAccountClient.mergedPreferences(base, replacing: [key: .string(json)], schema: old))
+  }
   func testUnsupportedCloudValuesFailBeforeAnApplicationPlanExists() throws {
     for settings: [String: BackendPreferenceValue] in [
       ["input.schema": .string("shuangpin"), "input.shuangpin_schema": .string("unsupported")],

--- a/shared/backend/Tests/BackendPreferencesTests.swift
+++ b/shared/backend/Tests/BackendPreferencesTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import MSIMEBackend
+
+final class BackendPreferencesTests: XCTestCase {
+  func testMergePreservesOtherPlatformsAndReadRevision() throws {
+    let base = BackendAccountClient.Preferences(revision: 42, settings: ["appearance.page_size": .integer(7), "input.schema": .string("quanpin")])
+    let schema = BackendAccountClient.PreferenceSchema(fields: ["input.schema": .init(type: "string")], maximum_bytes: 65536, update_mode: "replace", revision_required: true)
+    let merged = try BackendAccountClient.mergedPreferences(base, replacing: ["input.schema": .string("wubi")], schema: schema)
+    XCTAssertEqual(merged.revision, 42)
+    XCTAssertEqual(merged.settings["appearance.page_size"], .integer(7))
+    XCTAssertEqual(merged.settings["input.schema"], .string("wubi"))
+    XCTAssertThrowsError(try BackendAccountClient.mergedPreferences(base, replacing: ["platform.ios.nine_key": .boolean(true)], schema: schema))
+  }
+  func testUnsupportedCloudValuesFailBeforeAnApplicationPlanExists() throws {
+    for settings: [String: BackendPreferenceValue] in [
+      ["input.schema": .string("shuangpin"), "input.shuangpin_schema": .string("unsupported")],
+      ["input.schema": .string("wubi"), "input.wubi_schema": .string("wubi98")],
+      ["platform.ios.sound_enabled": .string("true")],
+      ["platform.ios.haptic_strength": .string("unsafe")]
+    ] { XCTAssertThrowsError(try IOSPreferencePlan(settings)) }
+    let nine = try IOSPreferencePlan(["input.schema": .string("quanpin"), "platform.ios.nine_key": .boolean(true)])
+    XCTAssertEqual(nine.scheme, "nineKey")
+    XCTAssertNil(nine.sound)
+    let shuangpin = try IOSPreferencePlan(["input.schema": .string("shuangpin"), "input.shuangpin_schema": .string("ziranma"), "input.character_set": .string("traditional")])
+    XCTAssertEqual(shuangpin.scheme, "ziranma")
+    XCTAssertEqual(shuangpin.traditional, true)
+  }
+}


### PR DESCRIPTION
iOS 账号页增加设置同步：用户明确选择上传或下载，支持输入方案、简繁体、声音触感、词库学习开关及自定义皮肤。上传保留其他平台字段并提交读取时的版本，冲突须重新读取和确认；下载先校验完整设置再应用，账号切换后拒绝使用原账号缓存。私人背景照片随设置同步，不要求发布到社区。

验证：13 项 Swift 协议与会话测试、45 项项目配置测试通过，完整 iOS Simulator App 构建通过。照片样例同时验证 1 MiB 服务端容量及旧服务端拒绝超限行为；真实签名账号与设置页面操作仍待验收。
