### PR TITLE
fix(ios): make keyboard layout switches visibly distinct

### DIFF
--- a/platforms/ios/App/Sources/KeyboardSkinPreview.swift
+++ b/platforms/ios/App/Sources/KeyboardSkinPreview.swift
@@ -51,7 +51,7 @@ struct KeyboardSkinPreview: View {
       } else {
         VStack(spacing: layout.rowSpacing) {
           row(Array("qwertyuiop").map(String.init))
-          row(Array("asdfghjkl").map(String.init)).padding(.horizontal, layout.centeredLetters ? 14 : 0)
+          row(Array("asdfghjkl").map(String.init)).padding(.horizontal, 376 * layout.letterInsetRatio)
           HStack(spacing: 5) {
             key("⇧").frame(width: 38)
             row(Array("zxcvbnm").map(String.init))

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
@@ -168,7 +168,7 @@ final class KeyboardSkinMiniature: UIView {
     let gap: CGFloat = layout?.keySpacing ?? 4
     let height = (canvas.height - gap * 3) / 4
     for (rowIndex, row) in rows.enumerated() {
-      let inset: CGFloat = !nineKey && rowIndex == 1 && (layout?.centeredLetters ?? true) ? canvas.width * 0.04 : 0
+      let inset: CGFloat = !nineKey && rowIndex == 1 && (layout?.centeredLetters ?? true) ? canvas.width * (layout?.letterInsetRatio ?? 0.04) : 0
       let width = (canvas.width - inset * 2 - gap * CGFloat(row.count - 1)) / CGFloat(row.count)
       for (index, title) in row.enumerated() {
         let key = CGRect(x: inset + CGFloat(index) * (width + gap), y: CGFloat(rowIndex) * (height + gap), width: width, height: height)

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -1505,7 +1505,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private func updateLetterRowInsets() {
     guard letterRowViews.count > 1, let row = letterRowViews[1] as? UIStackView else { return }
     let inset = KeyboardLayoutPreference.selected.centeredLetters && inputScheme != .microsoft
-      ? max(0, view.bounds.width - 10) * 0.05 : 0
+      ? max(0, view.bounds.width - 10) * KeyboardLayoutPreference.selected.letterInsetRatio : 0
     let margins = UIEdgeInsets(top: 0, left: inset, bottom: 0, right: inset)
     if row.layoutMargins != margins {
       row.isLayoutMarginsRelativeArrangement = true

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -314,6 +314,29 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
+  func testSelectingLayoutsChangesActualNineKeyGeometry() throws {
+    let previousLayout = KeyboardLayoutPreference.selected
+    let previousScheme = InputSchemePreference.scheme
+    defer { KeyboardLayoutPreference.selected = previousLayout; InputSchemePreference.scheme = previousScheme }
+    InputSchemePreference.scheme = .nineKey
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 414, height: 260)
+    var widths: [CGFloat] = []
+    for layout in KeyboardLayoutPreset.allCases {
+      try button("layoutShortcut", in: controller).sendActions(for: .primaryActionTriggered)
+      try button("layoutCard-" + layout.rawValue, in: controller).sendActions(for: .primaryActionTriggered)
+      controller.view.layoutIfNeeded()
+      let key = try button("nineKey2", in: controller)
+      widths.append(key.bounds.width)
+      let shot = XCTAttachment(image: UIGraphicsImageRenderer(bounds: controller.view.bounds).image { controller.view.layer.render(in: $0.cgContext) })
+      shot.name = "Applied layout " + layout.rawValue; shot.lifetime = .keepAlways; add(shot)
+    }
+    for i in widths.indices { for j in widths.indices where j > i {
+      XCTAssertGreaterThan(abs(widths[i] - widths[j]), 1)
+    } }
+  }
+
   func testKeyboardLayoutCardsPersistAndKeepHeight() throws {
     let previous = KeyboardLayoutPreference.selected
     defer { KeyboardLayoutPreference.selected = previous }

--- a/platforms/ios/SharedUI/KeyboardLayoutPreference.swift
+++ b/platforms/ios/SharedUI/KeyboardLayoutPreference.swift
@@ -19,9 +19,10 @@ enum KeyboardLayoutPreset: String, CaseIterable {
     case .doubao: "紧凑键距，中英靠右，顶部直达语音结果"
     }
   }
-  var keySpacing: Double { self == .sogou || self == .doubao ? 5 : 6 }
-  var rowSpacing: Double { self == .sogou || self == .doubao ? 6 : 7 }
-  var sidebarRatio: Double { self == .msime ? 0.14 : 0.12 }
+  var keySpacing: Double { switch self { case .msime, .sogou: 6; case .wechat: 4; case .doubao: 3 } }
+  var rowSpacing: Double { switch self { case .msime: 7; case .sogou: 10; case .wechat: 8; case .doubao: 4 } }
+  var sidebarRatio: Double { switch self { case .msime: 0.14; case .sogou: 0.17; case .wechat: 0.11; case .doubao: 0.13 } }
+  var letterInsetRatio: Double { switch self { case .msime: 0; case .sogou: 0.07; case .wechat: 0.05; case .doubao: 0.025 } }
   var centeredLetters: Bool { self != .msime }
   var showsBottomLanguage: Bool { true }
   var showsFullKeyboardSymbols: Bool { self == .sogou }


### PR DESCRIPTION
Keyboard preset switches previously changed spacing by only one point and shared almost identical nine-key geometry. Give the four presets distinct sidebar widths, row/key spacing and letter insets, and use the selected insets in app/card previews.

Validation: all 30 native keyboard tests pass, including toolbar-driven preset switching that checks actual key-width changes, plus 9/26-key bounds checks at 320/414 points. Reviewed applied-layout screenshots; Release archive passes.
