### PR TITLE
fix(ios): 更新键盘布局配置测试断言

### DIFF
--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -536,14 +536,16 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
         self.assertIn("private var isChineseMode = true", controller)
-        self.assertIn("languageModeButton", controller)
+        self.assertIn("bottomLanguageButton", controller)
         self.assertIn("toggleInputMode", controller)
         self.assertIn("render(session.handleCharacter(character))", controller)
         self.assertIn("insertOwnText(output)", controller)
         self.assertIn("if !isChineseMode {\n      insertOwnText(symbol)", controller)
         self.assertIn("isChineseMode ? session.finishComposition() : session.cancel()", controller)
         self.assertIn('inputScheme == .japanese ? "日" : "中"', controller)
-        self.assertIn('languageModeButton.accessibilityIdentifier = "languageModeButton"', controller)
+        self.assertIn('bottomLanguageButton?.accessibilityIdentifier = "bottomLanguageKey"', controller)
+        self.assertIn("bottomLanguageButton?.configuration = configuration", controller)
+        self.assertIn("bottomLanguageButton?.isHidden = false", controller)
 
     def test_english_keyboard_supports_one_shot_shift_and_caps_lock(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
@@ -603,9 +605,12 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
         self.assertIn(
-            "space.widthAnchor.constraint(greaterThanOrEqualToConstant: 79.2)",
+            "space.widthAnchor.constraint(greaterThanOrEqualToConstant: 44)",
             controller,
         )
+        # Presets add bottom-row actions; keep Space's minimum small enough for
+        # narrow screens, including when applying a different preset at runtime.
+        self.assertIn("standardActionWidths[1].constant = 44", controller)
         self.assertIn(
             "delete.widthAnchor.constraint(equalToConstant: 44)",
             controller,


### PR DESCRIPTION
键盘布局更新后，配置测试仍检查旧的空格键最小宽度和顶部中英切换按钮，导致 develop 的 iOS Simulator CI 失败。更新断言以检查 44 点最小宽度、运行时布局应用以及底栏中英切换按钮。

验证：
- 干净 develop 基线复现两项失败。
- `python3 platforms/ios/tests/ProjectConfigurationTests.py`：45 项通过。
- `python3 platforms/ios/tests/DictionaryPackagingTests.py`：1 项通过。
- 完整模拟器构建和 UI 测试待 PR CI 验证。
