### PR TITLE
feat(ios): add eight curated keyboard skin designs

### DIFF
--- a/platforms/ios/App/Sources/CustomSkinEditorView.swift
+++ b/platforms/ios/App/Sources/CustomSkinEditorView.swift
@@ -165,19 +165,12 @@ struct CustomSkinEditorView: View {
   Form {
     if section == "背景" { backgroundGallery }
     if section == "设计" {
-      Section("从一款设计开始") {
+      Section("水杉设计 · 14 款") {
         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
-          ForEach(CustomKeyboardSkin.templates, id: \.0) { title, template in
+          ForEach(CustomKeyboardSkin.curatedTemplates + Array(CustomKeyboardSkin.templates.prefix(6)), id: \.0) { title, template in
             Button { apply(template) } label: {
               VStack(alignment: .leading, spacing: 10) {
-                HStack(spacing: 5) {
-                  ForEach(["A", "S", "↵"], id: \.self) { key in
-                    Text(key).font(.system(.body, design: template.monospaced ? .monospaced : .default).weight(.medium))
-                      .frame(maxWidth: .infinity).frame(height: 34)
-                      .foregroundStyle(Color(uiColor: CustomKeyboardSkin.color(template.keyForeground)))
-                      .background(Color(uiColor: CustomKeyboardSkin.color(template.keyBackground)), in: RoundedRectangle(cornerRadius: template.cornerRadius * 0.6))
-                  }
-                }
+                CommunityDesignPreview(design: template, compact: true).frame(height: 96)
                 Text(title).font(.caption.weight(.semibold)).foregroundStyle(Color(uiColor: CustomKeyboardSkin.color(template.accent)))
               }.padding(10).background(LinearGradient(colors: [Color(uiColor: CustomKeyboardSkin.color(template.background)), Color(uiColor: CustomKeyboardSkin.color(template.gradientEnd ?? template.background))], startPoint: .topLeading, endPoint: .bottomTrailing), in: RoundedRectangle(cornerRadius: 12))
             }.buttonStyle(.plain).accessibilityIdentifier("skinTemplate_" + title)

--- a/platforms/ios/App/Sources/SkinCommunityView.swift
+++ b/platforms/ios/App/Sources/SkinCommunityView.swift
@@ -231,7 +231,8 @@ struct CommunityDesignPreview: View {
   private func key(_ text: String) -> some View {
     Text(text).font(.system(size: compact ? 8 : 14, weight: .medium, design: design.monospaced ? .monospaced : .default))
       .foregroundStyle(color(text == "↵" ? CustomKeyboardSkin.readableText(on: design.actionBackground) : design.keyForeground)).frame(maxWidth: .infinity, maxHeight: .infinity)
-      .background(color(text == "↵" ? design.actionBackground : design.keyBackground).opacity(text == "↵" ? 1 : design.keyOpacity ?? 1), in: RoundedRectangle(cornerRadius: min(design.cornerRadius, compact ? 4 : 12)))
-      .overlay(RoundedRectangle(cornerRadius: min(design.cornerRadius, compact ? 4 : 12)).stroke(color(design.customBorderColor ?? design.accent), lineWidth: design.borderWidth))
+      .background(color(text == "↵" ? design.actionBackground : design.keyBackground).opacity(text == "↵" ? 1 : design.keyOpacity ?? 1), in: RoundedRectangle(cornerRadius: design.cornerRadius * (compact ? 0.45 : 1)))
+      .overlay(RoundedRectangle(cornerRadius: design.cornerRadius * (compact ? 0.45 : 1)).stroke(color(design.customBorderColor ?? design.accent), lineWidth: design.borderWidth * (compact ? 0.6 : 1)))
+      .shadow(color: .black.opacity(design.shadow), radius: compact ? 1 : 3, y: compact ? 1 : 2)
   }
 }

--- a/platforms/ios/KeyboardTests/KeyboardSkinTests.swift
+++ b/platforms/ios/KeyboardTests/KeyboardSkinTests.swift
@@ -2,6 +2,15 @@ import XCTest
 import UIKit
 
 final class KeyboardSkinTests: XCTestCase {
+  func testCuratedDesignsRemainReadableAndRoundTrip() throws {
+    for (name, design) in CustomKeyboardSkin.templates {
+      XCTAssertTrue(design.hasReadableText, name)
+      XCTAssertEqual(design, design.normalized, name)
+      XCTAssertEqual(try JSONDecoder().decode(CustomKeyboardSkin.self, from: JSONEncoder().encode(design)), design)
+      XCTAssertGreaterThanOrEqual(CustomKeyboardSkin.contrast(CustomKeyboardSkin.readableText(on: design.actionBackground), design.actionBackground), 4.5, name)
+    }
+  }
+
   func testCustomSkinPersistenceValidationAndContrast() throws {
     let defaults = KeyboardFeedbackPreference.defaults
     let previous = defaults.object(forKey: CustomKeyboardSkinStore.key)

--- a/platforms/ios/SharedUI/CustomKeyboardSkin.swift
+++ b/platforms/ios/SharedUI/CustomKeyboardSkin.swift
@@ -171,7 +171,7 @@ extension CustomKeyboardSkin {
     grid.background = 0x102438; grid.gradientEnd = nil; grid.keyBackground = 0x17354F
     grid.accent = 0xA2D8FA; grid.actionBackground = 0x285D84; grid.cornerRadius = 2
     grid.monospaced = true; grid.pattern = 2; grid.customBorderColor = 0x548CAA
-    return [("水杉留白", Self()), ("复古纸感", paper), ("紫夜星光", night), ("奶油桃桃", peach), ("海盐渐变", blue), ("工程蓝图", grid)]
+    return [("水杉留白", Self()), ("复古纸感", paper), ("紫夜星光", night), ("奶油桃桃", peach), ("海盐渐变", blue), ("工程蓝图", grid)] + curatedTemplates
   }
 }
 

--- a/platforms/ios/SharedUI/KeyboardSkinCollection.swift
+++ b/platforms/ios/SharedUI/KeyboardSkinCollection.swift
@@ -1,0 +1,152 @@
+import UIKit
+
+extension CustomKeyboardSkin {
+  static var curatedTemplates: [(String, CustomKeyboardSkin)] {
+    [
+      ("苔庭晨雾", {
+        var skin = Self()
+        skin.background = 0xE0E9DF
+        skin.keyBackground = 0xF7FAF3
+        skin.keyForeground = 0x243F32
+        skin.accent = 0x214D3A
+        skin.actionBackground = 0x2F6047
+        skin.cornerRadius = 12
+        skin.borderWidth = 0.5
+        skin.shadow = 0.1
+        skin.pattern = 3
+        skin.monospaced = false
+        skin.gradientEnd = 0xC6D9CA
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0.035
+        skin.customBorderColor = 0xB8CDBE
+        return skin
+      }()),
+      ("竹影青瓷", {
+        var skin = Self()
+        skin.background = 0xD9E8E2
+        skin.keyBackground = 0xF5F8EE
+        skin.keyForeground = 0x243F38
+        skin.accent = 0x265443
+        skin.actionBackground = 0x265443
+        skin.cornerRadius = 4
+        skin.borderWidth = 1
+        skin.shadow = 0.04
+        skin.pattern = 0
+        skin.monospaced = false
+        skin.gradientEnd = 0xEBF2E7
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0
+        skin.customBorderColor = 0x94B4A3
+        return skin
+      }()),
+      ("月下银砂", {
+        var skin = Self()
+        skin.background = 0x181F2B
+        skin.keyBackground = 0x303E4F
+        skin.keyForeground = 0xEFF5FC
+        skin.accent = 0xCEE0F3
+        skin.actionBackground = 0xCADBEC
+        skin.cornerRadius = 10
+        skin.borderWidth = 0.5
+        skin.shadow = 0.08
+        skin.pattern = 1
+        skin.monospaced = false
+        skin.gradientEnd = 0x283645
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0.07
+        skin.customBorderColor = 0x6F8399
+        return skin
+      }()),
+      ("黑金刻度", {
+        var skin = Self()
+        skin.background = 0x191B19
+        skin.keyBackground = 0x292D29
+        skin.keyForeground = 0xEFE9D5
+        skin.accent = 0xE1CC91
+        skin.actionBackground = 0xDAC486
+        skin.cornerRadius = 3
+        skin.borderWidth = 0.75
+        skin.shadow = 0
+        skin.pattern = 2
+        skin.monospaced = true
+        skin.gradientEnd = 0x202720
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0.04
+        skin.customBorderColor = 0x8D8058
+        return skin
+      }()),
+      ("樱雪糯米", {
+        var skin = Self()
+        skin.background = 0xF4DFE5
+        skin.keyBackground = 0xFFF8F6
+        skin.keyForeground = 0x503449
+        skin.accent = 0x733E58
+        skin.actionBackground = 0x904D69
+        skin.cornerRadius = 18
+        skin.borderWidth = 0
+        skin.shadow = 0.14
+        skin.pattern = 3
+        skin.monospaced = false
+        skin.gradientEnd = 0xE7E2F2
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0.04
+        skin.customBorderColor = 0xDFBBC9
+        return skin
+      }()),
+      ("落日陶土", {
+        var skin = Self()
+        skin.background = 0xEAD4C4
+        skin.keyBackground = 0xFFF4DF
+        skin.keyForeground = 0x56382C
+        skin.accent = 0x733F2B
+        skin.actionBackground = 0x9A4E32
+        skin.cornerRadius = 7
+        skin.borderWidth = 0.75
+        skin.shadow = 0.18
+        skin.pattern = 1
+        skin.monospaced = false
+        skin.gradientEnd = 0xF3E4D1
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0.05
+        skin.customBorderColor = 0xCBA78D
+        return skin
+      }()),
+      ("冰川薄荷", {
+        var skin = Self()
+        skin.background = 0xD9EBEA
+        skin.keyBackground = 0xF5FFFF
+        skin.keyForeground = 0x203E4B
+        skin.accent = 0x275360
+        skin.actionBackground = 0x34717C
+        skin.cornerRadius = 14
+        skin.borderWidth = 0.5
+        skin.shadow = 0.06
+        skin.pattern = 3
+        skin.monospaced = false
+        skin.gradientEnd = 0xDDE7F4
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0.035
+        skin.customBorderColor = 0xC0DCDB
+        return skin
+      }()),
+      ("奶咖手账", {
+        var skin = Self()
+        skin.background = 0xD9CFC0
+        skin.keyBackground = 0xF6EFE2
+        skin.keyForeground = 0x453B31
+        skin.accent = 0x5A4630
+        skin.actionBackground = 0x65523B
+        skin.cornerRadius = 5
+        skin.borderWidth = 1
+        skin.shadow = 0.2
+        skin.pattern = 2
+        skin.monospaced = true
+        skin.gradientEnd = 0xE8DFD0
+        skin.gradientHorizontal = true
+        skin.patternOpacity = 0.06
+        skin.customBorderColor = 0xB09B83
+        return skin
+      }()),
+    ]
+  }
+}

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -475,6 +475,32 @@ final class OnboardingUITests: XCTestCase {
   }
 
   @MainActor
+  func testCuratedSkinCollectionShowsFullPreviewsAndUndo() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-hasCompletedOnboarding", "YES"]
+    app.launch()
+    app.buttons["skinSettingsLink"].tap()
+    app.buttons["customSkinEditorLink"].tap()
+    app.buttons["skinEditorTemplates"].tap()
+    let gallery = app.collectionViews.firstMatch.exists ? app.collectionViews.firstMatch : app.tables.firstMatch
+    for (index, name) in ["苔庭晨雾", "竹影青瓷", "月下银砂", "黑金刻度", "樱雪糯米", "落日陶土", "冰川薄荷", "奶咖手账"].enumerated() {
+      let template = app.buttons["skinTemplate_" + name]
+      for _ in 0..<6 { if template.isHittable { break }; gallery.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)).press(forDuration: 0.05, thenDragTo: gallery.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.25))) }
+      XCTAssertTrue(template.isHittable, name)
+      template.tap()
+      app.segmentedControls["skinEditorPreviewLayout"].buttons[index % 2 == 0 ? "26 键" : "9 键"].tap()
+      XCTAssertTrue(app.buttons["undoSkinDesign"].isEnabled)
+      let shot = XCTAttachment(screenshot: app.screenshot())
+      shot.name = "Curated skin " + name; shot.lifetime = .keepAlways; add(shot)
+    }
+    for _ in 0..<8 {
+      if !app.buttons["undoSkinDesign"].isEnabled { break }
+      app.buttons["undoSkinDesign"].tap()
+    }
+    XCTAssertFalse(app.buttons["undoSkinDesign"].isEnabled)
+  }
+
+  @MainActor
   func testCustomSkinDesignPersistsAndApplies() {
     let app = XCUIApplication()
     app.launchArguments = ["-hasCompletedOnboarding", "YES"]


### PR DESCRIPTION
Add eight original keyboard designs to the custom editor: 苔庭晨雾、竹影青瓷、月下银砂、黑金刻度、樱雪糯米、落日陶土、冰川薄荷 and 奶咖手账. The 14-template gallery shows new designs first and uses complete keyboard thumbnails. Designs vary corners, borders, shadows, typography and subtle background patterns; community previews preserve those corners and shadows. Existing designs and selected skins remain intact.

Validation: seven native skin tests pass, including all-template text contrast, normalization and round trips. Simulator UI coverage previews all eight designs with alternating 9/26-key layouts and verifies undo; screenshots inspected. All 45 project configuration checks and Release archive pass. Signed build installed on XR. Matching eight designs are published and verified in the production community, expanding the starter catalog to sixteen.
