### PR TITLE
test(ios): 覆盖新手引导按钮背景区域点击

### DIFF
--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -342,6 +342,52 @@ final class OnboardingUITests: XCTestCase {
   }
 
   @MainActor
+  func testWelcomePrimaryButtonsRespondAcrossTheirVisibleBackground() {
+    let app = XCUIApplication()
+    app.launchArguments = ["--reset-onboarding-for-ui-tests"]
+    app.launch()
+    let next = app.buttons["nextOnboardingButton"]
+    XCTAssertTrue(next.waitForExistence(timeout: 5))
+    // Tap the colored background, well outside the centered text.
+    next.coordinate(withNormalizedOffset: CGVector(dx: 0.08, dy: 0.5)).tap()
+    let settings = app.buttons["openKeyboardSettingsButton"]
+    XCTAssertTrue(settings.waitForExistence(timeout: 5))
+    settings.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5)).tap()
+    let systemSettings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+    XCTAssertTrue(systemSettings.wait(for: .runningForeground, timeout: 5))
+    app.activate()
+    next.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5)).tap()
+    XCTAssertTrue(app.buttons["welcomeScheme_nineKey"].waitForExistence(timeout: 5))
+    next.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.85)).tap()
+    let finish = app.buttons["finishOnboardingButton"]
+    XCTAssertTrue(finish.waitForExistence(timeout: 5))
+    finish.coordinate(withNormalizedOffset: CGVector(dx: 0.08, dy: 0.5)).tap()
+    XCTAssertTrue(app.tabBars.buttons["键盘"].waitForExistence(timeout: 5))
+  }
+
+  @MainActor
+  func testReplayedWelcomeStartRespondsOutsideText() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-hasCompletedOnboarding", "YES"]
+    app.launch()
+    app.tabBars.buttons["我的"].tap()
+    let loginAlert = app.alerts["账号与登录"]
+    if loginAlert.waitForExistence(timeout: 5) { loginAlert.buttons["好"].tap() }
+    let replay = app.buttons["replayOnboardingLink"]
+    for _ in 0..<8 {
+      if replay.isHittable { break }
+      app.swipeUp()
+    }
+    replay.tap()
+    let next = app.buttons["nextOnboardingButton"]
+    XCTAssertTrue(next.waitForExistence(timeout: 5))
+    next.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5)).tap()
+    XCTAssertTrue(app.buttons["openKeyboardSettingsButton"].waitForExistence(timeout: 5))
+    app.buttons["skipOnboardingButton"].tap()
+    XCTAssertTrue(app.tabBars.buttons["我的"].waitForExistence(timeout: 5))
+  }
+
+  @MainActor
   func testWelcomeFlowSelectsSchemeAndCompletesOnce() {
     let app = XCUIApplication()
     app.launchArguments = ["--reset-onboarding-for-ui-tests"]


### PR DESCRIPTION
补充新手引导按钮的点击区域回归测试，覆盖首次引导、系统设置跳转、完成引导，以及从“我的”重新进入引导后点击按钮背景边缘。

按钮点击区域修复已经包含在最新 develop 中；此 PR 保留该实现，仅增加 UI 回归测试。

验证：
- 原修复分支的 3 项引导 UI 测试通过。
- 同步最新 develop 并解决冲突后，45 项项目配置测试通过，git diff --check 通过。
- 最新基线上的 UI 测试由本次 CI 重新验证。
