### PR TITLE
fix(ios): organize tab navigation and account flows

### DIFF
--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -4,7 +4,7 @@ import AuthenticationServices
 struct AccountSettingsView: View {
   @State private var signedIn = false
   @State private var designs = CustomSkinLibrary.designs
-  @State private var showPublish = false
+  @State private var replayOnboarding = false
 
   var body: some View {
     Form {
@@ -20,26 +20,25 @@ struct AccountSettingsView: View {
             }
           }.padding(.vertical, 4)
         }.accessibilityIdentifier("accountLocalDesigns")
-        if signedIn {
-          NavigationLink(destination: SkinCommunityView(onlyMine: true)) {
-            HStack(spacing: 12) {
-              accountIcon("square.stack.3d.up.fill", color: MetasequoiaTheme.accent)
-              VStack(alignment: .leading, spacing: 4) {
-                Text("已发布作品").foregroundStyle(.primary)
-                Text("查看下载、评分和管理作品").font(.caption).foregroundStyle(.secondary)
-              }
-            }.padding(.vertical, 4)
-          }.accessibilityIdentifier("accountPublishedSkins")
-          Button { showPublish = true } label: {
-            Label("发布新作品", systemImage: "square.and.arrow.up")
-          }
-        }
       }
 
-      Section("社区收藏与发布") {
-        ForEach(CommunityResourceKind.allCases) { kind in
-          NavigationLink(destination: CommunityResourcesView(kind: kind, initialScope: "saved")) { Label("收藏的\(kind.title)", systemImage: "bookmark") }
-          NavigationLink(destination: CommunityResourcesView(kind: kind, initialScope: "mine")) { Label("我发布的\(kind.title)", systemImage: kind.icon) }
+      if signedIn {
+        Section("我发布的作品") {
+          NavigationLink(destination: SkinCommunityView(onlyMine: true)) {
+            Label("我发布的皮肤", systemImage: "paintpalette")
+          }.accessibilityIdentifier("accountPublishedSkins")
+          ForEach(CommunityResourceKind.allCases) { kind in
+            NavigationLink(destination: CommunityResourcesView(kind: kind, initialScope: "mine")) {
+              Label("我发布的\(kind.title)", systemImage: kind.icon)
+            }
+          }
+        }
+        Section("我的收藏") {
+          ForEach(CommunityResourceKind.allCases) { kind in
+            NavigationLink(destination: CommunityResourcesView(kind: kind, initialScope: "saved")) {
+              Label("收藏的\(kind.title)", systemImage: "bookmark")
+            }
+          }
         }
       }
 
@@ -67,7 +66,7 @@ struct AccountSettingsView: View {
         }
 
       Section {
-        NavigationLink(destination: WelcomeFlowView()) {
+        Button { replayOnboarding = true } label: {
           Label("重新查看新手引导", systemImage: "sparkles.rectangle.stack")
         }.accessibilityIdentifier("replayOnboardingLink")
       }
@@ -80,7 +79,9 @@ struct AccountSettingsView: View {
     }
     .navigationTitle("我的")
     .task { designs = CustomSkinLibrary.designs }
-    .sheet(isPresented: $showPublish) { CommunityPublishView {} }
+    .sheet(isPresented: $replayOnboarding) {
+      NavigationView { WelcomeFlowView(onFinish: { replayOnboarding = false }) }.navigationViewStyle(.stack)
+    }
   }
 
   private func accountIcon(_ symbol: String, color: Color) -> some View {

--- a/platforms/ios/App/Sources/AppNavigation.swift
+++ b/platforms/ios/App/Sources/AppNavigation.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+// Each tab owns its stack. Cross-tab discovery always opens the community root.
+final class AppNavigation: ObservableObject {
+  enum Tab: Hashable { case keyboard, community, statistics, account }
+  @Published var tab: Tab = .keyboard
+  @Published var communityCategory = 0
+  @Published var communityRoot = UUID()
+
+  func discoverSkins() {
+    communityRoot = UUID()
+    communityCategory = 0
+    tab = .community
+  }
+}
+
+// Authentication is a task sheet, never another copy of the My tab.
+struct AccountLoginSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  @State private var signedIn = false
+  var body: some View {
+    NavigationView {
+      Form { AppleAccountSection(signedIn: $signedIn) }
+        .navigationTitle("登录水杉").navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+          ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() } }
+        }
+        .onChange(of: signedIn) { if $0 { dismiss() } }
+    }.navigationViewStyle(.stack).tint(MetasequoiaTheme.accent)
+  }
+}

--- a/platforms/ios/App/Sources/CommunityResourcesView.swift
+++ b/platforms/ios/App/Sources/CommunityResourcesView.swift
@@ -2,10 +2,13 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct CommunityHomeView: View {
-  @State private var category = 0
+  @EnvironmentObject private var navigation: AppNavigation
+  private var category: Int { navigation.communityCategory }
+  @State private var pendingPublish: Int?
   @State private var publishing: Int?
   @State private var account = false
   @State private var refresh = UUID()
+  @State private var didPublish = false
   var body: some View {
     VStack(spacing: 0) {
       HStack(spacing: 10) {
@@ -27,18 +30,21 @@ struct CommunityHomeView: View {
           .accessibilityLabel("发布作品").accessibilityIdentifier("publishCommunityWork")
       }
     }
-    .sheet(isPresented: Binding(get: { publishing != nil }, set: { if !$0 { publishing = nil } }), onDismiss: { refresh = UUID() }) {
-      if publishing == 0 { CommunityPublishView {} }
-      else { CommunityResourceEditor(kind: publishing == 1 ? .dictionary : .reply) }
+    .sheet(isPresented: Binding(get: { publishing != nil }, set: { if !$0 { publishing = nil } }), onDismiss: {
+      if didPublish { refresh = UUID(); didPublish = false }
+    }) {
+      if publishing == 0 { CommunityPublishView { didPublish = true } }
+      else { CommunityResourceEditor(kind: publishing == 1 ? .dictionary : .reply, onPublished: { didPublish = true }) }
     }
-    .sheet(isPresented: $account) {
-      NavigationView { AccountSettingsView().toolbar {
-        ToolbarItem(placement: .navigationBarTrailing) { Button("完成") { account = false } }
-      }}.navigationViewStyle(.stack)
-    }
+    .sheet(isPresented: $account, onDismiss: {
+      let pending = pendingPublish; pendingPublish = nil
+      Task {
+        if let pending, (try? await SkinCommunityAPI.shared.signedIn()) == true { publishing = pending }
+      }
+    }) { AccountLoginSheet() }
   }
   private func categoryButton(_ value: Int, title: String, symbol: String) -> some View {
-    Button { category = value } label: {
+    Button { navigation.communityCategory = value } label: {
       HStack(spacing: 6) {
         Image(systemName: symbol).font(.system(size: 16, weight: .medium))
         Text(title).font(.system(size: 15, weight: .semibold))
@@ -52,7 +58,7 @@ struct CommunityHomeView: View {
     #if DEBUG && targetEnvironment(simulator)
     if CommunityPreviewFixtures.enabled { publishing = kind; return }
     #endif
-    Task { if (try? await SkinCommunityAPI.shared.signedIn()) == true { publishing = kind } else { account = true } }
+    Task { if (try? await SkinCommunityAPI.shared.signedIn()) == true { publishing = kind } else { pendingPublish = kind; account = true } }
   }
 }
 
@@ -211,6 +217,7 @@ struct CommunityResourceDetail: View {
 struct CommunityResourceEditor: View {
   let kind: CommunityResourceKind
   var existing: CommunityResource?
+  var onPublished: () -> Void = {}
   @State private var publicationID = UUID().uuidString.lowercased()
   @State private var name = ""
   @State private var description = ""
@@ -300,7 +307,7 @@ struct CommunityResourceEditor: View {
                   prompt: kind == .reply ? prompt : nil)
                 try await SkinCommunityAPI.shared.publishResource(id: publicationID, kind: kind, name: name,
                   description: description, content: content, revision: existing?.revision ?? 0)
-                dismiss()
+                onPublished(); dismiss()
               } catch { message = error.localizedDescription }
             }
           }

--- a/platforms/ios/App/Sources/FeatureSettingsViews.swift
+++ b/platforms/ios/App/Sources/FeatureSettingsViews.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 
 struct SkinSettingsView: View {
+  @EnvironmentObject private var navigation: AppNavigation
   @AppStorage(CustomKeyboardSkinStore.key, store: KeyboardFeedbackPreference.defaults)
   private var customSkinData = Data()
   @AppStorage(KeyboardSkinPreference.key, store: KeyboardFeedbackPreference.defaults)
@@ -17,7 +18,7 @@ struct SkinSettingsView: View {
         }.accessibilityIdentifier("customSkinEditorLink")
       }
       Section {
-        NavigationLink(destination: SkinCommunityView()) { Label("皮肤社区", systemImage: "person.3.fill") }
+        Button { navigation.discoverSkins() } label: { Label("去社区发现皮肤", systemImage: "square.grid.2x2") }
           .accessibilityIdentifier("skinCommunityLink")
       }
       Section("完整键盘预览") {

--- a/platforms/ios/App/Sources/KeyboardChatView.swift
+++ b/platforms/ios/App/Sources/KeyboardChatView.swift
@@ -198,7 +198,7 @@ struct KeyboardTryoutView: View {
       .task { focused = focusOnAppear; await chat.loadModels() }
       .onDisappear { chat.cancel(); focused = false }
       .sheet(isPresented: $showAccount, onDismiss: { Task { await chat.loadModels() } }) {
-        NavigationView { AccountSettingsView().toolbar { ToolbarItem(placement: .cancellationAction) { Button("完成") { showAccount = false } } } }
+        AccountLoginSheet()
       }
       .confirmationDialog("开始新对话？当前消息将被清空。", isPresented: $clearConfirmation, titleVisibility: .visible) {
         Button("新对话", role: .destructive) { chat.clear() }

--- a/platforms/ios/App/Sources/KeyboardHomeView.swift
+++ b/platforms/ios/App/Sources/KeyboardHomeView.swift
@@ -11,7 +11,6 @@ struct SettingsView: View {
     skin == .custom ? (CustomSkinLibrary.designs.first { $0.design == design }?.name ?? "自定义皮肤") : skin.title
   }
   var body: some View {
-    NavigationView {
       ScrollView {
         VStack(alignment: .leading, spacing: 20) {
           VStack(alignment: .leading, spacing: 5) {
@@ -68,7 +67,7 @@ struct SettingsView: View {
         .navigationTitle("水杉输入法").navigationBarTitleDisplayMode(.inline)
         .onAppear { refresh() }
         .onChange(of: scenePhase) { if $0 == .active { refresh() } }
-    }.navigationViewStyle(.stack).tint(MetasequoiaTheme.accent)
+      .tint(MetasequoiaTheme.accent)
   }
   private var keyboardCard: some View {
     NavigationLink(destination: KeyboardTryoutView(focusOnAppear: true)) {

--- a/platforms/ios/App/Sources/MetasequoiaImeApp.swift
+++ b/platforms/ios/App/Sources/MetasequoiaImeApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct MetasequoiaImeApp: App {
+  @StateObject private var onboardingNavigation = AppNavigation()
   @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
   init() {
@@ -58,7 +59,7 @@ struct MetasequoiaImeApp: App {
         MainTabView()
       } else {
         NavigationView { WelcomeFlowView(onFinish: { hasCompletedOnboarding = true }) }
-          .navigationViewStyle(.stack)
+          .navigationViewStyle(.stack).environmentObject(onboardingNavigation)
       }
   }
 }
@@ -81,21 +82,20 @@ private struct KeyboardVoicePreviewFixture: View {
 #endif
 
 private struct MainTabView: View {
+  @StateObject private var navigation = AppNavigation()
   var body: some View {
-    TabView {
-      SettingsView()
-        .tabItem { Label("键盘", systemImage: "keyboard") }
-      NavigationView { CommunityHomeView() }
-        .navigationViewStyle(.stack)
-        .tabItem { Label("社区", systemImage: "square.grid.2x2.fill") }
-      NavigationView { TypingStatisticsView() }
-        .navigationViewStyle(.stack)
-        .tabItem { Label("统计", systemImage: "chart.bar.xaxis") }
-      NavigationView { AccountSettingsView() }
-        .navigationViewStyle(.stack)
-        .tabItem { Label("我的", systemImage: "person.crop.circle") }
+    TabView(selection: $navigation.tab) {
+      NavigationView { SettingsView() }.navigationViewStyle(.stack)
+        .tabItem { Label("键盘", systemImage: "keyboard") }.tag(AppNavigation.Tab.keyboard)
+      NavigationView { CommunityHomeView() }.navigationViewStyle(.stack).id(navigation.communityRoot)
+        .tabItem { Label("社区", systemImage: "square.grid.2x2.fill") }.tag(AppNavigation.Tab.community)
+      NavigationView { TypingStatisticsView() }.navigationViewStyle(.stack)
+        .tabItem { Label("统计", systemImage: "chart.bar.xaxis") }.tag(AppNavigation.Tab.statistics)
+      NavigationView { AccountSettingsView() }.navigationViewStyle(.stack)
+        .tabItem { Label("我的", systemImage: "person.crop.circle") }.tag(AppNavigation.Tab.account)
     }
-    .tint(MetasequoiaTheme.forest)
+    .environmentObject(navigation)
+    .tint(MetasequoiaTheme.accent)
   }
 }
 

--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct KeyboardSettingsView: View {
   var body: some View {
     Form {
-        Section("键盘与服务") {
+        Section("键盘外观与输入") {
           NavigationLink(destination: InputSettingsView()) {
             Label("输入设置", systemImage: "slider.horizontal.3")
           }.accessibilityIdentifier("inputSettingsLink")
@@ -14,6 +14,8 @@ struct KeyboardSettingsView: View {
           NavigationLink(destination: SkinSettingsView()) {
             Label("皮肤", systemImage: "paintpalette")
           }.accessibilityIdentifier("skinSettingsLink")
+        }
+        Section("词库与智能服务") {
           NavigationLink(destination: DictionarySettingsView()) {
             Label("词库", systemImage: "books.vertical")
           }.accessibilityIdentifier("dictionarySettingsLink")

--- a/platforms/ios/App/Sources/SkinCommunityView.swift
+++ b/platforms/ios/App/Sources/SkinCommunityView.swift
@@ -50,7 +50,7 @@ struct SkinCommunityView: View {
       }
       }
     }
-    .navigationTitle(onlyMine ? "已发布作品" : (embedded ? "社区" : "皮肤社区"))
+    .navigationTitle(onlyMine ? "我发布的皮肤" : (embedded ? "社区" : "皮肤社区"))
     .navigationBarTitleDisplayMode(.inline)
     .refreshable { do { try await load() } catch { message = error.localizedDescription } }
     .task {
@@ -62,14 +62,11 @@ struct SkinCommunityView: View {
     }
     .sheet(isPresented: $showPublish) { CommunityPublishView { run { try await load() } } }
     .sheet(isPresented: $showAccount, onDismiss: {
-      Task { signedIn = (try? await api.signedIn()) ?? false }
-    }) {
-      NavigationView {
-        AccountSettingsView().toolbar {
-          ToolbarItem(placement: .navigationBarTrailing) { Button("完成") { showAccount = false } }
-        }
-      }.navigationViewStyle(.stack)
-    }
+      Task {
+        signedIn = (try? await api.signedIn()) ?? false
+        if signedIn { showPublish = true }
+      }
+    }) { AccountLoginSheet() }
     .alert("皮肤社区", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
       Button("好", role: .cancel) {}
     } message: { Text(message ?? "") }

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -181,6 +181,73 @@ final class OnboardingUITests: XCTestCase {
   }
 
   @MainActor
+  func testSkinDiscoveryUsesCommunityTabAndReturnsToOrigin() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-hasCompletedOnboarding", "YES", "-communityPreview"]
+    app.launch()
+    app.tabBars.buttons["社区"].tap()
+    app.buttons["communitySkinCard-20000000-0000-4000-8000-000000000001"].tap()
+    XCTAssertTrue(app.navigationBars["皮肤详情"].waitForExistence(timeout: 5))
+    app.tabBars.buttons["键盘"].tap()
+    app.buttons["skinSettingsLink"].tap()
+    app.buttons["skinCommunityLink"].tap()
+    XCTAssertTrue(app.tabBars.buttons["社区"].isSelected)
+    XCTAssertTrue(app.navigationBars["社区"].waitForExistence(timeout: 5))
+    XCTAssertFalse(app.navigationBars["皮肤详情"].exists)
+    app.buttons["communityCategory-2"].tap()
+    app.tabBars.buttons["键盘"].tap()
+    XCTAssertTrue(app.navigationBars["皮肤"].exists)
+    app.buttons["skinCommunityLink"].tap()
+    XCTAssertTrue(app.buttons["communitySkinCard-20000000-0000-4000-8000-000000000001"].exists)
+    app.tabBars.buttons["键盘"].tap()
+    app.navigationBars.buttons.firstMatch.tap()
+    XCTAssertTrue(app.navigationBars["水杉输入法"].exists)
+    app.tabBars.buttons["我的"].tap()
+    let replay = app.buttons["replayOnboardingLink"]
+    for _ in 0..<6 { if replay.isHittable { break }; app.swipeUp() }
+    replay.tap()
+    XCTAssertTrue(app.buttons["skipOnboardingButton"].waitForExistence(timeout: 5))
+    app.buttons["skipOnboardingButton"].tap()
+    XCTAssertTrue(app.navigationBars["我的"].waitForExistence(timeout: 5))
+    XCTAssertTrue(app.tabBars.buttons["我的"].isSelected)
+  }
+
+  @MainActor
+  func testChatLoginIsFocusedAndCancelReturnsToTryout() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-hasCompletedOnboarding", "YES"]
+    app.launch()
+    app.buttons["keyboardTryoutLink"].tap()
+    let login = app.buttons["登录使用 AI"]
+    XCTAssertTrue(login.waitForExistence(timeout: 8))
+    login.tap()
+    XCTAssertTrue(app.navigationBars["登录水杉"].waitForExistence(timeout: 5))
+    XCTAssertFalse(app.buttons["accountLocalDesigns"].exists)
+    XCTAssertFalse(app.buttons["aboutSettingsLink"].exists)
+    app.navigationBars["登录水杉"].buttons["取消"].tap()
+    XCTAssertTrue(app.navigationBars["试用键盘"].waitForExistence(timeout: 5))
+    app.navigationBars.buttons.firstMatch.tap()
+    XCTAssertTrue(app.navigationBars["水杉输入法"].exists)
+  }
+
+  @MainActor
+  func testCancellingPublicationPreservesCommunitySearch() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-hasCompletedOnboarding", "YES", "-communityPreview"]
+    app.launch()
+    app.tabBars.buttons["社区"].tap()
+    app.buttons["communityCategory-2"].tap()
+    let search = app.textFields.firstMatch
+    search.tap(); search.typeText("reply\n")
+    app.buttons["publishCommunityWork"].tap()
+    XCTAssertTrue(app.navigationBars["发布回复"].waitForExistence(timeout: 5))
+    app.buttons["取消"].tap()
+    XCTAssertTrue(app.navigationBars["社区"].waitForExistence(timeout: 5))
+    XCTAssertEqual(search.value as? String, "reply")
+    XCTAssertTrue(app.buttons["communityCategory-2"].isSelected)
+  }
+
+  @MainActor
   func testBrandedLaunchScreenResource() {
     let app = XCUIApplication()
     app.launchArguments = ["-launchScreenPreview"]


### PR DESCRIPTION
Make navigation predictable across the four iOS tabs. Skin discovery now opens the Community tab at its skin gallery and preserves the original Keyboard screen for return. Each tab owns one navigation container.

Login sheets contain authentication only instead of a second My hierarchy. Publishing resumes for the originally selected category after login; chat reloads models and preserves its draft without automatically sending. My separates published skins, word packs and replies from saved resources, and onboarding replay closes directly back to My. Settings are grouped by keyboard/input and dictionary/intelligent services. Cancelling publication preserves the community gallery instead of rebuilding it.

Validation: targeted simulator navigation tests cover independent tabs, cross-tab discovery and return, login cancellation, category-specific publishers, onboarding replay, and skin trial restoration. Project configuration checks and Release archive pass; signed build installed on the XR.
