### PR TITLE
feat(ios): 重新设计个人资料编辑界面

### DIFF
--- a/platforms/ios/App/Sources/AccountSettingsView.swift
+++ b/platforms/ios/App/Sources/AccountSettingsView.swift
@@ -209,7 +209,7 @@ struct AppleAccountSection: View {
         catch { message = error.localizedDescription }
       }
     }) { channel in CodeLoginView(model: codeModel, channel: channel) }
-    .sheet(isPresented: $editProfile) { AccountProfileEditor { profile in user = profile } }
+    .sheet(isPresented: $editProfile) { AccountProfileEditor(initialUser: user) { profile in user = profile } }
     .alert("账号与登录", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
       Button("好", role: .cancel) {}
     } message: { Text(message ?? "") }
@@ -242,16 +242,35 @@ struct AppleAccountSection: View {
 }
 
 struct AccountProfileEditor: View {
+  var initialUser: CommunityUser? = nil
   var onSaved: (CommunityUser) -> Void
   @Environment(\.dismiss) private var dismiss
+  @FocusState private var editingName: Bool
   @State private var profile: CommunityProfile?
   @State private var name = ""
-  @State private var busy = false
+  @State private var loading = true
+  @State private var saving = false
   @State private var message: String?
+  @State private var copiedID = false
+  @State private var confirmDiscard = false
+
   private var normalizedName: String { name.trimmingCharacters(in: .whitespacesAndNewlines) }
   private var validName: Bool {
     !normalizedName.isEmpty && normalizedName.unicodeScalars.count <= 64 &&
       !normalizedName.unicodeScalars.contains { CharacterSet.controlCharacters.contains($0) }
+  }
+  private var hasChanges: Bool {
+    guard let profile else { return false }
+    return normalizedName != profile.user.preferredDisplayName
+  }
+  private var previewName: String {
+    if profile == nil { return initialUser?.preferredDisplayName ?? "水杉用户" }
+    return normalizedName.isEmpty ? "你的昵称" : normalizedName
+  }
+  private var nameHint: String {
+    if normalizedName.isEmpty { return "取一个喜欢的名字，让大家记住你。" }
+    if !validName { return "昵称最多 64 个字符，请勿使用换行或控制字符。" }
+    return "昵称会显示在社区作品中，已发布的作品也会同步更新。"
   }
   private var joined: String? {
     guard let value = profile?.user.created_at else { return nil }
@@ -262,79 +281,251 @@ struct AccountProfileEditor: View {
     guard let date = fractional ?? formatter.date(from: value) else { return nil }
     return date.formatted(date: .abbreviated, time: .omitted)
   }
+
   var body: some View {
     NavigationView {
-      Form {
-        Section {
-          TextField("设置你的昵称", text: $name)
-            .textContentType(.nickname).submitLabel(.done)
-            .accessibilityIdentifier("accountNicknameField")
-            .disabled(profile == nil || busy)
-          Text("\(normalizedName.unicodeScalars.count)/64").font(.caption).foregroundStyle(.secondary)
-        } header: { Text("昵称") } footer: {
-          Text("昵称会公开显示在你的社区作品上，修改后已发布作品也会使用新昵称。")
-        }
-        if let profile {
-          Section("账号信息") {
-            Button {
-              UIPasteboard.general.string = profile.user.id
-              message = "完整账号 ID 已复制。"
-            } label: {
-              HStack {
-                Text("账号 ID").foregroundStyle(.primary)
-                Spacer()
-                Text("#" + profile.user.id.prefix(6).uppercased()).font(.subheadline.monospaced())
-                Image(systemName: "doc.on.doc").font(.subheadline)
+      ScrollView {
+        VStack(spacing: 28) {
+          profilePreview
+          if loading {
+            ProgressView("正在加载资料")
+              .font(.subheadline).frame(maxWidth: .infinity).padding(.vertical, 28)
+          } else if profile != nil {
+            nicknameCard
+            accountDetails
+          }
+          if let message, profile == nil {
+            VStack(alignment: .leading, spacing: 12) {
+              Label(message, systemImage: "exclamationmark.circle")
+                .font(.subheadline).foregroundStyle(.secondary)
+              if profile == nil {
+                Button("重新加载") { Task { await load() } }
+                  .font(.subheadline.weight(.semibold))
               }
-            }.accessibilityLabel("复制完整账号 ID")
-              .accessibilityIdentifier("copyAccountID")
-            HStack {
-              Text("登录方式")
-              Spacer()
-              Text(profile.identities.map { $0.provider == "apple" ? "Apple" : $0.provider }.joined(separator: "、"))
-                .foregroundStyle(.secondary)
             }
-            if let joined {
-              HStack { Text("注册时间"); Spacer(); Text(joined).foregroundStyle(.secondary) }
-            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+            .background(MetasequoiaTheme.surface, in: RoundedRectangle(cornerRadius: 20))
+            .accessibilityIdentifier("accountProfileError")
           }
         }
-        if busy { ProgressView().frame(maxWidth: .infinity) }
-        if profile == nil && !busy { Button("重新加载资料") { load() } }
+        .frame(maxWidth: 540)
+        .padding(.horizontal, 24).padding(.top, 24).padding(.bottom, 28)
+        .frame(maxWidth: .infinity)
       }
-      .navigationTitle("个人资料").navigationBarTitleDisplayMode(.inline)
+      .background(MetasequoiaTheme.canvas.ignoresSafeArea())
+      .navigationTitle("编辑资料")
+      .navigationBarTitleDisplayMode(.inline)
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) { Button("取消") { dismiss() }.disabled(busy) }
-        ToolbarItem(placement: .confirmationAction) {
-          Button("保存") {
-            busy = true
-            Task {
-              defer { busy = false }
-              do {
-                let updated = try await SkinCommunityAPI.shared.updateProfile(name: normalizedName)
-                onSaved(updated.user)
-                dismiss()
-              } catch { message = error.localizedDescription }
-            }
-          }.disabled(busy || profile == nil || !validName || normalizedName == profile?.user.preferredDisplayName)
-            .accessibilityIdentifier("saveAccountProfile")
+        ToolbarItem(placement: .cancellationAction) {
+          Button {
+            editingName = false
+            if hasChanges { confirmDiscard = true } else { dismiss() }
+          } label: {
+            Image(systemName: "xmark").font(.subheadline.weight(.semibold))
+              .frame(width: 32, height: 32)
+          }
+          .accessibilityLabel("关闭编辑资料").disabled(saving)
+        }
+        ToolbarItemGroup(placement: .keyboard) {
+          Spacer()
+          Button("完成") { editingName = false }
         }
       }
-      .task { load() }
-      .alert("个人资料", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
-        Button("好", role: .cancel) {}
-      } message: { Text(message ?? "") }
+      .safeAreaInset(edge: .bottom, spacing: 0) { saveBar }
+      .interactiveDismissDisabled(hasChanges || saving)
+      .confirmationDialog("要放弃这次修改吗？", isPresented: $confirmDiscard, titleVisibility: .visible) {
+        Button("放弃修改", role: .destructive) { dismiss() }
+        Button("继续编辑", role: .cancel) {}
+      }
+      .task { await load() }
+    }
+    .navigationViewStyle(.stack)
+    .tint(MetasequoiaTheme.accent)
+  }
+
+  private var profilePreview: some View {
+    VStack(spacing: 14) {
+      ZStack {
+        Circle().fill(MetasequoiaTheme.accent.opacity(0.07)).frame(width: 104, height: 104)
+        Circle()
+          .fill(LinearGradient(colors: [MetasequoiaTheme.needle, MetasequoiaTheme.forest],
+                               startPoint: .topLeading, endPoint: .bottomTrailing))
+          .frame(width: 84, height: 84)
+        Text(String(previewName.prefix(1)))
+          .font(.system(size: 32, weight: .medium, design: .rounded)).foregroundStyle(.white)
+      }
+      .accessibilityHidden(true)
+      VStack(spacing: 6) {
+        Text(previewName).font(.title2.weight(.semibold))
+          .multilineTextAlignment(.center).lineLimit(2)
+        Text("在水杉，留下你的名字")
+          .font(.subheadline).foregroundStyle(.secondary)
+      }
+    }
+    .frame(maxWidth: .infinity).padding(.vertical, 8)
+    .accessibilityIdentifier("accountProfilePreview")
+  }
+
+  private var nicknameCard: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("社区昵称").font(.subheadline.weight(.semibold))
+      VStack(alignment: .leading, spacing: 16) {
+        HStack(spacing: 12) {
+          TextField("设置你的昵称", text: $name)
+            .font(.title3.weight(.medium))
+            .textContentType(.nickname).submitLabel(.done)
+            .focused($editingName).onSubmit { editingName = false }
+            .disabled(saving)
+            .accessibilityIdentifier("accountNicknameField")
+          if !name.isEmpty {
+            Button { name = ""; editingName = true } label: {
+              Image(systemName: "xmark.circle.fill").foregroundStyle(.tertiary)
+                .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain).accessibilityLabel("清空昵称").disabled(saving)
+          }
+        }
+        Divider()
+        HStack(alignment: .top, spacing: 16) {
+          Text(nameHint).fixedSize(horizontal: false, vertical: true)
+          Spacer(minLength: 0)
+          Text("\(normalizedName.unicodeScalars.count)/64")
+            .monospacedDigit().fixedSize()
+            .accessibilityLabel("已输入 \(normalizedName.unicodeScalars.count) 个字符，最多 64 个")
+        }
+        .font(.caption)
+        .foregroundStyle(validName || normalizedName.isEmpty ? Color.secondary : Color.red)
+      }
+      .padding(20)
+      .background(MetasequoiaTheme.surface, in: RoundedRectangle(cornerRadius: 22))
+      .overlay {
+        RoundedRectangle(cornerRadius: 22)
+          .strokeBorder(editingName ? MetasequoiaTheme.accent.opacity(0.5) : .clear, lineWidth: 1.5)
+      }
     }
   }
-  private func load() {
-    guard !busy else { return }; busy = true
+
+  private var accountDetails: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("账号信息").font(.subheadline.weight(.semibold))
+      VStack(spacing: 0) {
+        if let profile {
+          Button {
+            UIPasteboard.general.string = profile.user.id
+            copiedID = true
+          } label: {
+            detailRow("账号 ID", value: "#" + profile.user.id.prefix(6).uppercased(),
+                      symbol: "number", accessory: copiedID ? "checkmark" : "doc.on.doc")
+          }
+          .buttonStyle(.plain)
+          .accessibilityLabel(copiedID ? "账号 ID 已复制" : "复制完整账号 ID")
+          .accessibilityIdentifier("copyAccountID")
+          if copiedID {
+            Text("账号 ID 已复制").font(.caption).foregroundStyle(MetasequoiaTheme.accent)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.horizontal, 20).padding(.bottom, 12)
+          }
+          Divider().padding(.leading, 54)
+          detailRow("登录方式", value: loginProviders(profile), symbol: "person.badge.key")
+          if let joined {
+            Divider().padding(.leading, 54)
+            detailRow("加入水杉", value: joined, symbol: "calendar")
+          }
+        }
+      }
+      .background(MetasequoiaTheme.surface, in: RoundedRectangle(cornerRadius: 22))
+      Label("轻点账号 ID 即可复制", systemImage: "lock")
+        .font(.caption).foregroundStyle(.secondary).padding(.horizontal, 4)
+    }
+  }
+
+  private func detailRow(_ title: String, value: String, symbol: String,
+                         accessory: String? = nil) -> some View {
+    HStack(alignment: .center, spacing: 12) {
+      Image(systemName: symbol).font(.subheadline)
+        .foregroundStyle(MetasequoiaTheme.accent).frame(width: 22)
+      VStack(alignment: .leading, spacing: 5) {
+        Text(title).font(.caption).foregroundStyle(.secondary)
+        Text(value.isEmpty ? "暂无信息" : value).font(.subheadline.weight(.medium))
+          .foregroundStyle(.primary)
+      }
+      Spacer(minLength: 8)
+      if let accessory {
+        Image(systemName: accessory).font(.subheadline)
+          .foregroundStyle(MetasequoiaTheme.accent)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading).padding(20)
+  }
+
+  private func loginProviders(_ profile: CommunityProfile) -> String {
+    profile.identities.map {
+      switch $0.provider {
+      case "apple": return "Apple"
+      case "email": return "邮箱"
+      case "phone", "sms": return "手机号"
+      default: return $0.provider
+      }
+    }.joined(separator: "、")
+  }
+
+  private var saveBar: some View {
+    VStack(spacing: 12) {
+      if let message, profile != nil {
+        Label(message, systemImage: "exclamationmark.circle")
+          .font(.caption).foregroundStyle(.red)
+          .fixedSize(horizontal: false, vertical: true)
+          .accessibilityIdentifier("accountProfileSaveError")
+      }
+      Button(action: save) {
+        HStack(spacing: 10) {
+          if saving { ProgressView().tint(.white) }
+          Text(saving ? "正在保存…" : "保存修改").font(.body.weight(.semibold))
+        }
+        .foregroundStyle(.white)
+        .frame(maxWidth: .infinity).padding(.vertical, 17)
+        .background(MetasequoiaTheme.forest.opacity(canSave || saving ? 1 : 0.45),
+                    in: RoundedRectangle(cornerRadius: 18))
+      }
+      .buttonStyle(.plain)
+      .disabled(!canSave)
+      .accessibilityIdentifier("saveAccountProfile")
+    }
+    .frame(maxWidth: 540)
+    .padding(.horizontal, 24).padding(.top, 12).padding(.bottom, 12)
+    .frame(maxWidth: .infinity)
+    .background(.regularMaterial)
+  }
+
+  private var canSave: Bool { !loading && !saving && profile != nil && validName && hasChanges }
+
+  private func save() {
+    guard canSave else { return }
+    editingName = false
+    saving = true
+    message = nil
+    let submittedName = normalizedName
     Task {
-      defer { busy = false }
+      defer { saving = false }
       do {
-        let result = try await SkinCommunityAPI.shared.profile()
-        profile = result; name = result.user.preferredDisplayName
-        onSaved(result.user)
+        let updated = try await SkinCommunityAPI.shared.updateProfile(name: submittedName)
+        onSaved(updated.user)
+        dismiss()
       } catch { message = error.localizedDescription }
     }
+  }
+
+  @MainActor private func load() async {
+    loading = true
+    message = nil
+    defer { loading = false }
+    do {
+      let result = try await SkinCommunityAPI.shared.profile()
+      profile = result
+      name = result.user.preferredDisplayName
+      onSaved(result.user)
+    } catch is CancellationError {
+    } catch { message = error.localizedDescription }
   }
 }


### PR DESCRIPTION
“我的 → 个人资料”原先使用系统表单，昵称编辑、账号信息和保存动作的层级不够清晰。改为水杉主题的卡片布局：顶部昵称头像与实时预览、中部昵称编辑、下方账号信息，以及固定在底部的“保存修改”按钮。

加载、保存和失败反馈分别展示；复制账号 ID 使用就地提示；有未保存修改时关闭会确认。保留昵称校验和现有资料 API，支持深色模式与动态字号。

验证：
- 修改文件通过 Swift 语法检查与 git diff --check。
- 使用实际编辑视图和测试账号 API 的独立 iOS 预览程序编译成功。
- 在 iOS 26 模拟器检查浅色、深色和辅助功能大字号布局。
- 未验证真实账号资料提交，也未在本地构建完整应用；完整集成检查由 PR CI 执行。
