### PR TITLE
fix(ios): 增高手写键盘书写区

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -52,7 +52,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private let moreShortcut = UIButton()
   private var morePicker: KeyboardMorePickerView?
   private let handwriting = HandwritingInputView()
-  private var handwritingHeight: NSLayoutConstraint?
+  private var handwritingActionHeight: NSLayoutConstraint?
   private var layoutPicker: KeyboardLayoutPickerView?
   private var moreMenu: UIMenu?
   private let dismissShortcut = UIButton()
@@ -165,6 +165,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     height.identifier = "keyboardHeight"
     height.isActive = true
     keyboardHeightConstraint = height
+    updatePreferredKeyboardHeight()
     updateReturnKey()
     // installKeyboard builds the candidate strip before the letter rows exist, so the hints the
     // scheme button gathered there have not reached any key yet.
@@ -309,7 +310,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     // Keep the three keypad rows the same height as the bottom controls.
     nineKeyHeight = nineKeyContainer.heightAnchor.constraint(
       equalTo: actionRow.heightAnchor, multiplier: 3, constant: 14)
-    handwritingHeight = handwriting.heightAnchor.constraint(equalTo: actionRow.heightAnchor, multiplier: 3, constant: 14)
+    // Extra handwriting space belongs to the canvas, not enlarged Space/Return keys.
+    handwritingActionHeight = actionRow.heightAnchor.constraint(equalToConstant: 44)
     updateKeyboardLayout()
   }
 
@@ -1573,7 +1575,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     if !writes && !handwriting.isHidden { handwriting.deactivate() }
     handwriting.isHidden = !writes
     if writes { handwriting.activate() }
-    handwritingHeight?.isActive = writes
+    handwritingActionHeight?.isActive = writes
     letterRowViews.forEach { $0.isHidden = showsSymbols || nineKey || writes }
     nineKeyContainer.isHidden = showsSymbols || !nineKey
     nineKeyRows.forEach { $0.isHidden = showsSymbols || !nineKey }
@@ -1623,6 +1625,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     }
     layoutToggleButton?.accessibilityLabel =
       showsSymbols ? "切换到字母" : "切换到数字和符号"
+    updatePreferredKeyboardHeight()
   }
 
   private func handleBackspace() {
@@ -1985,11 +1988,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     if let globe = actionGlobeButton, globe.isHidden != !needsInputModeSwitchKey {
       updateKeyboardLayout()
     }
-    // Use the same viewport for every input layout; content's intrinsic height must not shrink it.
-    let landscape = view.window?.windowScene?.interfaceOrientation.isLandscape
-      ?? (traitCollection.verticalSizeClass == .compact)
-    let height: CGFloat = landscape ? 216 : 260
-    if keyboardHeightConstraint?.constant != height { keyboardHeightConstraint?.constant = height }
+    updatePreferredKeyboardHeight()
     func updateShadows(_ node: UIView) {
       if let button = node as? UIButton, button.layer.shadowOpacity > 0 {
         button.layer.shadowPath = UIBezierPath(roundedRect: button.bounds,
@@ -1998,6 +1997,15 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       node.subviews.forEach { updateShadows($0) }
     }
     updateShadows(view)
+  }
+
+  private func updatePreferredKeyboardHeight() {
+    let landscape = view.window?.windowScene?.interfaceOrientation.isLandscape
+      ?? (traitCollection.verticalSizeClass == .compact)
+    let height: CGFloat = handwriting.isHidden
+      ? (landscape ? 216 : 260)
+      : (landscape ? 260 : 360)
+    if keyboardHeightConstraint?.constant != height { keyboardHeightConstraint?.constant = height }
   }
 
   private func showClipboardHistory() {

--- a/platforms/ios/KeyboardTests/HandwritingTests.swift
+++ b/platforms/ios/KeyboardTests/HandwritingTests.swift
@@ -80,18 +80,58 @@ final class HandwritingTests: XCTestCase {
     InputSchemePreference.scheme = .handwriting
     let controller = KeyboardViewController(); controller.loadViewIfNeeded()
     for width in [320.0, 414.0] {
-      controller.view.frame = CGRect(x: 0, y: 0, width: width, height: 260); controller.view.layoutIfNeeded()
+      let height = try XCTUnwrap(controller.view.constraints.first { $0.identifier == "keyboardHeight" })
+      XCTAssertEqual(height.constant, 360)
+      controller.view.frame = CGRect(x: 0, y: 0, width: width, height: height.constant); controller.view.layoutIfNeeded()
       let panel = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "handwritingInput" } as? HandwritingInputView)
       XCTAssertFalse(panel.isHidden)
-      XCTAssertGreaterThan(panel.canvas.bounds.height, 90)
+      XCTAssertGreaterThanOrEqual(panel.canvas.bounds.height, 200)
       XCTAssertGreaterThan(panel.canvas.bounds.width, 200)
       let shot = XCTAttachment(image: UIGraphicsImageRenderer(bounds: controller.view.bounds).image { controller.view.layer.render(in: $0.cgContext) }); shot.name = "Handwriting keyboard \(Int(width))"; shot.lifetime = .keepAlways; add(shot)
     }
     let language = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "bottomLanguageKey" } as? UIButton)
     language.sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(controller.view.constraints.first { $0.identifier == "keyboardHeight" }?.constant, 260)
     XCTAssertTrue(try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "handwritingInput" }).isHidden)
     language.sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(controller.view.constraints.first { $0.identifier == "keyboardHeight" }?.constant, 360)
     XCTAssertFalse(try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "handwritingInput" }).isHidden)
+  }
+  func testHandwritingHeightTracksOrientationAndSymbolMode() throws {
+    let previous = InputSchemePreference.scheme
+    let enabled = InputSchemePreference.enabledSchemes
+    defer { InputSchemePreference.enabledSchemes = enabled; InputSchemePreference.scheme = previous }
+    InputSchemePreference.enabledSchemes = ChineseInputScheme.allCases
+    InputSchemePreference.scheme = .handwriting
+    let parent = UIViewController()
+    let controller = KeyboardViewController()
+    parent.addChild(controller)
+    controller.loadViewIfNeeded()
+    let height = try XCTUnwrap(controller.view.constraints.first { $0.identifier == "keyboardHeight" })
+    let toggle = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "layoutToggleButton" } as? UIButton)
+    let panel = try XCTUnwrap(nodes(controller.view).first { $0 is HandwritingInputView } as? HandwritingInputView)
+    let enter = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "returnKey" })
+    for (verticalSize, width, writingHeight, typingHeight) in [
+      (UIUserInterfaceSizeClass.regular, 414.0, 360.0, 260.0),
+      (.compact, 812.0, 260.0, 216.0),
+      (.regular, 320.0, 360.0, 260.0),
+    ] {
+      parent.setOverrideTraitCollection(UITraitCollection(verticalSizeClass: verticalSize), forChild: controller)
+      controller.viewDidLayoutSubviews()
+      XCTAssertEqual(height.constant, writingHeight)
+      controller.view.frame = CGRect(x: 0, y: 0, width: width, height: writingHeight)
+      controller.view.layoutIfNeeded()
+      XCTAssertEqual(enter.bounds.height, 44, accuracy: 0.5)
+      XCTAssertGreaterThanOrEqual(panel.canvas.bounds.height, verticalSize == .compact ? 110 : 200)
+      toggle.sendActions(for: .primaryActionTriggered)
+      XCTAssertTrue(panel.isHidden)
+      XCTAssertEqual(height.constant, typingHeight)
+      controller.view.frame.size.height = typingHeight
+      controller.view.layoutIfNeeded()
+      toggle.sendActions(for: .primaryActionTriggered)
+      XCTAssertFalse(panel.isHidden)
+      XCTAssertEqual(height.constant, writingHeight)
+    }
   }
   private func nodes(_ view: UIView) -> [UIView] { [view] + view.subviews.flatMap(nodes) }
 }

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -675,7 +675,7 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
-  func testAllLayoutsKeepNineKeyHeight() throws {
+  func testKeyLayoutsKeepNineKeyHeight() throws {
     let previous = InputSchemePreference.scheme
     defer { InputSchemePreference.scheme = previous }
     for width in [320.0, 414.0] {
@@ -685,7 +685,8 @@ final class NineKeyKeyboardTests: XCTestCase {
       controller.view.frame = CGRect(x: 0, y: 0, width: width, height: 260)
       controller.view.layoutIfNeeded()
       let reference = try button("nineKey6", in: controller).bounds.height
-      for scheme in ChineseInputScheme.allCases {
+      // Handwriting has a taller canvas, covered by HandwritingTests.
+      for scheme in ChineseInputScheme.allCases where scheme != .handwriting {
         InputSchemePreference.scheme = scheme
         controller.viewWillAppear(false)
         for symbols in [false, true] {


### PR DESCRIPTION
中文手写键盘原先与按键布局共用 260 点高度，竖屏书写区只有约 113 点。现在手写模式竖屏增至 360 点、横屏增至 260 点，底部操作键保持 44 点，将新增空间分配给书写区（竖屏约 214 点）。切换英文或符号后恢复原键盘高度。

验证：
- 33 项 iOS 键盘测试通过，覆盖窄屏、横竖屏及英文/符号模式切换。
- 45 项项目配置测试通过。
- 将原有统一高度测试限定为按键布局，手写高度由专门测试覆盖。
