### PR TITLE
ci(release): 合入 main 仅递增 build，保留产品版本号

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,18 @@ on:
     inputs:
       tag:
         description: Existing draft release tag to build and publish
-        required: true
+        required: false
         type: string
+      bump_version:
+        description: Prepare and publish the next semantic version with release-please (leave tag empty)
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.event_name }}-${{ github.ref }}
+  group: release-main
   cancel-in-progress: false
 
 jobs:
@@ -29,17 +33,63 @@ jobs:
       issues: write
       pull-requests: write
     outputs:
-      should_publish: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.release_created == 'true' || steps.finalized_release.outputs.release_created == 'true' || steps.finalized_promoted_release.outputs.release_created == 'true' }}
-      tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || steps.finalized_promoted_release.outputs.tag_name || steps.finalized_release.outputs.tag_name || steps.release.outputs.tag_name }}
-      target_sha: ${{ github.event_name == 'workflow_dispatch' && steps.requested_release.outputs.target_sha || steps.promote_release_commit.outputs.target_sha || steps.finalized_release.outputs.sha || steps.release.outputs.sha }}
+      should_publish: ${{ (github.event_name == 'workflow_dispatch' && !inputs.bump_version) || steps.build_release.outputs.release_created == 'true' || steps.release.outputs.release_created == 'true' || steps.finalized_release.outputs.release_created == 'true' || steps.finalized_promoted_release.outputs.release_created == 'true' }}
+      tag_name: ${{ steps.build_release.outputs.tag_name || (!inputs.bump_version && inputs.tag) || steps.finalized_promoted_release.outputs.tag_name || steps.finalized_release.outputs.tag_name || steps.release.outputs.tag_name }}
+      target_sha: ${{ steps.build_release.outputs.target_sha || steps.requested_release.outputs.target_sha || steps.promote_release_commit.outputs.target_sha || steps.finalized_release.outputs.sha || steps.release.outputs.sha }}
+      build_number: ${{ steps.build_number.outputs.value }}
     steps:
+      - name: Validate invocation
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+          BUMP_VERSION: ${{ inputs.bump_version }}
+        run: |
+          test "$GITHUB_REF" = refs/heads/main
+          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
+            if [[ "$BUMP_VERSION" == true ]]; then
+              test -z "$REQUESTED_TAG"
+            else
+              test -n "$REQUESTED_TAG"
+            fi
+          fi
+      - name: Allocate build number
+        id: build_number
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          # Start above the legacy iOS commit-count builds (491 at migration).
+          # Three numeric components; retries receive a distinct build, up to 99 attempts.
+          test "$GITHUB_RUN_ATTEMPT" -lt 100
+          build="$((1000 + GITHUB_RUN_NUMBER / 100)).$((GITHUB_RUN_NUMBER % 100)).$GITHUB_RUN_ATTEMPT"
+          if [[ "$REQUESTED_TAG" == *-build.* ]]; then
+            build="${REQUESTED_TAG##*-build.}"
+          fi
+          if [[ ! "$build" =~ ^[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+            echo "Invalid build number: $build" >&2
+            exit 1
+          fi
+          printf 'value=%s\n' "$build" >> "$GITHUB_OUTPUT"
       - name: Check out release automation
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Capture existing release branch
+      - name: Create automatic build draft
         if: ${{ github.event_name == 'push' }}
+        id: build_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BUILD_NUMBER: ${{ steps.build_number.outputs.value }}
+        run: |
+          version=$(cat version.txt)
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version.txt" >&2
+            exit 1
+          fi
+          tag="v$version-build.$BUILD_NUMBER"
+          gh release create "$tag" --target "$GITHUB_SHA" --title "$tag" --generate-notes --draft --prerelease
+          printf 'release_created=true\ntag_name=%s\ntarget_sha=%s\n' "$tag" "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+      - name: Capture existing release branch
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump_version) }}
         id: release_branch_before
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,7 +103,7 @@ jobs:
           fi
           printf 'sha=%s\n' "$sha" >> "$GITHUB_OUTPUT"
       - name: Prepare release
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump_version) }}
         id: release
         continue-on-error: true
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
@@ -62,7 +112,7 @@ jobs:
           # A pull request opened with GITHUB_TOKEN is authored by github-actions[bot], and its pull_request CI run is parked in action_required until a maintainer approves it, so it expires and shows a red check. RELEASE_PLEASE_TOKEN, when set, makes the pull request come from a real account and CI runs on its own.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Test and merge release pull request
-        if: ${{ github.event_name == 'push' && steps.release.outputs.prs_created == 'true' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump_version) && steps.release.outputs.prs_created == 'true' }}
         id: merge_release_pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +120,7 @@ jobs:
           RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: bash platforms/macos/scripts/merge-release-pr.sh
       - name: Promote validated release commit when pull requests are blocked
-        if: ${{ github.event_name == 'push' && steps.release.outcome == 'failure' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump_version) && steps.release.outcome == 'failure' }}
         id: promote_release_commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +129,7 @@ jobs:
           EXPECTED_PREVIOUS_RELEASE_SHA: ${{ steps.release_branch_before.outputs.sha }}
         run: bash platforms/macos/scripts/promote-release-branch.sh
       - name: Finalize automated release
-        if: ${{ github.event_name == 'push' && steps.merge_release_pr.outputs.merged == 'true' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump_version) && steps.merge_release_pr.outputs.merged == 'true' }}
         id: finalized_release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
@@ -87,7 +137,7 @@ jobs:
           # A pull request opened with GITHUB_TOKEN is authored by github-actions[bot], and its pull_request CI run is parked in action_required until a maintainer approves it, so it expires and shows a red check. RELEASE_PLEASE_TOKEN, when set, makes the pull request come from a real account and CI runs on its own.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Create draft release for promoted commit
-        if: ${{ github.event_name == 'push' && steps.promote_release_commit.outputs.promoted == 'true' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump_version) && steps.promote_release_commit.outputs.promoted == 'true' }}
         id: finalized_promoted_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,15 +146,15 @@ jobs:
           TAG_NAME: ${{ steps.promote_release_commit.outputs.tag_name }}
         run: bash platforms/macos/scripts/create-promoted-release.sh
       - name: Validate requested draft release
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.bump_version }}
         id: requested_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ inputs.tag }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Tag must use the vMAJOR.MINOR.PATCH format." >&2
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+            echo "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
             exit 1
           fi
           release_json=$(gh release view "$TAG_NAME" --json isDraft,targetCommitish)
@@ -120,7 +170,7 @@ jobs:
           fi
           target_sha=$target
           version=$(gh api "repos/$GH_REPO/contents/version.txt?ref=$target_sha" --jq .content | base64 --decode)
-          if [[ "$TAG_NAME" != "v$version" ]]; then
+          if [[ "${TAG_NAME%%-build.*}" != "v$version" ]]; then
             echo "Release $TAG_NAME does not match version.txt ($version)." >&2
             exit 1
           fi
@@ -133,6 +183,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     env:
+      METASEQUOIA_BUILD_NUMBER: ${{ needs.prepare.outputs.build_number }}
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     permissions:
       contents: write
@@ -220,7 +271,7 @@ jobs:
       - name: Fetch the locked dictionary
         run: python3 scripts/fetch_dictionary.py
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
+        run: cmake -S . -B build -DMETASEQUOIA_BUILD_NUMBER="$METASEQUOIA_BUILD_NUMBER" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(brew --prefix)"
       - name: Build
         run: cmake --build build --parallel
       - name: Test
@@ -236,7 +287,9 @@ jobs:
             echo 'Unsigned release: skipping Developer ID signature verification before packaging.'
           fi
           lipo build/MetasequoiaIME.app/Contents/MacOS/MetasequoiaIME -verify_arch arm64 x86_64
-          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' build/MetasequoiaIME.app/Contents/Info.plist)" = "${TAG_NAME#v}"
+          version=${TAG_NAME#v}
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' build/MetasequoiaIME.app/Contents/Info.plist)" = "${version%%-build.*}"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' build/MetasequoiaIME.app/Contents/Info.plist)" = "$METASEQUOIA_BUILD_NUMBER"
       - name: Package release
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,5 @@ macOS 每次 Engine 动作完成后更新值快照；候选选择必须用当前
 高亮候选的自动提交调用 Session::finish(index)，剩余分段仍由 Engine 完成。
 
 iOS 个人词库通过 Engine `<metasequoia/personal_dictionary.h>` 校验和编辑；SharedUI 同步文件仅传递用户操作、确认和分页快照，不复制拼音解析或 SQL。键盘仅在完全访问开启且会话空闲时处理队列，写入前释放会话，完成后保留方案、九键和学习偏好重建。操作 UUID 作为 Engine 事务回执 ID，确认文件写入中断后的重试必须复用它。
+
+发布构建：push 到 main 保留 version.txt 的语义版本，仅递增独立 build，以 v<version>-build.<build> 发布 Pre-release。正式升版本通过 release.yml 的 workflow_dispatch（bump_version=true、tag 留空）调用 release-please；tag 输入用于发布已有 draft。macOS、iOS 和 Sparkle 使用同一 METASEQUOIA_BUILD_NUMBER，安装器版本也使用 build。正式发布后仍须将 main 回合到 develop。

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "Minimum supported macOS ver
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "macOS target architectures")
 
 project(MetasequoiaImeApple VERSION 0.48.6 LANGUAGES CXX OBJCXX) # x-release-please-version
+set(METASEQUOIA_BUILD_NUMBER "${PROJECT_VERSION}" CACHE STRING "Bundle build number supplied by release CI")
 
 include(CTest)
 
@@ -253,7 +254,7 @@ if(METASEQUOIA_IME_BUILD_INPUT_METHOD)
         PROPERTIES MACOSX_PACKAGE_LOCATION Resources/Licenses)
     set_source_files_properties(${METASEQUOIA_IME_UNINSTALLER}
         PROPERTIES MACOSX_PACKAGE_LOCATION Resources HEADER_FILE_ONLY TRUE)
-    set_target_properties(MetasequoiaIME PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_BINARY_DIR}/MetasequoiaIME-Info.plist MACOSX_BUNDLE_BUNDLE_NAME "Metasequoia IME" MACOSX_BUNDLE_GUI_IDENTIFIER "com.houko.inputmethod.MetasequoiaIME" MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION} MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION} OUTPUT_NAME MetasequoiaIME BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH "@executable_path/../Frameworks")
+    set_target_properties(MetasequoiaIME PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_BINARY_DIR}/MetasequoiaIME-Info.plist MACOSX_BUNDLE_BUNDLE_NAME "Metasequoia IME" MACOSX_BUNDLE_GUI_IDENTIFIER "com.houko.inputmethod.MetasequoiaIME" MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION} MACOSX_BUNDLE_BUNDLE_VERSION ${METASEQUOIA_BUILD_NUMBER} OUTPUT_NAME MetasequoiaIME BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH "@executable_path/../Frameworks")
     target_compile_options(MetasequoiaIME PRIVATE -fobjc-arc -Wall -Wextra -Wpedantic -Werror)
     target_link_libraries(MetasequoiaIME PRIVATE MSIMEBackendAccount MetasequoiaMacDictionaryRuntime MetasequoiaAppleVoice MetasequoiaIme::Engine MetasequoiaSparkle ${APPKIT_FRAMEWORK} ${CARBON_FRAMEWORK} ${INPUT_METHOD_KIT_FRAMEWORK})
     add_custom_command(TARGET MetasequoiaIME POST_BUILD

--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -23,11 +23,12 @@ if [[ "$output_dir" != /* ]]; then
     output_dir="$(pwd)/$output_dir"
 fi
 
-if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    printf '%s\n' "Tag must use the vMAJOR.MINOR.PATCH format." >&2
+if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+    printf '%s\n' "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
     exit 1
 fi
 version=${tag_name#v}
+version=${version%%-build.*}
 
 for tool in git xcodegen xcodebuild ditto shasum; do
     if ! command -v "$tool" >/dev/null 2>&1; then
@@ -39,15 +40,27 @@ done
 # This archive is what a maintainer opens in Xcode Organizer to push to TestFlight, so it needs the
 # same build number rule as the signed path: unique and increasing within one marketing version,
 # rather than a copy of the marketing version that allows only one build per release.
-if ! git -C "$project_root" rev-parse --git-dir >/dev/null 2>&1; then
-    printf 'Not a git checkout, so the build number cannot be derived: %s\n' "$project_root" >&2
-    exit 1
+# CI supplies the shared build. Keep commit-count builds for local legacy packaging.
+if [[ -n "${METASEQUOIA_BUILD_NUMBER:-}" || "$tag_name" == *-build.* ]]; then
+    build_number=${METASEQUOIA_BUILD_NUMBER:-}
+    if [[ "$tag_name" == *-build.* ]]; then
+        build_number=${tag_name##*-build.}
+        if [[ "${METASEQUOIA_BUILD_NUMBER:-$build_number}" != "$build_number" ]]; then
+            printf '%s\n' "Build number does not match release tag." >&2
+            exit 1
+        fi
+    fi
+else
+    if ! git -C "$project_root" rev-parse --git-dir >/dev/null 2>&1; then
+        printf 'Not a git checkout, so the build number cannot be derived: %s\n' "$project_root" >&2
+        exit 1
+    fi
+    if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]; then
+        printf 'Refusing to build from a shallow checkout: the commit count would restart low and App Store Connect would reject the build as a downgrade. Check out with fetch-depth: 0.\n' >&2
+        exit 1
+    fi
+    build_number=$(git -C "$project_root" rev-list --count HEAD)
 fi
-if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]; then
-    printf 'Refusing to build from a shallow checkout: the commit count would restart low and App Store Connect would reject the build as a downgrade. Check out with fetch-depth: 0.\n' >&2
-    exit 1
-fi
-build_number=$(git -C "$project_root" rev-list --count HEAD)
 
 # TestFlight groups builds by CFBundleShortVersionString and reviews each group on its own, so
 # carrying the patch digit here bought a fresh Beta App Review for every release. iOS ships x.y and
@@ -113,13 +126,20 @@ if [[ ! -s "$extension/msime.db" ]]; then
     exit 1
 fi
 
+# Verify both targets before distributing the archive.
+for bundle in "$archive_path/Products/Applications/MetasequoiaIME.app" \
+    "$archive_path/Products/Applications/MetasequoiaIME.app/PlugIns/MetasequoiaKeyboard.appex"; do
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$bundle/Info.plist")" = "$build_number"
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$bundle/Info.plist")" = "$marketing_version"
+done
+
 archive_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$application/Info.plist")
-if [[ "$archive_version" != "$version" ]]; then
+if [[ "$archive_version" != "$marketing_version" ]]; then
     printf 'Archive version %s does not match tag %s.\n' "$archive_version" "$tag_name" >&2
     exit 1
 fi
 extension_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$extension/Info.plist")
-if [[ "$extension_version" != "$version" ]]; then
+if [[ "$extension_version" != "$marketing_version" ]]; then
     printf 'Keyboard extension version %s does not match tag %s.\n' "$extension_version" "$tag_name" >&2
     exit 1
 fi

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -15,8 +15,8 @@ tag_name=${1:-}
 : "${METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH:?METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH is required}"
 : "${METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH:?METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH is required}"
 
-if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    printf '%s\n' 'Tag must use the vMAJOR.MINOR.PATCH format.' >&2
+if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+    printf '%s\n' 'Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix.' >&2
     exit 1
 fi
 if [[ ! -s "$METASEQUOIA_IOS_AUTH_KEY_PATH" ]]; then
@@ -51,21 +51,34 @@ if [[ ! -s "$dictionary" ]]; then
 fi
 
 version=${tag_name#v}
+version=${version%%-build.*}
 
 # CFBundleVersion has to be unique and strictly increasing within one CFBundleShortVersionString.
 # Deriving it from the marketing version left exactly one possible build per release, so a build that
 # failed Beta App Review could not be replaced without cutting another release -- and every new
 # marketing version starts a fresh TestFlight version train that needs its own review. The commit
 # count is monotonic and reproducible from the checkout alone.
-if ! git -C "$project_root" rev-parse --git-dir >/dev/null 2>&1; then
-    printf 'Not a git checkout, so the build number cannot be derived: %s\n' "$project_root" >&2
-    exit 1
+# CI supplies the shared build. Keep commit-count builds for local legacy packaging.
+if [[ -n "${METASEQUOIA_BUILD_NUMBER:-}" || "$tag_name" == *-build.* ]]; then
+    build_number=${METASEQUOIA_BUILD_NUMBER:-}
+    if [[ "$tag_name" == *-build.* ]]; then
+        build_number=${tag_name##*-build.}
+        if [[ "${METASEQUOIA_BUILD_NUMBER:-$build_number}" != "$build_number" ]]; then
+            printf '%s\n' "Build number does not match release tag." >&2
+            exit 1
+        fi
+    fi
+else
+    if ! git -C "$project_root" rev-parse --git-dir >/dev/null 2>&1; then
+        printf 'Not a git checkout, so the build number cannot be derived: %s\n' "$project_root" >&2
+        exit 1
+    fi
+    if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]; then
+        printf 'Refusing to build from a shallow checkout: the commit count would restart low and App Store Connect would reject the build as a downgrade. Check out with fetch-depth: 0.\n' >&2
+        exit 1
+    fi
+    build_number=$(git -C "$project_root" rev-list --count HEAD)
 fi
-if [[ "$(git -C "$project_root" rev-parse --is-shallow-repository)" == "true" ]]; then
-    printf 'Refusing to build from a shallow checkout: the commit count would restart low and App Store Connect would reject the build as a downgrade. Check out with fetch-depth: 0.\n' >&2
-    exit 1
-fi
-build_number=$(git -C "$project_root" rev-list --count HEAD)
 
 # TestFlight groups builds by CFBundleShortVersionString and reviews each group on its own, so
 # carrying the patch digit here bought a fresh Beta App Review for every release. iOS ships x.y and
@@ -127,6 +140,13 @@ if [[ ! -d "$application" || ! -d "$extension" ]]; then
     printf '%s\n' 'Signed archive is missing the host application or keyboard extension.' >&2
     exit 1
 fi
+
+# Verify both targets before distributing the archive.
+for bundle in "$archive_path/Products/Applications/MetasequoiaIME.app" \
+    "$archive_path/Products/Applications/MetasequoiaIME.app/PlugIns/MetasequoiaKeyboard.appex"; do
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$bundle/Info.plist")" = "$build_number"
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$bundle/Info.plist")" = "$marketing_version"
+done
 
 export_options="$build_root/ExportOptions.plist"
 cat > "$export_options" <<EOF

--- a/platforms/macos/resources/Info.plist
+++ b/platforms/macos/resources/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundleShortVersionString</key>
     <string>@PROJECT_VERSION@</string>
     <key>CFBundleVersion</key>
-    <string>@PROJECT_VERSION@</string>
+    <string>@METASEQUOIA_BUILD_NUMBER@</string>
     <key>ComponentInputModeDict</key>
     <dict>
         <key>tsInputModeListKey</key>

--- a/platforms/macos/scripts/generate-sparkle-appcast.sh
+++ b/platforms/macos/scripts/generate-sparkle-appcast.sh
@@ -9,8 +9,8 @@ tag_name=${1:-}
 archive_path=${2:-}
 output_path=${3:-}
 
-if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    printf '%s\n' "Tag must use the vMAJOR.MINOR.PATCH format." >&2
+if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+    printf '%s\n' "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
     exit 1
 fi
 if [[ -z "$archive_path" || ! -f "$archive_path" ]]; then
@@ -20,6 +20,12 @@ fi
 if [[ -z "$output_path" ]]; then
     printf '%s\n' "Appcast output path is required." >&2
     exit 1
+fi
+
+version=${tag_name#v}
+build_number=${METASEQUOIA_BUILD_NUMBER:-$version}
+if [[ "$tag_name" == *-build.* ]]; then
+    build_number=${tag_name##*-build.}
 fi
 
 archive_name=$(basename "$archive_path")
@@ -60,7 +66,7 @@ product_link="https://github.com/$GH_REPO/releases/tag/$tag_name"
         --ed-key-file - \
         --download-url-prefix "$download_prefix" \
         --link "$product_link" \
-        --versions "${tag_name#v}" \
+        --versions "$build_number" \
         --maximum-deltas 0 \
         -o appcast.xml \
         .

--- a/platforms/macos/scripts/package_release.sh
+++ b/platforms/macos/scripts/package_release.sh
@@ -27,14 +27,23 @@ tag_name=${1:-}
 source_bundle=${2:-$project_root/build/MetasequoiaIME.app}
 output_dir=${3:-$project_root/dist}
 
-if [[ ! "$tag_name" =~ '^v[0-9]+\.[0-9]+\.[0-9]+$' ]]; then
-    print -u2 "Tag must use the vMAJOR.MINOR.PATCH format."
+if [[ ! "$tag_name" =~ '^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$' ]]; then
+    print -u2 "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix."
     exit 1
 fi
 
 source_bundle=${source_bundle:A}
 output_dir=${output_dir:A}
 version=${tag_name#v}
+version=${version%%-build.*}
+build_number=${METASEQUOIA_BUILD_NUMBER:-$version}
+if [[ "$tag_name" == *-build.* ]]; then
+    build_number=${tag_name##*-build.}
+    if [[ "${METASEQUOIA_BUILD_NUMBER:-$build_number}" != "$build_number" ]]; then
+        printf '%s\n' "Build number does not match release tag." >&2
+        exit 1
+    fi
+fi
 require_release_signing=${METASEQUOIA_REQUIRE_RELEASE_SIGNING:-false}
 application_identity=${METASEQUOIA_DEVELOPER_ID_APPLICATION:-}
 installer_identity=${METASEQUOIA_DEVELOPER_ID_INSTALLER:-}
@@ -100,6 +109,12 @@ fi
 bundle_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$source_bundle/Contents/Info.plist")
 if [[ "$bundle_version" != "$version" ]]; then
     print -u2 "Bundle version $bundle_version does not match tag $tag_name."
+    exit 1
+fi
+
+bundle_build=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$source_bundle/Contents/Info.plist")
+if [[ "$bundle_build" != "$build_number" ]]; then
+    print -u2 "Bundle build $bundle_build does not match expected build $build_number."
     exit 1
 fi
 
@@ -218,8 +233,8 @@ ditto -c -k --keepParent "$packaged_bundle" "$update_archive_path"
 (cd "$staging_root" && shasum -a 256 "$update_archive_name") > "$update_checksum_path"
 ditto -c -k --keepParent "$package_root" "$archive_path"
 (cd "$staging_root" && shasum -a 256 "$archive_name") > "$checksum_path"
-pkgbuild --component "$packaged_bundle" --identifier com.houko.inputmethod.MetasequoiaIME.pkg --version "$version" --scripts "$pkg_scripts" --install-location "Library/Input Methods" "$component_package"
-sed "s/@VERSION@/$version/g" "$installer_distribution" > "$distribution_file"
+pkgbuild --component "$packaged_bundle" --identifier com.houko.inputmethod.MetasequoiaIME.pkg --version "$build_number" --scripts "$pkg_scripts" --install-location "Library/Input Methods" "$component_package"
+sed "s/@VERSION@/$build_number/g" "$installer_distribution" > "$distribution_file"
 mkdir -p "$installer_resources"
 ditto "$project_root/LICENSE" "$installer_resources/LICENSE"
 ditto "$project_root/THIRD_PARTY_NOTICES.txt" "$installer_resources/THIRD_PARTY_NOTICES.txt"

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -35,8 +35,8 @@ case "$SIGNING_ENABLED:$ASSET_SUFFIX" in
         ;;
 esac
 
-if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    printf '%s\n' "Tag must use the vMAJOR.MINOR.PATCH format." >&2
+if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+    printf '%s\n' "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
     exit 1
 fi
 

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import json
 import os
+import textwrap
 import subprocess
 import tempfile
 import unittest
@@ -21,6 +22,88 @@ SIGNING_SECRETS = (
     "MACOS_DEVELOPER_ID_APPLICATION",
     "MACOS_DEVELOPER_ID_INSTALLER",
 )
+
+
+class BuildNumberTests(unittest.TestCase):
+    def run_step(self, step, prefix="", **values):
+        workflow = (MACOS_ROOT.parents[1] / ".github/workflows/release.yml").read_text()
+        body = workflow.split("      - name: " + step + "\n", 1)[1]
+        body = body.split("\n      - name:", 1)[0].split("        run: |\n", 1)[1]
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "output"
+            environment = dict(os.environ, GITHUB_OUTPUT=str(output),
+                               GITHUB_RUN_NUMBER="123", GITHUB_RUN_ATTEMPT="1",
+                               REQUESTED_TAG="")
+            environment.update(values)
+            result = subprocess.run(["bash", "-e", "-c", prefix + "\n" + textwrap.dedent(body)],
+                                    env=environment, text=True, capture_output=True)
+            return result, output.read_text() if output.exists() else ""
+
+    def test_build_increases_across_runs_rollover_and_retries(self):
+        builds = []
+        for run, attempt in [(99, 1), (99, 2), (100, 1), (101, 1)]:
+            result, output = self.run_step("Allocate build number",
+                                         GITHUB_RUN_NUMBER=str(run),
+                                         GITHUB_RUN_ATTEMPT=str(attempt))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            builds.append(tuple(map(int, output.strip().split("=")[1].split("."))))
+        self.assertEqual(builds, sorted(set(builds)))
+        self.assertGreater(builds[0], (491, 0, 0))
+
+    def test_manual_build_draft_preserves_its_build(self):
+        result, output = self.run_step("Allocate build number",
+                                     REQUESTED_TAG="v0.48.6-build.2.23.1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(output, "value=2.23.1\n")
+
+    def test_push_creates_unique_draft_at_exact_source_commit(self):
+        result, output = self.run_step(
+            "Create automatic build draft",
+            prefix='cat() { printf "0.48.6\\n"; }; gh() { printf "%s\\n" "$*"; }',
+            BUILD_NUMBER="2.23.1", GITHUB_SHA=HEAD_SHA)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("release create v0.48.6-build.2.23.1 --target " + HEAD_SHA, result.stdout)
+        self.assertIn("--draft --prerelease", result.stdout)
+        self.assertEqual(output, "release_created=true\ntag_name=v0.48.6-build.2.23.1\ntarget_sha=" + HEAD_SHA + "\n")
+
+    def test_manual_version_bump_and_draft_selection_are_exclusive(self):
+        for bump, tag, valid in [("true", "", True), ("false", "v0.48.6", True),
+                                 ("true", "v0.48.6", False), ("false", "", False)]:
+            result, _ = self.run_step("Validate invocation", GITHUB_REF="refs/heads/main",
+                                     GITHUB_EVENT_NAME="workflow_dispatch",
+                                     BUMP_VERSION=bump, REQUESTED_TAG=tag)
+            self.assertEqual(result.returncode == 0, valid)
+        result, _ = self.run_step("Validate invocation", GITHUB_REF="refs/heads/develop",
+                                 GITHUB_EVENT_NAME="push")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_ios_uses_ci_build_and_rejects_tag_mismatch(self):
+        root = MACOS_ROOT.parents[1]
+        for name in ("package_ios_archive.sh", "package_ios_testflight.sh"):
+            script = (root / "platforms/ios/scripts" / name).read_text()
+            fragment = script.split("# CI supplies the shared build.", 1)[1]
+            fragment = "# CI supplies the shared build." + fragment.split("marketing_version=", 1)[0]
+            for tag, supplied, expected in [
+                ("v0.48.6-build.1001.23.1", "1001.23.1", "1001.23.1"),
+                ("v0.48.6", "1001.24.1", "1001.24.1"),
+                ("v0.48.6-build.1001.23.1", "1001.24.1", None),
+            ]:
+                result = subprocess.run(
+                    ["bash", "-eu", "-c", fragment + '\nprintf "%s" "$build_number"'],
+                    env=dict(os.environ, tag_name=tag, METASEQUOIA_BUILD_NUMBER=supplied),
+                    text=True, capture_output=True)
+                if expected is None:
+                    self.assertNotEqual(result.returncode, 0, name)
+                    self.assertIn("does not match", result.stderr)
+                else:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout, expected, name)
+
+    def test_invalid_build_is_rejected(self):
+        for tag in ["v0.48.6-build.1.100.1", "v0.48.6-build.x", "v0.48.6-build.0.1.1"]:
+            result, output = self.run_step("Allocate build number", REQUESTED_TAG=tag)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(output, "")
 
 
 class ReleaseAutomationTests(unittest.TestCase):
@@ -656,13 +739,13 @@ fi
 
 
 class SparkleAppcastTests(unittest.TestCase):
-    def run_generator(self, private_key="test-private-key", archive_name=None):
+    def run_generator(self, private_key="test-private-key", archive_name=None, tag="v1.2.3", build=None):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary = Path(temporary_directory)
             tools = temporary / "tools"
             tools.mkdir()
             log = temporary / "tools.log"
-            archive_name = archive_name or "MetasequoiaIME-v1.2.3-macos-universal-unsigned-update.zip"
+            archive_name = archive_name or f"MetasequoiaIME-{tag}-macos-universal-unsigned-update.zip"
             archive = temporary / archive_name
             archive.write_bytes(b"update archive")
             output = temporary / "appcast.xml"
@@ -687,6 +770,7 @@ cat > "$output" <<'XML'
 XML
 """
             )
+            generate_appcast.write_text(generate_appcast.read_text().replace("v1.2.3", tag))
             generate_appcast.chmod(0o755)
             sign_update = tools / "sign_update"
             sign_update.write_text(
@@ -710,10 +794,12 @@ fi
                     "GH_REPO": "metasequoiaime/MSIME-Apple",
                 }
             )
+            if build:
+                environment["METASEQUOIA_BUILD_NUMBER"] = build
             result = subprocess.run(
                 [
                     MACOS_ROOT / "scripts/generate-sparkle-appcast.sh",
-                    "v1.2.3",
+                    tag,
                     archive,
                     output,
                 ],
@@ -735,6 +821,17 @@ fi
         self.assertIn("test-signature", appcast)
         self.assertIn("generate:test-private-key:", calls)
         self.assertIn("sign:test-private-key:", calls)
+
+    def test_build_tag_selects_internal_build_for_appcast(self):
+        result, appcast, calls = self.run_generator(tag="v1.2.3-build.2.23.1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--versions 2.23.1", calls)
+        self.assertIn("releases/download/v1.2.3-build.2.23.1/", appcast)
+
+    def test_formal_release_uses_independent_build(self):
+        result, appcast, calls = self.run_generator(build="2.24.1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--versions 2.24.1", calls)
 
     def test_rejects_archive_that_does_not_match_release_tag(self):
         result, appcast, calls = self.run_generator(


### PR DESCRIPTION
合入 main 的自动构建目前会通过 release-please 推进产品版本，无法在同一版本下持续发布新 build。此改动让 main 的 push 保留 version.txt，仅递增 build，生成独立的 v<version>-build.<build> tag 和 Pre-release；正式语义版本仍由手动运行 Release（bump_version=true、tag 留空）时调用 release-please 生成。

macOS、iOS、安装器和 Sparkle 共用 CI build；iOS 保留 develop 已有的两段营销版本号，本地旧式打包保留提交数作为 fallback。新 CI build 从 1000 段起步，高于迁移时的旧 iOS 提交数 build；运行编号和重试次数负责递增。打包前校验主应用及键盘扩展版本，并修正 unsigned archive 仍按完整三段版本校验的问题。手动 tag 输入继续只接受尚未发布的 draft。

验证：
- 发布自动化测试：43 项通过，覆盖 build 递增、重试、旧编号迁移、tag 与 build 一致性、手动入口互斥和 Sparkle。
- iOS 项目配置测试：45 项，44 项通过、1 项跳过。
- actionlint、相关 Bash/Zsh 语法检查及 git diff --check 通过。
- 未运行完整原生打包、签名、公证、TestFlight 上传或真实发布；交由 PR CI 和后续发布环境验证。
