### PR TITLE
fix(ios): 社区与剪贴板请求绑定原账号

### DIFF
--- a/platforms/ios/App/Services/SkinCommunityAPI.swift
+++ b/platforms/ios/App/Services/SkinCommunityAPI.swift
@@ -31,17 +31,21 @@ actor SkinCommunityAPI {
   func currentUser() async throws -> CommunityUser? { try await account.user() }
   func signedIn() async throws -> Bool { try await account.user() != nil }
   private func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil, authenticated: Bool = false) async throws -> T {
-    var token: String?
-    if try await account.user() != nil { token = try await account.accessToken() }
+    var identity: (userID: String, token: String)?
+    if try await account.user() != nil { identity = try await account.credentials() }
+    let token = identity?.token
     if authenticated && token == nil { throw CommunityFailure(message: "请先使用 Apple 登录。") }
     let data: Data
     do {
       do { data = try await client.request(method, path, token: token, body: body) }
       catch let error as BackendAccountClient.Failure where error.status == 401 && token != nil {
-        let fresh = try await account.accessToken(retrying: token)
-        data = try await client.request(method, path, token: fresh, body: body)
+        guard let identity else { throw CancellationError() }
+        let fresh = try await account.credentials(retrying: token, matchingUserID: identity.userID)
+        data = try await client.request(method, path, token: fresh.token, body: body)
       }
     } catch let error as BackendAccountClient.Failure { throw Self.failure(Data(), status: error.status) }
+    guard try await account.user()?.id == identity?.userID else { throw CancellationError() }
+    try Task.checkCancellation()
     return try JSONDecoder().decode(T.self, from: data.isEmpty ? Data("{}".utf8) : data)
   }
   private static func failure(_ data: Data, status: Int) -> CommunityFailure {

--- a/platforms/ios/App/Sources/CloudClipboardView.swift
+++ b/platforms/ios/App/Sources/CloudClipboardView.swift
@@ -15,6 +15,7 @@ private enum ClipboardConfirmation: String, Identifiable {
 struct CloudClipboardView: View {
   let session: BackendAccountSession
   let client: BackendAccountClient
+  @State private var accountID: String?
   @State private var enabled = false
   @State private var loaded = false
   @State private var items: [BackendAccountClient.ClipboardItem] = []
@@ -56,7 +57,7 @@ struct CloudClipboardView: View {
             VStack(alignment: .leading, spacing: 8) {
               Text(item.text).textSelection(.enabled)
               HStack {
-                Button("复制") { UIPasteboard.general.string = item.text }
+                Button("复制") { run { _ in UIPasteboard.general.string = item.text } }
                 Spacer()
                 Button("删除", role: .destructive) { run { token in try await client.deleteClipboard(id: item.id, token: token) } }
               }
@@ -73,7 +74,7 @@ struct CloudClipboardView: View {
     }
     .disabled(busy)
     .navigationTitle("云剪贴板")
-    .task { await execute { _ in } }
+    .task { run { _ in } }
     .onDisappear { pending?.cancel(); items = []; text = "" }
     .confirmationDialog(confirmation?.title ?? "", isPresented: Binding(
       get: { confirmation != nil }, set: { if !$0 { confirmation = nil } })) {
@@ -88,21 +89,24 @@ struct CloudClipboardView: View {
       Button("取消", role: .cancel) { confirmation = nil }
     }
   }
-  private func run(_ action: @escaping (String) async throws -> Void) {
+  @MainActor private func run(_ action: @escaping (String) async throws -> Void) {
+    guard !busy else { return }
+    busy = true; message = nil
     pending = Task { await execute(action) }
   }
   @MainActor private func execute(_ action: (String) async throws -> Void) async {
-    guard !busy else { return }
-    busy = true; message = nil
     defer { busy = false }
     do {
-      let token = try await session.accessToken()
-      try await action(token)
-      let page = try await client.clipboard(token: token, search: search)
+      let identity = try await session.credentials(matchingUserID: accountID)
+      try Task.checkCancellation()
+      accountID = identity.userID
+      try await action(identity.token)
+      let page = try await client.clipboard(token: identity.token, search: search)
+      _ = try await session.credentials(matchingUserID: identity.userID)
       try Task.checkCancellation()
       enabled = page.enabled; items = page.items; loaded = true
-    } catch is CancellationError { }
-    catch let error as BackendAccountClient.Failure { message = error.localizedDescription }
-    catch { message = "连接未完成，请检查网络后重试。" }
+    } catch is CancellationError { items = []; text = ""; loaded = false }
+    catch let error as BackendAccountClient.Failure { items = []; loaded = false; message = error.localizedDescription }
+    catch { items = []; loaded = false; message = "连接未完成，请检查网络后重试。" }
   }
 }

--- a/shared/backend/BackendAccountSession.swift
+++ b/shared/backend/BackendAccountSession.swift
@@ -148,9 +148,12 @@ actor BackendAccountSession {
     let value = BackendSavedSession(tokens: tokens, expiresAt: current.expiresAt)
     try storage.save(value); saved = value
   }
-  func credentials() async throws -> (userID: String, token: String) {
-    let token = try await accessToken()
-    guard let saved, saved.tokens.access_token == token else { throw CancellationError() }
+  func credentials(retrying rejectedToken: String? = nil, matchingUserID expected: String? = nil) async throws -> (userID: String, token: String) {
+    try load()
+    if let expected, saved?.tokens.user.id != expected { throw CancellationError() }
+    let token = try await accessToken(retrying: rejectedToken)
+    guard let saved, saved.tokens.access_token == token,
+          expected == nil || saved.tokens.user.id == expected else { throw CancellationError() }
     return (saved.tokens.user.id, token)
   }
   func forget() throws {

--- a/shared/backend/Tests/BackendAccountSessionTests.swift
+++ b/shared/backend/Tests/BackendAccountSessionTests.swift
@@ -62,6 +62,28 @@ final class BackendAccountSessionTests: XCTestCase {
     catch is CancellationError { }
     XCTAssertNil(try storage.load())
   }
+  func testRetryForDifferentAccountNeverRefreshesOrReturnsCurrentToken() async throws {
+    let storage = MemorySessions(.init(tokens: RefreshAPI.tokens(), expiresAt: .distantPast))
+    let api = RefreshAPI()
+    let session = BackendAccountSession(api: api, storage: storage)
+    do {
+      _ = try await session.credentials(retrying: "old-account-token", matchingUserID: "previous-account")
+      XCTFail("must not retry an old account request as the current account")
+    } catch is CancellationError { }
+    let count = await api.refreshCount
+    XCTAssertEqual(count, 0)
+  }
+  func testBoundCredentialsRejectLogoutDuringRefresh() async throws {
+    let storage = MemorySessions(.init(tokens: RefreshAPI.tokens(), expiresAt: .distantPast))
+    let api = RefreshAPI()
+    let session = BackendAccountSession(api: api, storage: storage)
+    let pending = Task { try await session.credentials(matchingUserID: "synthetic-user") }
+    await api.waitUntilRefreshing()
+    try await session.forget()
+    await api.finish()
+    do { _ = try await pending.value; XCTFail("late credentials returned") }
+    catch is CancellationError { }
+  }
   func testLogoutGenerationRejectsLateRefresh() async throws {
     let storage = MemorySessions(.init(tokens: RefreshAPI.tokens(), expiresAt: .distantPast))
     let api = RefreshAPI()


### PR DESCRIPTION
社区请求在旧账号收到 401 后重试时，可能取到新账号令牌；云剪贴板页面也未将后续操作绑定到首次加载的账号。现在重试和剪贴板操作均校验原账号，账号切换或取消后丢弃旧响应并清理缓存，快速连续操作不会覆盖仍在执行的任务句柄。

验证：35 项共享客户端测试（包括不同账号拒绝重试及刷新期间退出）通过；4 项原生社区测试通过；45 项项目检查通过；iOS App/键盘 ARM64 与 x86_64 Simulator 构建通过。基于已合并的云词库 PR #353。
