### PR TITLE
feat(ios): 将输入方案切换改为四列图标网格

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
@@ -1,96 +1,222 @@
 import UIKit
 
 final class KeyboardSchemePickerView: UIView {
-  init(selected: ChineseInputScheme, onSelect: @escaping (ChineseInputScheme) -> Void, onClose: @escaping () -> Void) {
+  private var glyphBorders: [(UILabel, Bool)] = []
+  private let accent = UIColor { $0.userInterfaceStyle == .dark
+    ? UIColor(red: 1, green: 0.62, blue: 0.28, alpha: 1)
+    : UIColor(red: 1, green: 0.47, blue: 0.10, alpha: 1) }
+
+  init(selected: ChineseInputScheme, isChineseMode: Bool = true,
+       onSelect: @escaping (ChineseInputScheme) -> Void,
+       onSelectEnglish: (() -> Void)? = nil,
+       onSelectSkin: ((KeyboardSkin) -> Void)? = nil,
+       onSettings: (() -> Void)? = nil,
+       onClose: @escaping () -> Void) {
     super.init(frame: .zero)
     accessibilityIdentifier = "keyboardSchemePicker"
     backgroundColor = .secondarySystemBackground
-    let skin = KeyboardSkinPreference.selected
-    let header = UILabel()
-    header.text = "选择输入方案"
-    header.font = .systemFont(ofSize: 17, weight: .semibold)
+
     let close = UIButton(type: .system)
-    close.setTitle("完成", for: .normal)
+    close.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+    close.tintColor = .label
+    close.accessibilityLabel = "返回键盘"
     close.accessibilityIdentifier = "closeSchemePicker"
     close.addAction(UIAction { _ in onClose() }, for: .primaryActionTriggered)
-    let scroll = UIScrollView()
-    let rows = UIStackView()
-    rows.axis = .vertical
-    rows.spacing = 10
-    let schemes = InputSchemePreference.enabledSchemes
-    for index in stride(from: 0, to: schemes.count, by: 2) {
-      let row = UIStackView()
-      row.spacing = 10
-      row.distribution = .fillEqually
-      for scheme in schemes[index..<min(index + 2, schemes.count)] {
-        let card = KeyboardKeyButton()
-        card.accessibilityIdentifier = "schemeCard-\(scheme.rawValue)"
-        card.accessibilityLabel = scheme.title
-        card.accessibilityValue = scheme == selected ? "已选中" : ""
-        if scheme == selected { card.accessibilityTraits.insert(.selected) }
-        card.backgroundColor = skin.background
-        card.layer.cornerRadius = 12
-        card.layer.borderWidth = scheme == selected ? 2 : 1
-        card.layer.borderColor = (scheme == selected ? UIColor.label : UIColor.separator).resolvedColor(with: traitCollection).cgColor
-        card.clipsToBounds = true
-        let title = UILabel()
-        title.text = scheme.title + (scheme == selected ? "  ✓" : "")
-        title.font = .systemFont(ofSize: 13, weight: .semibold)
-        title.textColor = skin.keyForeground
-        title.adjustsFontSizeToFitWidth = true
-        title.minimumScaleFactor = 0.75
-        let preview = KeyboardSkinMiniature(skin: skin, nineKey: scheme == .nineKey)
-        for child in [title, preview] {
-          child.isUserInteractionEnabled = false
-          child.translatesAutoresizingMaskIntoConstraints = false
-          card.addSubview(child)
-        }
-        let preferredWidth = preview.widthAnchor.constraint(equalTo: card.widthAnchor, constant: -14)
-        preferredWidth.priority = .defaultHigh
-        NSLayoutConstraint.activate([
-          preferredWidth,
-          preview.widthAnchor.constraint(lessThanOrEqualToConstant: 220),
-          preview.heightAnchor.constraint(equalTo: preview.widthAnchor, multiplier: KeyboardSkinMiniature.heightToWidthRatio),
-          preview.centerXAnchor.constraint(equalTo: card.centerXAnchor),
-          title.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 10),
-          title.topAnchor.constraint(equalTo: card.topAnchor, constant: 7),
-          title.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -8),
-          preview.leadingAnchor.constraint(greaterThanOrEqualTo: card.leadingAnchor, constant: 7),
-          preview.trailingAnchor.constraint(lessThanOrEqualTo: card.trailingAnchor, constant: -7),
-          preview.topAnchor.constraint(equalTo: card.topAnchor, constant: 29),
-          preview.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -7),
-        ])
-        card.addAction(UIAction { _ in onSelect(scheme) }, for: .primaryActionTriggered)
-        row.addArrangedSubview(card)
-      }
-      if row.arrangedSubviews.count == 1 { row.addArrangedSubview(UIView()) }
-      rows.addArrangedSubview(row)
+
+    let keyboardTab = UIButton(type: .system)
+    keyboardTab.setTitle("键盘", for: .normal)
+    keyboardTab.accessibilityIdentifier = "schemePickerKeyboardTab"
+    keyboardTab.accessibilityTraits.insert(.selected)
+    let themeTab = UIButton(type: .system)
+    themeTab.setTitle("主题", for: .normal)
+    themeTab.accessibilityIdentifier = "schemePickerThemeTab"
+    themeTab.isEnabled = onSelectSkin != nil
+    let tabs = UIStackView(arrangedSubviews: [keyboardTab, themeTab])
+    tabs.distribution = .fillEqually
+    tabs.backgroundColor = .systemBackground
+    tabs.layer.cornerRadius = 15
+    for button in [keyboardTab, themeTab] {
+      button.titleLabel?.font = .systemFont(ofSize: 13, weight: .semibold)
+      button.layer.cornerRadius = 15
+      button.setTitleColor(.label, for: .normal)
     }
-    for child in [header, close, scroll] {
+    keyboardTab.backgroundColor = accent
+    keyboardTab.setTitleColor(.white, for: .normal)
+
+    let settings = UIButton(type: .system)
+    settings.setImage(UIImage(systemName: "gearshape"), for: .normal)
+    settings.tintColor = .label
+    settings.accessibilityLabel = "键盘设置"
+    settings.accessibilityIdentifier = "schemePickerSettings"
+    settings.isEnabled = onSettings != nil
+    settings.addAction(UIAction { _ in onSettings?() }, for: .primaryActionTriggered)
+
+    let content = UIView()
+    let scroll = UIScrollView()
+    scroll.accessibilityIdentifier = "schemePickerScroll"
+    scroll.alwaysBounceVertical = false
+    scroll.delaysContentTouches = false
+    let panel = UIStackView()
+    panel.axis = .vertical
+    panel.spacing = 4
+    panel.backgroundColor = .systemBackground
+    panel.layer.cornerRadius = 18
+    panel.isLayoutMarginsRelativeArrangement = true
+    panel.layoutMargins = UIEdgeInsets(top: 6, left: 8, bottom: 6, right: 8)
+
+    var cards: [UIView] = InputSchemePreference.enabledSchemes.map { scheme in
+      let glyph: String
+      let badge: String
+      switch scheme {
+      case .quanpin: glyph = "拼"; badge = "26"
+      case .nineKey: glyph = "拼"; badge = "9"
+      case .shuangpin: glyph = "鹤"; badge = "双"
+      case .ziranma: glyph = "自"; badge = "双"
+      case .microsoft: glyph = "微"; badge = "双"
+      case .shoudao: glyph = "S"; badge = "双"
+      case .wubi: glyph = "五"; badge = "86"
+      case .japanese: glyph = "あ"; badge = "日"
+      case .thoughtfulReply: glyph = "聊"; badge = "AI"
+      }
+      return makeCard(title: scheme.title, glyph: glyph, badge: badge,
+        selected: isChineseMode && scheme == selected, identifier: "schemeCard-\(scheme.rawValue)") { onSelect(scheme) }
+    }
+    if let onSelectEnglish {
+      // English is a platform text mode, not a second persisted Engine scheme.
+      cards.insert(makeCard(title: "英文 26 键", glyph: "EN", badge: "26",
+        selected: !isChineseMode, identifier: "schemeEnglishCard", action: onSelectEnglish), at: min(2, cards.count))
+    }
+    for start in stride(from: 0, to: cards.count, by: 4) {
+      let row = UIStackView()
+      row.spacing = 4
+      row.distribution = .fillEqually
+      for card in cards[start..<min(start + 4, cards.count)] { row.addArrangedSubview(card) }
+      while row.arrangedSubviews.count < 4 { row.addArrangedSubview(UIView()) }
+      panel.addArrangedSubview(row)
+      row.heightAnchor.constraint(equalToConstant: 62).isActive = true
+    }
+
+    for child in [close, tabs, settings, content] {
       child.translatesAutoresizingMaskIntoConstraints = false
       addSubview(child)
     }
-    rows.translatesAutoresizingMaskIntoConstraints = false
-    scroll.addSubview(rows)
+    scroll.translatesAutoresizingMaskIntoConstraints = false
+    panel.translatesAutoresizingMaskIntoConstraints = false
+    content.addSubview(scroll)
+    scroll.addSubview(panel)
     NSLayoutConstraint.activate([
-      header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-      header.topAnchor.constraint(equalTo: topAnchor),
-      header.heightAnchor.constraint(equalToConstant: 40),
-      close.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+      close.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
       close.topAnchor.constraint(equalTo: topAnchor),
-      close.heightAnchor.constraint(equalToConstant: 40),
-      close.widthAnchor.constraint(equalToConstant: 56),
-      scroll.topAnchor.constraint(equalTo: header.bottomAnchor),
-      scroll.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
-      scroll.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
-      scroll.bottomAnchor.constraint(equalTo: bottomAnchor),
-      rows.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
-      rows.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
-      rows.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
-      rows.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor, constant: -10),
-      rows.widthAnchor.constraint(equalTo: scroll.frameLayoutGuide.widthAnchor),
+      close.widthAnchor.constraint(equalToConstant: 44), close.heightAnchor.constraint(equalToConstant: 44),
+      settings.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+      settings.topAnchor.constraint(equalTo: topAnchor),
+      settings.widthAnchor.constraint(equalToConstant: 44), settings.heightAnchor.constraint(equalToConstant: 44),
+      tabs.centerXAnchor.constraint(equalTo: centerXAnchor), tabs.centerYAnchor.constraint(equalTo: close.centerYAnchor),
+      tabs.widthAnchor.constraint(equalToConstant: 150), tabs.heightAnchor.constraint(equalToConstant: 30),
+      tabs.leadingAnchor.constraint(greaterThanOrEqualTo: close.trailingAnchor, constant: 8),
+      tabs.trailingAnchor.constraint(lessThanOrEqualTo: settings.leadingAnchor, constant: -8),
+      content.topAnchor.constraint(equalTo: close.bottomAnchor),
+      content.leadingAnchor.constraint(equalTo: leadingAnchor), content.trailingAnchor.constraint(equalTo: trailingAnchor),
+      content.bottomAnchor.constraint(equalTo: bottomAnchor),
+      scroll.topAnchor.constraint(equalTo: content.topAnchor), scroll.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+      scroll.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 14),
+      scroll.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -14),
+      panel.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+      panel.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor, constant: -10),
+      panel.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+      panel.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+      panel.widthAnchor.constraint(equalTo: scroll.frameLayoutGuide.widthAnchor),
     ])
+    let showTab: (Bool) -> Void = { [weak content, weak scroll, weak keyboardTab, weak themeTab, weak self] showThemes in
+      guard let self, let content, let scroll, let keyboardTab, let themeTab else { return }
+      scroll.isHidden = showThemes
+      keyboardTab.backgroundColor = showThemes ? .clear : accent
+      themeTab.backgroundColor = showThemes ? accent : .clear
+      keyboardTab.setTitleColor(showThemes ? .label : .white, for: .normal)
+      themeTab.setTitleColor(showThemes ? .white : .label, for: .normal)
+      keyboardTab.accessibilityTraits = showThemes ? [.button] : [.button, .selected]
+      themeTab.accessibilityTraits = showThemes ? [.button, .selected] : [.button]
+      content.subviews.filter { $0 !== scroll }.forEach { $0.removeFromSuperview() }
+      if showThemes, let onSelectSkin {
+        let themes = KeyboardSkinPickerView(selected: KeyboardSkinPreference.selected,
+          showsHeader: false, onSelect: onSelectSkin, onClose: onClose)
+        themes.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(themes)
+        NSLayoutConstraint.activate([
+          themes.leadingAnchor.constraint(equalTo: content.leadingAnchor), themes.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+          themes.topAnchor.constraint(equalTo: content.topAnchor), themes.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+        ])
+      }
+    }
+    keyboardTab.addAction(UIAction { _ in showTab(false) }, for: .primaryActionTriggered)
+    themeTab.addAction(UIAction { _ in showTab(true) }, for: .primaryActionTriggered)
+  }
+
+  private func makeCard(title: String, glyph: String, badge: String, selected: Bool,
+                        identifier: String, action: @escaping () -> Void) -> UIButton {
+    let card = KeyboardKeyButton()
+    card.accessibilityIdentifier = identifier
+    card.accessibilityLabel = title
+    card.accessibilityValue = selected ? "已选中" : ""
+    if selected { card.accessibilityTraits.insert(.selected) }
+    card.layer.cornerRadius = 13
+    card.backgroundColor = selected ? accent.withAlphaComponent(0.10) : .clear
+    let color: UIColor = selected ? accent : .label
+    let symbol = UILabel()
+    symbol.text = glyph
+    symbol.textAlignment = .center
+    symbol.font = .systemFont(ofSize: glyph.count > 1 ? 15 : 20, weight: .semibold)
+    symbol.textColor = color
+    symbol.layer.cornerRadius = 4
+    symbol.layer.borderWidth = 1.7
+    symbol.layer.borderColor = color.resolvedColor(with: traitCollection).cgColor
+    glyphBorders.append((symbol, selected))
+    let suffix = UILabel()
+    suffix.text = badge
+    suffix.font = .systemFont(ofSize: 9, weight: .bold)
+    suffix.textAlignment = .center
+    suffix.textColor = color
+    suffix.backgroundColor = .systemBackground
+    let label = UILabel()
+    label.text = title
+    label.textAlignment = .center
+    label.numberOfLines = 1
+    label.font = .systemFont(ofSize: 12)
+    label.adjustsFontSizeToFitWidth = true
+    label.minimumScaleFactor = 0.65
+    label.textColor = color
+    let check = UIImageView(image: UIImage(systemName: "checkmark.circle.fill"))
+    check.tintColor = accent
+    check.backgroundColor = .systemBackground
+    check.layer.cornerRadius = 6
+    check.isHidden = !selected
+    for child in [symbol, suffix, label, check] {
+      child.translatesAutoresizingMaskIntoConstraints = false
+      child.isUserInteractionEnabled = false
+      child.isAccessibilityElement = false
+      card.addSubview(child)
+    }
+    NSLayoutConstraint.activate([
+      symbol.topAnchor.constraint(equalTo: card.topAnchor, constant: 8), symbol.centerXAnchor.constraint(equalTo: card.centerXAnchor),
+      symbol.widthAnchor.constraint(equalToConstant: 27), symbol.heightAnchor.constraint(equalToConstant: 27),
+      suffix.trailingAnchor.constraint(equalTo: symbol.trailingAnchor, constant: 4), suffix.bottomAnchor.constraint(equalTo: symbol.bottomAnchor, constant: 3),
+      suffix.widthAnchor.constraint(equalToConstant: 16), suffix.heightAnchor.constraint(equalToConstant: 12),
+      label.topAnchor.constraint(equalTo: symbol.bottomAnchor, constant: 6),
+      label.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 2), label.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -2),
+      label.bottomAnchor.constraint(lessThanOrEqualTo: card.bottomAnchor, constant: -4),
+      check.leadingAnchor.constraint(equalTo: symbol.trailingAnchor, constant: 1), check.topAnchor.constraint(equalTo: symbol.topAnchor, constant: -3),
+      check.widthAnchor.constraint(equalToConstant: 12), check.heightAnchor.constraint(equalToConstant: 12),
+    ])
+    card.addAction(UIAction { _ in action() }, for: .primaryActionTriggered)
+    return card
   }
 
   required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    for (label, selected) in glyphBorders {
+      label.layer.borderColor = (selected ? accent : UIColor.label).resolvedColor(with: traitCollection).cgColor
+    }
+  }
 }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSkinPickerView.swift
@@ -1,15 +1,17 @@
 import UIKit
 
 final class KeyboardSkinPickerView: UIView {
-  init(selected: KeyboardSkin, onSelect: @escaping (KeyboardSkin) -> Void, onClose: @escaping () -> Void) {
+  init(selected: KeyboardSkin, showsHeader: Bool = true, onSelect: @escaping (KeyboardSkin) -> Void, onClose: @escaping () -> Void) {
     super.init(frame: .zero)
     accessibilityIdentifier = "keyboardSkinPicker"
     backgroundColor = .secondarySystemBackground
     let header = UILabel()
     header.text = "选择皮肤"
+    header.isHidden = !showsHeader
     header.font = .systemFont(ofSize: 17, weight: .semibold)
     let close = UIButton(type: .system)
     close.setTitle("完成", for: .normal)
+    close.isHidden = !showsHeader
     close.accessibilityIdentifier = "closeSkinPicker"
     close.addAction(UIAction { _ in onClose() }, for: .primaryActionTriggered)
     let scroll = UIScrollView()
@@ -116,7 +118,7 @@ final class KeyboardSkinPickerView: UIView {
     NSLayoutConstraint.activate([
       header.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
       header.topAnchor.constraint(equalTo: topAnchor),
-      header.heightAnchor.constraint(equalToConstant: 40),
+      header.heightAnchor.constraint(equalToConstant: showsHeader ? 40 : 0),
       close.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
       close.topAnchor.constraint(equalTo: topAnchor),
       close.heightAnchor.constraint(equalToConstant: 40),

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -2044,10 +2044,23 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private func showSchemePicker() {
     closeKeyboardService()
     closeKeyboardPicker()
-    let picker = KeyboardSchemePickerView(selected: inputScheme, onSelect: { [weak self] scheme in
+    let picker = KeyboardSchemePickerView(selected: inputScheme, isChineseMode: isChineseMode, onSelect: { [weak self] scheme in
       guard let self else { return }
       closeKeyboardPicker()
+      if !isChineseMode { toggleInputMode() }
       selectInputScheme(scheme)
+    }, onSelectEnglish: { [weak self] in
+      guard let self else { return }
+      closeKeyboardPicker()
+      if isChineseMode { toggleInputMode() }
+    }, onSelectSkin: { [weak self] skin in
+      guard let self else { return }
+      KeyboardFeedbackPreference.defaults.set(skin.rawValue, forKey: KeyboardSkinPreference.key)
+      closeKeyboardPicker()
+      applyKeyboardSkin()
+      playInputClick()
+    }, onSettings: { [weak self] in
+      self?.showMorePicker()
     }, onClose: { [weak self] in self?.closeKeyboardPicker() })
     picker.accessibilityViewIsModal = true
     picker.translatesAutoresizingMaskIntoConstraints = false

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -405,16 +405,24 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
-  func testWidePickerCardsPreservePreviewAspectRatio() throws {
-    for nineKey in [false, true] {
-      let picker = KeyboardSchemePickerView(selected: nineKey ? .nineKey : .quanpin, onSelect: { _ in }, onClose: {})
-      picker.frame = CGRect(x: 0, y: 0, width: 812, height: 216)
+  func testSchemeGridHasFourColumnsAtNarrowAndWideSizes() throws {
+    for width in [320.0, 414.0, 812.0] {
+      let picker = KeyboardSchemePickerView(selected: .nineKey, onSelect: { _ in }, onClose: {})
+      picker.frame = CGRect(x: 0, y: 0, width: width, height: width > 500 ? 216 : 260)
       picker.layoutIfNeeded()
-      for miniature in descendants(picker).compactMap({ $0 as? KeyboardSkinMiniature }) {
-        XCTAssertEqual(miniature.bounds.height / miniature.bounds.width, 0.6, accuracy: 0.01)
-        XCTAssertLessThanOrEqual(miniature.bounds.width, 220)
-        XCTAssertLessThanOrEqual(try XCTUnwrap(miniature.superview).bounds.height, 176)
+      let cards = descendants(picker).filter { $0.accessibilityIdentifier?.hasPrefix("schemeCard-") == true }
+      XCTAssertGreaterThanOrEqual(cards.count, 4)
+      let firstRow = cards.prefix(4).map { $0.convert($0.bounds, to: picker) }
+      for frame in firstRow {
+        XCTAssertEqual(frame.minY, firstRow[0].minY, accuracy: 0.1)
+        XCTAssertEqual(frame.width, firstRow[0].width, accuracy: 0.5)
+        XCTAssertGreaterThanOrEqual(frame.width, 60)
+        XCTAssertGreaterThanOrEqual(frame.height, 44)
+        XCTAssertGreaterThanOrEqual(frame.minX, 14)
+        XCTAssertLessThanOrEqual(frame.maxX, width - 14)
       }
+      XCTAssertEqual(Set(firstRow.map { $0.minX }).count, 4)
+      XCTAssertTrue(descendants(picker).compactMap { $0 as? KeyboardSkinMiniature }.isEmpty)
     }
   }
 
@@ -433,11 +441,8 @@ final class NineKeyKeyboardTests: XCTestCase {
       XCTAssertEqual(picker.bounds.height, 260)
       for scheme in ChineseInputScheme.allCases {
         let card = try button("schemeCard-\(scheme.rawValue)", in: controller)
-        XCTAssertGreaterThan(card.bounds.width, 140)
-        let miniature = try XCTUnwrap(descendants(card).compactMap { $0 as? KeyboardSkinMiniature }.first)
-        XCTAssertGreaterThan(miniature.bounds.height, 75)
-        XCTAssertEqual(miniature.bounds.height / miniature.bounds.width, 0.6, accuracy: 0.01)
-        XCTAssertEqual(card.bounds.height, miniature.bounds.height + 36, accuracy: 0.1)
+        XCTAssertGreaterThanOrEqual(card.bounds.width, 60)
+        XCTAssertEqual(card.bounds.height, 62, accuracy: 0.1)
       }
       XCTAssertEqual(try button("schemeCard-nineKey", in: controller).accessibilityValue, "已选中")
       let attachment = XCTAttachment(image: UIGraphicsImageRenderer(bounds: controller.view.bounds).image { context in
@@ -458,6 +463,33 @@ final class NineKeyKeyboardTests: XCTestCase {
       XCTAssertFalse(descendants(controller.view).contains { $0.accessibilityIdentifier == "keyboardSchemePicker" })
       XCTAssertEqual(InputSchemePreference.scheme, .quanpin)
     }
+  }
+
+  func testSchemePickerSwitchesEnglishThemesAndSettings() throws {
+    let previous = InputSchemePreference.scheme
+    defer { InputSchemePreference.scheme = previous }
+    InputSchemePreference.scheme = .quanpin
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 393, height: 260)
+    controller.view.layoutIfNeeded()
+    try button("schemeButton", in: controller).sendActions(for: .primaryActionTriggered)
+    try button("schemeEnglishCard", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(try button("bottomLanguageKey", in: controller).accessibilityValue, "英文输入")
+    try button("schemeButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(try button("schemeEnglishCard", in: controller).accessibilityValue, "已选中")
+    XCTAssertEqual(try button("schemeCard-quanpin", in: controller).accessibilityValue, "")
+    try button("schemeCard-quanpin", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(try button("bottomLanguageKey", in: controller).accessibilityValue, "中文输入")
+    try button("schemeButton", in: controller).sendActions(for: .primaryActionTriggered)
+    try button("schemePickerThemeTab", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertTrue(descendants(controller.view).contains { $0 is KeyboardSkinPickerView })
+    try button("schemePickerKeyboardTab", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertFalse(descendants(controller.view).contains { $0 is KeyboardSkinPickerView })
+    XCTAssertEqual(try button("schemeCard-quanpin", in: controller).accessibilityValue, "已选中")
+    try button("schemePickerSettings", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertFalse(descendants(controller.view).contains { $0 is KeyboardSchemePickerView })
+    XCTAssertTrue(descendants(controller.view).contains { $0.accessibilityIdentifier == "keyboardMorePicker" })
   }
 
   func testVisibleInputViewReflectsSoundPreference() throws {


### PR DESCRIPTION
将键盘输入方案选择从两列缩略键盘卡片改为四列图标网格，提供橙色选中态和顶部「键盘 / 主题」切换。正常键盘高度内完整显示三行选项，窄屏、横屏可保持触摸区域并滚动。

新增英文入口，选择中文方案时恢复中文模式；主题页复用现有皮肤选择，设置入口打开键盘设置面板。仅显示已启用的受支持方案，不新增输入算法。

验证：
- 31 项 NineKeyKeyboardTests 原生模拟器测试通过，覆盖四列布局、方案切换、键盘高度、英文、主题和设置入口。
- 320/414 点截图已检查；网格几何检查覆盖 320/414/812 点。
- 同步最新 develop（含 #357）后，45 项 ProjectConfigurationTests、1 项 DictionaryPackagingTests 通过；31 项原生键盘测试复跑通过。
- 未进行真机或 TestFlight 验证。
