### PR TITLE
feat(ios): 增加日语九键并独立展示 9 键和 26 键入口

### DIFF
--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -41,6 +41,8 @@ struct KeyboardSettingsView: View {
 }
 
 struct InputSettingsView: View {
+  @AppStorage(JapaneseKeyboardPreference.romanKeysKey, store: JapaneseKeyboardPreference.defaults)
+  private var japaneseRomanKeys = false
   @Environment(\.scenePhase) private var scenePhase
   @AppStorage(KeyboardFeedbackPreference.soundKey, store: KeyboardFeedbackPreference.defaults)
   private var soundEnabled = true
@@ -55,6 +57,14 @@ struct InputSettingsView: View {
 
   var body: some View {
     Form {
+      Section("日语键盘") {
+        Picker("键盘类型", selection: $japaneseRomanKeys) {
+          Text("九键假名").tag(false)
+          Text("26 键罗马字").tag(true)
+        }.pickerStyle(.segmented).accessibilityIdentifier("japaneseKeyboardLayout")
+        Text("九键轻点输入首个假名，向左、上、右、下滑动选字；长按显示选项。小假名与浊音可从「小・゛゜」选择。")
+          .font(.footnote).foregroundStyle(.secondary)
+      }
         Section {
           ForEach(ChineseInputScheme.allCases, id: \.self) { scheme in
             HStack {

--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -41,8 +41,6 @@ struct KeyboardSettingsView: View {
 }
 
 struct InputSettingsView: View {
-  @AppStorage(JapaneseKeyboardPreference.romanKeysKey, store: JapaneseKeyboardPreference.defaults)
-  private var japaneseRomanKeys = false
   @Environment(\.scenePhase) private var scenePhase
   @AppStorage(KeyboardFeedbackPreference.soundKey, store: KeyboardFeedbackPreference.defaults)
   private var soundEnabled = true
@@ -57,14 +55,6 @@ struct InputSettingsView: View {
 
   var body: some View {
     Form {
-      Section("日语键盘") {
-        Picker("键盘类型", selection: $japaneseRomanKeys) {
-          Text("九键假名").tag(false)
-          Text("26 键罗马字").tag(true)
-        }.pickerStyle(.segmented).accessibilityIdentifier("japaneseKeyboardLayout")
-        Text("九键轻点输入首个假名，向左、上、右、下滑动选字；长按显示选项。小假名与浊音可从「小・゛゜」选择。")
-          .font(.footnote).foregroundStyle(.secondary)
-      }
         Section {
           ForEach(ChineseInputScheme.allCases, id: \.self) { scheme in
             HStack {

--- a/platforms/ios/App/Sources/SettingsSyncView.swift
+++ b/platforms/ios/App/Sources/SettingsSyncView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 private enum IOSCloudSettings {
   static func snapshot() throws -> [String: BackendPreferenceValue] {
     let scheme = InputSchemePreference.scheme
-    let name = scheme.shuangpinProfile != nil ? "shuangpin" : ((scheme == .nineKey || scheme == .thoughtfulReply || scheme == .handwriting) ? "quanpin" : scheme.rawValue)
+    let name = scheme.isJapanese ? "japanese" : scheme.shuangpinProfile != nil ? "shuangpin" : ((scheme == .nineKey || scheme == .thoughtfulReply || scheme == .handwriting) ? "quanpin" : scheme.rawValue)
     let skinData = try JSONEncoder().encode(CustomKeyboardSkinStore.current)
     var settings: [String: BackendPreferenceValue] = [
       "input.schema": .string(name),
       "input.character_set": .string(ChineseOutputPreference.usesTraditional ? "traditional" : "simplified"),
-      "platform.ios.nine_key": .boolean(scheme == .nineKey),
+      "platform.ios.nine_key": .boolean(scheme == .nineKey || scheme == .japaneseNineKey),
       "platform.ios.sound_enabled": .boolean(KeyboardFeedbackPreference.soundEnabled),
       "platform.ios.haptics_enabled": .boolean(KeyboardFeedbackPreference.hapticsEnabled),
       "platform.ios.haptic_strength": .string(KeyboardFeedbackPreference.hapticStrength.rawValue),

--- a/platforms/ios/KeyboardExtension/Sources/JapaneseNineKeyView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/JapaneseNineKeyView.swift
@@ -1,0 +1,127 @@
+import UIKit
+
+/// Physical key labels and keystrokes only; composition and conversion stay in Engine.
+@MainActor
+final class JapaneseNineKeyView: UIStackView {
+  struct Key {
+    let kana: [String]
+    let strokes: [String]
+  }
+  static let keys: [Key] = [
+    Key(kana: ["あ", "い", "う", "え", "お"], strokes: ["a", "i", "u", "e", "o"]),
+    Key(kana: ["か", "き", "く", "け", "こ"], strokes: ["ka", "ki", "ku", "ke", "ko"]),
+    Key(kana: ["さ", "し", "す", "せ", "そ"], strokes: ["sa", "shi", "su", "se", "so"]),
+    Key(kana: ["た", "ち", "つ", "て", "と"], strokes: ["ta", "chi", "tsu", "te", "to"]),
+    Key(kana: ["な", "に", "ぬ", "ね", "の"], strokes: ["na", "ni", "nu", "ne", "no"]),
+    Key(kana: ["は", "ひ", "ふ", "へ", "ほ"], strokes: ["ha", "hi", "fu", "he", "ho"]),
+    Key(kana: ["ま", "み", "む", "め", "も"], strokes: ["ma", "mi", "mu", "me", "mo"]),
+    Key(kana: ["や", "（", "ゆ", "）", "よ"], strokes: ["ya", "", "yu", "", "yo"]),
+    Key(kana: ["ら", "り", "る", "れ", "ろ"], strokes: ["ra", "ri", "ru", "re", "ro"]),
+    Key(kana: ["わ", "を", "ん", "ー", "〜"], strokes: ["wa", "wo", "n'", "", ""]),
+  ]
+  var onInput: ((String) -> Void)?
+  var onSymbol: ((String) -> Void)?
+  var onDelete: (() -> Void)?
+  private var rows: [UIStackView] = []
+  private var keyButtons: [UIButton] = []
+
+  init(makeKey: (String, String, @escaping () -> Void) -> UIButton) {
+    super.init(frame: .zero)
+    axis = .horizontal
+    spacing = 6
+    accessibilityIdentifier = "japaneseNineKey"
+    let grid = UIStackView()
+    grid.axis = .vertical; grid.distribution = .fillEqually; grid.spacing = 7
+    addArrangedSubview(grid)
+    for rowIndex in 0..<3 {
+      let row = UIStackView(); row.distribution = .fillEqually; row.spacing = 6
+      rows.append(row); grid.addArrangedSubview(row)
+      for column in 0..<3 {
+        let index = rowIndex * 3 + column
+        row.addArrangedSubview(makeKanaKey(index, factory: makeKey))
+      }
+    }
+    let side = UIStackView()
+    side.axis = .vertical; side.distribution = .fillEqually; side.spacing = 7
+    rows.append(side)
+    addArrangedSubview(side)
+    side.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.19).isActive = true
+    side.addArrangedSubview(makeKanaKey(9, factory: makeKey))
+    let variants = makeKey("小゛゜", "小假名、浊音和半浊音", {})
+    variants.accessibilityIdentifier = "japaneseVariants"
+    variants.configuration?.contentInsets = .zero
+    variants.titleLabel?.adjustsFontSizeToFitWidth = true
+    variants.titleLabel?.minimumScaleFactor = 0.6
+    let groups: [(String, [String], [String])] = [
+      ("小假名", ["ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゃ", "ゅ", "ょ", "っ", "ゎ"], ["xa", "xi", "xu", "xe", "xo", "xya", "xyu", "xyo", "xtsu", "xwa"]),
+      ("浊音", ["が", "ぎ", "ぐ", "げ", "ご", "ざ", "じ", "ず", "ぜ", "ぞ", "だ", "ぢ", "づ", "で", "ど", "ば", "び", "ぶ", "べ", "ぼ", "ゔ"], ["ga", "gi", "gu", "ge", "go", "za", "ji", "zu", "ze", "zo", "da", "di", "du", "de", "do", "ba", "bi", "bu", "be", "bo", "vu"]),
+      ("半浊音", ["ぱ", "ぴ", "ぷ", "ぺ", "ぽ"], ["pa", "pi", "pu", "pe", "po"]),
+    ]
+    variants.menu = UIMenu(children: groups.map { title, kana, strokes in
+      UIMenu(title: title, children: zip(kana, strokes).map { label, input in
+        UIAction(title: label) { [weak self] _ in self?.onInput?(input) }
+      })
+    })
+    variants.showsMenuAsPrimaryAction = true
+    side.addArrangedSubview(variants)
+    let delete = makeKey("⌫", "删除", { [weak self] in self?.onDelete?() })
+    delete.accessibilityIdentifier = "japaneseDelete"
+    side.addArrangedSubview(delete)
+  }
+  required init(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  private func makeKanaKey(_ index: Int, factory: (String, String, @escaping () -> Void) -> UIButton) -> UIButton {
+    let key = Self.keys[index]
+    let button = factory(key.kana[0], key.kana.joined(separator: "、"), { [weak self] in self?.select(index, direction: 0) })
+    button.accessibilityIdentifier = "japaneseKana\(index)"
+    button.accessibilityHint = "轻点输入\(key.kana[0])；左、上、右、下滑动选择其他假名；长按显示全部选项"
+    button.configuration?.subtitle = key.kana.dropFirst().joined(separator: " ")
+    button.configuration?.subtitleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
+      var attributes = $0; attributes.font = .systemFont(ofSize: 10); return attributes
+    }
+    button.configuration?.contentInsets = .init(top: 2, leading: 0, bottom: 2, trailing: 0)
+    button.menu = UIMenu(children: key.kana.enumerated().map { direction, kana in
+      UIAction(title: kana) { [weak self] _ in self?.select(index, direction: direction) }
+    })
+    let pan = KanaFlickGesture { [weak self, weak button] direction, ended in
+      if ended { self?.select(index, direction: direction) }
+      button?.configuration?.title = key.kana[ended ? 0 : direction]
+    }
+    button.addGestureRecognizer(pan)
+    keyButtons.append(button)
+    return button
+  }
+  func select(_ index: Int, direction: Int) {
+    guard Self.keys.indices.contains(index), Self.keys[index].kana.indices.contains(direction) else { return }
+    let key = Self.keys[index]
+    if key.strokes[direction].isEmpty { onSymbol?(key.kana[direction]) }
+    else { onInput?(key.strokes[direction]) }
+  }
+  func applyLayout() {
+    let layout = KeyboardLayoutPreference.selected
+    spacing = layout.keySpacing
+    for row in rows { row.spacing = row.axis == .vertical ? layout.rowSpacing : layout.keySpacing }
+    (arrangedSubviews.first as? UIStackView)?.spacing = layout.rowSpacing
+  }
+}
+
+@MainActor
+private final class KanaFlickGesture: UIPanGestureRecognizer {
+  private let feedback: (Int, Bool) -> Void
+  init(feedback: @escaping (Int, Bool) -> Void) {
+    self.feedback = feedback
+    super.init(target: nil, action: nil)
+    addTarget(self, action: #selector(update))
+    maximumNumberOfTouches = 1
+    cancelsTouchesInView = true
+  }
+  @objc private func update() {
+    let offset = translation(in: view)
+    let direction: Int
+    if max(abs(offset.x), abs(offset.y)) < 12 { direction = 0 }
+    else if abs(offset.x) > abs(offset.y) { direction = offset.x < 0 ? 1 : 3 }
+    else { direction = offset.y < 0 ? 2 : 4 }
+    if state == .cancelled || state == .failed { feedback(0, false) }
+    else { feedback(direction, state == .ended) }
+  }
+}

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
@@ -75,7 +75,8 @@ final class KeyboardSchemePickerView: UIView {
       case .microsoft: glyph = "微"; badge = "双"
       case .shoudao: glyph = "S"; badge = "双"
       case .wubi: glyph = "五"; badge = "86"
-      case .japanese: glyph = "あ"; badge = "日"
+      case .japanese: glyph = "あ"; badge = "26"
+      case .japaneseNineKey: glyph = "あ"; badge = "9"
       case .handwriting: glyph = "写"; badge = "手"
       case .thoughtfulReply: glyph = "聊"; badge = "AI"
       }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -78,6 +78,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var actionDeleteButton: UIButton!
   private var actionGlobeButton: UIButton!
   private var globeWidthConstraint: NSLayoutConstraint?
+  private var japaneseKeys: JapaneseNineKeyView!
+  private var japaneseHeight: NSLayoutConstraint!
   private var nineKeyHeight: NSLayoutConstraint!
   private var nineKeySymbolsButton: UIButton!
   private let punctuationStack = UIStackView()
@@ -286,6 +288,17 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       root.addArrangedSubview(rowView)
     }
     root.addArrangedSubview(makeNineKeyLayout())
+    japaneseKeys = JapaneseNineKeyView { [unowned self] title, label, action in
+      makeKey(title: title, accessibilityLabel: label, action: action)
+    }
+    japaneseKeys.onInput = { [weak self] input in
+      guard let self, isChineseMode, inputScheme == .japanese else { return }
+      playInputClick()
+      for character in input { render(session.handleCharacter(String(character))) }
+    }
+    japaneseKeys.onSymbol = { [weak self] symbol in self?.handleSymbol(symbol) }
+    japaneseKeys.onDelete = { [weak self] in self?.handleBackspace() }
+    root.addArrangedSubview(japaneseKeys)
     handwriting.isHidden = true
     handwriting.onInsert = { [weak self] text in
       guard let self, inputScheme == .handwriting, isChineseMode else { return }
@@ -310,6 +323,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     // Keep the three keypad rows the same height as the bottom controls.
     nineKeyHeight = nineKeyContainer.heightAnchor.constraint(
       equalTo: actionRow.heightAnchor, multiplier: 3, constant: 14)
+    japaneseHeight = japaneseKeys.heightAnchor.constraint(equalTo: actionRow.heightAnchor, multiplier: 3, constant: 14)
     // Extra handwriting space belongs to the canvas, not enlarged Space/Return keys.
     handwritingActionHeight = actionRow.heightAnchor.constraint(equalToConstant: 44)
     updateKeyboardLayout()
@@ -1570,13 +1584,18 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     applyLayoutPreferences()
     standardRowHeights.forEach { $0.1.isActive = false }
     microsoftFinalKey?.isHidden = !(isChineseMode && inputScheme == .microsoft && !session.isInLocalMode)
+    let kana = isChineseMode && inputScheme == .japanese && !JapaneseKeyboardPreference.usesRomanKeys && !session.isInLocalMode
+    japaneseKeys?.isHidden = !kana || showsSymbols
+    japaneseHeight?.constant = KeyboardLayoutPreference.selected.rowSpacing * 2
+    japaneseHeight?.isActive = kana && !showsSymbols
+    japaneseKeys?.applyLayout()
     let nineKey = isChineseMode && inputScheme == .nineKey && !session.isInLocalMode
     let writes = isChineseMode && inputScheme == .handwriting && !showsSymbols && !session.isInLocalMode
     if !writes && !handwriting.isHidden { handwriting.deactivate() }
     handwriting.isHidden = !writes
     if writes { handwriting.activate() }
     handwritingActionHeight?.isActive = writes
-    letterRowViews.forEach { $0.isHidden = showsSymbols || nineKey || writes }
+    letterRowViews.forEach { $0.isHidden = showsSymbols || nineKey || writes || kana }
     nineKeyContainer.isHidden = showsSymbols || !nineKey
     nineKeyRows.forEach { $0.isHidden = showsSymbols || !nineKey }
     let hasSpellings = !session.nineKeySpellings().isEmpty
@@ -1605,7 +1624,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       fullSymbolsWidth?.isActive = !nineKeySymbolsButton.isHidden && !usesNineKeyLayout
       bottomLanguageButton?.isHidden = false
       bottomLanguageWidth?.isActive = true
-      quickPunctuationButton.isHidden = usesNineKeyLayout || showsSymbols || writes
+      quickPunctuationButton.isHidden = usesNineKeyLayout || showsSymbols || writes || kana
       quickPunctuationWidth?.isActive = !quickPunctuationButton.isHidden
       let punctuation = quickPunctuationSymbols
       quickPunctuationButton.configuration?.title = punctuation[0]
@@ -1620,7 +1639,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     symbolRowViews.forEach { $0.isHidden = !showsSymbols }
     for (row, height) in standardRowHeights { height.isActive = !row.isHidden }
     if var configuration = layoutToggleButton?.configuration {
-      configuration.title = showsSymbols ? (nineKey ? "九键" : "ABC") : "123"
+      configuration.title = showsSymbols ? (kana ? "あいう" : (nineKey ? "九键" : "ABC")) : "123"
       layoutToggleButton?.configuration = configuration
     }
     layoutToggleButton?.accessibilityLabel =

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -72,7 +72,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var inputContext = KeyboardInputContext()
   private var inputScheme: ChineseInputScheme = .quanpin
   private var usesShuangpin: Bool { inputScheme.shuangpinProfile != nil }
-  private var supportsLocalTools: Bool { isChineseMode && inputScheme != .wubi && inputScheme != .japanese }
+  private var supportsLocalTools: Bool { isChineseMode && inputScheme != .wubi && !inputScheme.isJapanese }
   private var nineKeyRows: [UIView] = []
   private var actionRow: UIStackView!
   private var actionDeleteButton: UIButton!
@@ -292,7 +292,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       makeKey(title: title, accessibilityLabel: label, action: action)
     }
     japaneseKeys.onInput = { [weak self] input in
-      guard let self, isChineseMode, inputScheme == .japanese else { return }
+      guard let self, isChineseMode, inputScheme.isJapanese else { return }
       playInputClick()
       for character in input { render(session.handleCharacter(String(character))) }
     }
@@ -601,7 +601,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     }
     configure(scriptShortcut, title: usesTraditionalOutput ? "繁" : "简", symbol: nil,
       label: usesTraditionalOutput ? "切换到简体" : "切换到繁体", id: "scriptShortcut")
-    scriptShortcut.isEnabled = !(isChineseMode && inputScheme == .japanese)
+    scriptShortcut.isEnabled = !(isChineseMode && inputScheme.isJapanese)
     scriptShortcut.accessibilityValue = scriptShortcut.isEnabled ? (usesTraditionalOutput ? "繁体" : "简体") : "日语不使用简繁转换"
     if KeyboardLayoutPreference.selected == .doubao {
       configure(scriptShortcut, title: nil, symbol: "waveform", label: "语音结果", id: "layoutVoiceShortcut")
@@ -1140,7 +1140,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
 
   private func updateLanguageModeButton() {
     var configuration = UIButton.Configuration.filled()
-    configuration.title = isChineseMode ? (inputScheme == .japanese ? "日" : "中") : "英"
+    configuration.title = isChineseMode ? (inputScheme.isJapanese ? "日" : "中") : "英"
     configuration.baseForegroundColor = KeyboardSkinPreference.selected.actionForeground
     configuration.baseBackgroundColor = KeyboardSkinPreference.selected.actionBackground
     configuration.contentInsets = NSDirectionalEdgeInsets(
@@ -1152,7 +1152,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     bottomLanguageButton?.accessibilityIdentifier = "bottomLanguageKey"
     bottomLanguageButton?.accessibilityLabel =
       isChineseMode ? "切换到英文输入" : "切换到所选输入方案"
-    bottomLanguageButton?.accessibilityValue = isChineseMode ? (inputScheme == .japanese ? "日语输入" : "中文输入") : "英文输入"
+    bottomLanguageButton?.accessibilityValue = isChineseMode ? (inputScheme.isJapanese ? "日语输入" : "中文输入") : "英文输入"
     updateShortcutButtons()
     updateKeyboardLayout()
   }
@@ -1196,7 +1196,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     case .nineKey: session.switchToNineKey()
     case .ziranma, .microsoft, .shoudao: session.switch(toShuangpinProfile: inputScheme.rawValue)
     case .wubi: session.switchToWubi()
-    case .japanese: session.switchToJapanese()
+    case .japanese, .japaneseNineKey: session.switchToJapanese()
     case .handwriting: session.switch(toShuangpin: false)
     case .quanpin, .shuangpin, .thoughtfulReply: session.switch(toShuangpin: usesShuangpin)
     }
@@ -1497,7 +1497,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   }
 
   private func chineseOutput(_ text: String) -> String {
-    if inputScheme == .japanese || localModeTrigger == "R" { return text }
+    if inputScheme.isJapanese || localModeTrigger == "R" { return text }
     return ChineseTextConversion.outputString(text, traditional: usesTraditionalOutput)
   }
 
@@ -1536,7 +1536,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
 
   private var quickPunctuationSymbols: [String] {
     guard isChineseMode, !session.isInLocalMode else { return [",", ".", "?", "!", ":", ";", "@"] }
-    if inputScheme == .japanese { return ["、", "。", "？", "！", "「", "」", "・"] }
+    if inputScheme.isJapanese { return ["、", "。", "？", "！", "「", "」", "・"] }
     return ["，", "。", "？", "！", "、", "；", "："]
   }
 
@@ -1584,7 +1584,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     applyLayoutPreferences()
     standardRowHeights.forEach { $0.1.isActive = false }
     microsoftFinalKey?.isHidden = !(isChineseMode && inputScheme == .microsoft && !session.isInLocalMode)
-    let kana = isChineseMode && inputScheme == .japanese && !JapaneseKeyboardPreference.usesRomanKeys && !session.isInLocalMode
+    let kana = isChineseMode && inputScheme == .japaneseNineKey && !session.isInLocalMode
     japaneseKeys?.isHidden = !kana || showsSymbols
     japaneseHeight?.constant = KeyboardLayoutPreference.selected.rowSpacing * 2
     japaneseHeight?.isActive = kana && !showsSymbols
@@ -1777,7 +1777,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   // Every document mutation the keyboard makes goes through here so textWillChange can tell its own
   // echo apart from a genuine host-initiated change.
   private var typingSource: TypingSource {
-    if localModeTrigger == "R" { return .japanese }
+    if localModeTrigger == "R" || (isChineseMode && inputScheme.isJapanese) { return .japanese }
     if localModeTrigger != nil { return .local }
     if !isChineseMode { return .english }
     if inputScheme == .thoughtfulReply { return .quanpin }
@@ -1898,7 +1898,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       })
     button.accessibilityLabel = "候选词 \(number)：\(display)"
     button.accessibilityIdentifier = "candidate-\(number)"
-    if isChineseMode && inputScheme != .japanese && !session.isInLocalMode {
+    if isChineseMode && !inputScheme.isJapanese && !session.isInLocalMode {
       let revision = candidateRevision
       func action(_ title: String, _ symbol: String, _ operation: MetasequoiaCandidateAction,
                   destructive: Bool = false) -> UIAction {

--- a/platforms/ios/KeyboardTests/JapaneseNineKeyTests.swift
+++ b/platforms/ios/KeyboardTests/JapaneseNineKeyTests.swift
@@ -6,15 +6,12 @@ final class JapaneseNineKeyTests: XCTestCase {
   func testKanaKeysFeedJapaneseEngineCandidates() throws {
     let previous = InputSchemePreference.scheme
     let enabled = InputSchemePreference.enabledSchemes
-    let roman = JapaneseKeyboardPreference.usesRomanKeys
     defer {
       InputSchemePreference.enabledSchemes = enabled
       InputSchemePreference.scheme = previous
-      JapaneseKeyboardPreference.usesRomanKeys = roman
     }
     InputSchemePreference.enabledSchemes = ChineseInputScheme.allCases
-    InputSchemePreference.scheme = .japanese
-    JapaneseKeyboardPreference.usesRomanKeys = false
+    InputSchemePreference.scheme = .japaneseNineKey
     let controller = KeyboardViewController()
     controller.loadViewIfNeeded()
     controller.view.frame = CGRect(x: 0, y: 0, width: 414, height: 260)
@@ -30,9 +27,37 @@ final class JapaneseNineKeyTests: XCTestCase {
       controller.view.layer.render(in: $0.cgContext)
     })
     screenshot.name = "Japanese nine-key candidates"; screenshot.lifetime = .keepAlways; add(screenshot)
-    JapaneseKeyboardPreference.usesRomanKeys = true
-    controller.viewWillAppear(false)
+    let picker = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "schemeButton" } as? UIButton)
+    picker.sendActions(for: .primaryActionTriggered)
+    for name in ["japanese", "japaneseNineKey"] {
+      XCTAssertNotNil(nodes(controller.view).first { $0.accessibilityIdentifier == "schemeCard-\(name)" })
+    }
+    let roman = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "schemeCard-japanese" } as? UIButton)
+    roman.sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(InputSchemePreference.scheme, .japanese)
     XCTAssertTrue(panel.isHidden)
+    controller.view.layoutIfNeeded()
+    let letter = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityLabel == "字母 A" } as? UIButton)
+    XCTAssertGreaterThan(letter.bounds.height, 40)
+    picker.sendActions(for: .primaryActionTriggered)
+    let nine = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "schemeCard-japaneseNineKey" } as? UIButton)
+    nine.sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(InputSchemePreference.scheme, .japaneseNineKey)
+    XCTAssertFalse(panel.isHidden)
+  }
+
+  func testExistingJapaneseEnablesBothLayoutsOnlyOnce() throws {
+    let name = "japanese-scheme-test-" + UUID().uuidString
+    let store = try XCTUnwrap(UserDefaults(suiteName: name))
+    defer { store.removePersistentDomain(forName: name) }
+    store.set(["quanpin", "japanese"], forKey: InputSchemePreference.enabledSchemesKey)
+    store.set("japanese", forKey: "chineseInputScheme")
+    InputSchemePreference.splitJapaneseSchemes(in: store)
+    XCTAssertEqual(store.string(forKey: "chineseInputScheme"), "japaneseNineKey")
+    XCTAssertEqual(store.stringArray(forKey: InputSchemePreference.enabledSchemesKey), ["quanpin", "japanese", "japaneseNineKey"])
+    store.set(["quanpin", "japanese"], forKey: InputSchemePreference.enabledSchemesKey)
+    InputSchemePreference.splitJapaneseSchemes(in: store)
+    XCTAssertEqual(store.stringArray(forKey: InputSchemePreference.enabledSchemesKey), ["quanpin", "japanese"], "A user can disable nine keys after the split")
   }
 
   func testEveryKanaKeyConvertsAndLayoutsKeepFullHeight() throws {

--- a/platforms/ios/KeyboardTests/JapaneseNineKeyTests.swift
+++ b/platforms/ios/KeyboardTests/JapaneseNineKeyTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import UIKit
+
+@MainActor
+final class JapaneseNineKeyTests: XCTestCase {
+  func testKanaKeysFeedJapaneseEngineCandidates() throws {
+    let previous = InputSchemePreference.scheme
+    let enabled = InputSchemePreference.enabledSchemes
+    let roman = JapaneseKeyboardPreference.usesRomanKeys
+    defer {
+      InputSchemePreference.enabledSchemes = enabled
+      InputSchemePreference.scheme = previous
+      JapaneseKeyboardPreference.usesRomanKeys = roman
+    }
+    InputSchemePreference.enabledSchemes = ChineseInputScheme.allCases
+    InputSchemePreference.scheme = .japanese
+    JapaneseKeyboardPreference.usesRomanKeys = false
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 414, height: 260)
+    controller.view.layoutIfNeeded()
+    let panel = try XCTUnwrap(nodes(controller.view).compactMap { $0 as? JapaneseNineKeyView }.first)
+    XCTAssertFalse(panel.isHidden)
+    panel.select(4, direction: 1) // に
+    panel.select(5, direction: 4) // ほ
+    panel.select(9, direction: 2) // ん
+    let first = try XCTUnwrap(nodes(controller.view).first { $0.accessibilityIdentifier == "candidate-1" } as? UIButton)
+    XCTAssertTrue(first.configuration?.title?.hasSuffix("日本") == true, first.configuration?.title ?? "No candidate")
+    let screenshot = XCTAttachment(image: UIGraphicsImageRenderer(bounds: controller.view.bounds).image {
+      controller.view.layer.render(in: $0.cgContext)
+    })
+    screenshot.name = "Japanese nine-key candidates"; screenshot.lifetime = .keepAlways; add(screenshot)
+    JapaneseKeyboardPreference.usesRomanKeys = true
+    controller.viewWillAppear(false)
+    XCTAssertTrue(panel.isHidden)
+  }
+
+  func testEveryKanaKeyConvertsAndLayoutsKeepFullHeight() throws {
+    let bridge = MetasequoiaInputSessionBridge()
+    _ = bridge.switchToJapanese()
+    for key in JapaneseNineKeyView.keys {
+      for (kana, input) in zip(key.kana, key.strokes) where !input.isEmpty {
+        _ = bridge.cancel()
+        var snapshot: MetasequoiaInputSnapshot?
+        for letter in input { snapshot = bridge.handleCharacter(String(letter)) }
+        XCTAssertTrue(snapshot?.candidates.contains(kana) == true, "\(input) → \(kana): \(snapshot?.candidates ?? [])")
+      }
+    }
+    let previous = KeyboardLayoutPreference.selected
+    defer { KeyboardLayoutPreference.selected = previous }
+    for layout in KeyboardLayoutPreset.allCases {
+      KeyboardLayoutPreference.selected = layout
+      for width in [320.0, 414.0] {
+        let panel = JapaneseNineKeyView { title, _, action in
+          var config = UIButton.Configuration.plain(); config.title = title
+          return UIButton(configuration: config, primaryAction: UIAction { _ in action() })
+        }
+        panel.frame = CGRect(x: 0, y: 0, width: width, height: 176)
+        panel.applyLayout(); panel.layoutIfNeeded()
+        let buttons = nodes(panel).compactMap { $0 as? UIButton }
+        XCTAssertEqual(buttons.count, 12)
+        for button in buttons {
+          XCTAssertGreaterThan(button.bounds.height, 45)
+          XCTAssertGreaterThan(button.bounds.width, 44)
+          XCTAssertLessThanOrEqual(button.convert(button.bounds, to: panel).maxX, width + 0.5)
+        }
+      }
+    }
+  }
+  private func nodes(_ view: UIView) -> [UIView] { [view] + view.subviews.flatMap { nodes($0) } }
+}

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -713,15 +713,15 @@ final class NineKeyKeyboardTests: XCTestCase {
             }
           }
           let punctuation = try button("quickPunctuationKey", in: controller)
-          XCTAssertEqual(punctuation.isHidden, symbols || [.nineKey, .japanese, .handwriting].contains(scheme))
+          XCTAssertEqual(punctuation.isHidden, symbols || [.nineKey, .japaneseNineKey, .handwriting].contains(scheme))
           if !punctuation.isHidden {
-            XCTAssertEqual(punctuation.configuration?.title, scheme == .japanese ? "、" : "，")
+            XCTAssertEqual(punctuation.configuration?.title, scheme.isJapanese ? "、" : "，")
             XCTAssertEqual(punctuation.bounds.width, 44, accuracy: 0.5)
             XCTAssertGreaterThanOrEqual(try button("spaceKey", in: controller).bounds.width, 79.2)
             XCTAssertEqual(punctuation.menu?.children.count, 7)
           }
           XCTAssertEqual(try button("symbolDeleteKey", in: controller).isHidden, !symbols)
-          if !symbols && ![.nineKey, .japanese, .handwriting].contains(scheme) {
+          if !symbols && ![.nineKey, .japaneseNineKey, .handwriting].contains(scheme) {
             let delete = try button("letterDeleteKey", in: controller)
             let shift = try button("shiftButton", in: controller)
             let m = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityLabel == "字母 M" } as? UIButton)
@@ -739,7 +739,7 @@ final class NineKeyKeyboardTests: XCTestCase {
               XCTAssertLessThanOrEqual(frame.maxX, controller.view.bounds.width - 4.5, "\(scheme) \(label) frame \(frame)")
             }
           }
-          if !symbols && scheme == .japanese {
+          if !symbols && scheme == .japaneseNineKey {
             XCTAssertEqual(try button("japaneseKana0", in: controller).bounds.height, reference, accuracy: 0.5)
           }
           if symbols { try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered) }

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -713,7 +713,7 @@ final class NineKeyKeyboardTests: XCTestCase {
             }
           }
           let punctuation = try button("quickPunctuationKey", in: controller)
-          XCTAssertEqual(punctuation.isHidden, symbols || scheme == .nineKey)
+          XCTAssertEqual(punctuation.isHidden, symbols || [.nineKey, .japanese, .handwriting].contains(scheme))
           if !punctuation.isHidden {
             XCTAssertEqual(punctuation.configuration?.title, scheme == .japanese ? "、" : "，")
             XCTAssertEqual(punctuation.bounds.width, 44, accuracy: 0.5)
@@ -721,7 +721,7 @@ final class NineKeyKeyboardTests: XCTestCase {
             XCTAssertEqual(punctuation.menu?.children.count, 7)
           }
           XCTAssertEqual(try button("symbolDeleteKey", in: controller).isHidden, !symbols)
-          if !symbols && scheme != .nineKey {
+          if !symbols && ![.nineKey, .japanese, .handwriting].contains(scheme) {
             let delete = try button("letterDeleteKey", in: controller)
             let shift = try button("shiftButton", in: controller)
             let m = try XCTUnwrap(descendants(controller.view).first { $0.accessibilityLabel == "字母 M" } as? UIButton)
@@ -738,6 +738,9 @@ final class NineKeyKeyboardTests: XCTestCase {
               XCTAssertGreaterThanOrEqual(frame.minX, 4.5)
               XCTAssertLessThanOrEqual(frame.maxX, controller.view.bounds.width - 4.5, "\(scheme) \(label) frame \(frame)")
             }
+          }
+          if !symbols && scheme == .japanese {
+            XCTAssertEqual(try button("japaneseKana0", in: controller).bounds.height, reference, accuracy: 0.5)
           }
           if symbols { try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered) }
         }

--- a/platforms/ios/SharedUI/InputSchemePreference.swift
+++ b/platforms/ios/SharedUI/InputSchemePreference.swift
@@ -19,7 +19,7 @@ enum ChineseInputScheme: String, CaseIterable {
     case .microsoft: "微软双拼"
     case .shoudao: "Shoudao 双拼"
     case .wubi: "86 五笔"
-    case .japanese: "日语罗马字"
+    case .japanese: "日语"
     case .handwriting: "手写"
     case .thoughtfulReply: "高情商回复"
     }
@@ -82,5 +82,15 @@ enum InputSchemePreference {
       defaults.set(newValue, forKey: key)
       defaults.set(newValue ? ChineseInputScheme.shuangpin.rawValue : ChineseInputScheme.quanpin.rawValue, forKey: schemeKey)
     }
+  }
+}
+
+// A keyboard presentation preference; Engine remains in the Japanese session mode.
+enum JapaneseKeyboardPreference {
+  static let romanKeysKey = "japaneseRomanKeys"
+  static var defaults: UserDefaults { UserDefaults(suiteName: InputSchemePreference.appGroupIdentifier) ?? .standard }
+  static var usesRomanKeys: Bool {
+    get { defaults.bool(forKey: romanKeysKey) }
+    set { defaults.set(newValue, forKey: romanKeysKey) }
   }
 }

--- a/platforms/ios/SharedUI/InputSchemePreference.swift
+++ b/platforms/ios/SharedUI/InputSchemePreference.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 enum ChineseInputScheme: String, CaseIterable {
-  case quanpin, nineKey, shuangpin, ziranma, microsoft, shoudao, wubi, japanese, handwriting, thoughtfulReply
+  case quanpin, nineKey, shuangpin, ziranma, microsoft, shoudao, wubi, japaneseNineKey, japanese, handwriting, thoughtfulReply
+
+  var isJapanese: Bool { self == .japanese || self == .japaneseNineKey }
 
   var shuangpinProfile: String? {
     switch self {
@@ -19,7 +21,8 @@ enum ChineseInputScheme: String, CaseIterable {
     case .microsoft: "微软双拼"
     case .shoudao: "Shoudao 双拼"
     case .wubi: "86 五笔"
-    case .japanese: "日语"
+    case .japanese: "日语 26 键"
+    case .japaneseNineKey: "日语 9 键"
     case .handwriting: "手写"
     case .thoughtfulReply: "高情商回复"
     }
@@ -30,13 +33,28 @@ enum InputSchemePreference {
   static let enabledSchemesKey = "enabledInputSchemes"
   private static var defaults: UserDefaults { UserDefaults(suiteName: appGroupIdentifier) ?? .standard }
 
+  // Split the previous Japanese layout setting into two independently visible schemes once.
+  static func splitJapaneseSchemes(in store: UserDefaults) {
+    guard !store.bool(forKey: "japaneseSchemesSplit") else { return }
+    if var enabled = store.stringArray(forKey: enabledSchemesKey), enabled.contains("japanese") {
+      if !enabled.contains("japaneseNineKey") { enabled.append("japaneseNineKey") }
+      store.set(enabled, forKey: enabledSchemesKey)
+    }
+    if store.string(forKey: schemeKey) == "japanese", !store.bool(forKey: "japaneseRomanKeys") {
+      store.set("japaneseNineKey", forKey: schemeKey)
+    }
+    store.set(true, forKey: "japaneseSchemesSplit")
+  }
+
   static var enabledSchemes: [ChineseInputScheme] {
     get {
+      splitJapaneseSchemes(in: defaults)
       guard let stored = defaults.stringArray(forKey: enabledSchemesKey) else { return ChineseInputScheme.allCases }
       let enabled = ChineseInputScheme.allCases.filter { stored.contains($0.rawValue) }
       return enabled.isEmpty ? [.quanpin] : enabled
     }
     set {
+      splitJapaneseSchemes(in: defaults)
       let ordered = ChineseInputScheme.allCases.filter { newValue.contains($0) }
       let enabled = ordered.isEmpty ? [.quanpin] : ordered
       defaults.set(enabled.map(\.rawValue), forKey: enabledSchemesKey)
@@ -48,6 +66,7 @@ enum InputSchemePreference {
   static var scheme: ChineseInputScheme {
     get {
       let defaults = UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+      splitJapaneseSchemes(in: defaults)
       if let value = defaults.string(forKey: schemeKey), let scheme = ChineseInputScheme(rawValue: value) {
         return enabledSchemes.contains(scheme) ? scheme : enabledSchemes[0]
       }
@@ -82,15 +101,5 @@ enum InputSchemePreference {
       defaults.set(newValue, forKey: key)
       defaults.set(newValue ? ChineseInputScheme.shuangpin.rawValue : ChineseInputScheme.quanpin.rawValue, forKey: schemeKey)
     }
-  }
-}
-
-// A keyboard presentation preference; Engine remains in the Japanese session mode.
-enum JapaneseKeyboardPreference {
-  static let romanKeysKey = "japaneseRomanKeys"
-  static var defaults: UserDefaults { UserDefaults(suiteName: InputSchemePreference.appGroupIdentifier) ?? .standard }
-  static var usesRomanKeys: Bool {
-    get { defaults.bool(forKey: romanKeysKey) }
-    set { defaults.set(newValue, forKey: romanKeysKey) }
   }
 }

--- a/platforms/ios/SharedUI/TypingStatistics.swift
+++ b/platforms/ios/SharedUI/TypingStatistics.swift
@@ -12,7 +12,7 @@ enum TypingSource: String, CaseIterable {
     case .microsoft: "微软双拼"
     case .shoudao: "Shoudao 双拼"
     case .wubi: "86 五笔"
-    case .japanese: "日语罗马字"
+    case .japanese: "日语"
     case .handwriting: "手写"
     case .english: "英文键盘"
     case .local: "本地输入"

--- a/shared/backend/IOSPreferencePlan.swift
+++ b/shared/backend/IOSPreferencePlan.swift
@@ -35,7 +35,7 @@ struct IOSPreferencePlan {
         scheme = "wubi"
       case "japanese":
         guard try string("input.japanese_schema") ?? "romaji" == "romaji" else { throw BackendAccountClient.Failure(status: 400) }
-        scheme = "japanese"
+        scheme = nineKey == true ? "japaneseNineKey" : "japanese"
       default: throw BackendAccountClient.Failure(status: 400)
       }
     } else { scheme = nil }

--- a/shared/backend/Tests/BackendPreferencesTests.swift
+++ b/shared/backend/Tests/BackendPreferencesTests.swift
@@ -29,6 +29,10 @@ final class BackendPreferencesTests: XCTestCase {
       ["platform.ios.sound_enabled": .string("true")],
       ["platform.ios.haptic_strength": .string("unsafe")]
     ] { XCTAssertThrowsError(try IOSPreferencePlan(settings)) }
+    let japanese = try IOSPreferencePlan(["input.schema": .string("japanese"), "platform.ios.nine_key": .boolean(true)])
+    XCTAssertEqual(japanese.scheme, "japaneseNineKey")
+    let roman = try IOSPreferencePlan(["input.schema": .string("japanese"), "platform.ios.nine_key": .boolean(false)])
+    XCTAssertEqual(roman.scheme, "japanese")
     let nine = try IOSPreferencePlan(["input.schema": .string("quanpin"), "platform.ios.nine_key": .boolean(true)])
     XCTAssertEqual(nine.scheme, "nineKey")
     XCTAssertNil(nine.sound)


### PR DESCRIPTION
键盘快捷切换和 App 输入方案列表分别提供「日语 9 键」与「日语 26 键」，两者可以独立启用或隐藏。此前单个“日语”入口默认九键，26 键藏在设置里；本次直接通过方案卡片切换。升级时保留已有选择，为已启用日语的用户补齐两个入口，仅执行一次，后续尊重用户取消显示的选择。云端配置正确保存并恢复两种布局，统计仍归入日语。

九键提供あ/か/さ、た/な/は、ま/や/ら以及わ/を/ん、长音符、删除和小假名/浊音/半浊音菜单。轻点输入首字，左/上/右/下滑动选字，长按也可选择。键帽映射到既有 Engine 日语会话按键，候选转换和上屏沿用现有流程。ん 使用 n' 边界避免重复鼻音，长音符走现有符号插入。三行按键与底部操作键等高，并适配皮肤和布局间距。

验证：
- 真实键盘扩展滑动输入 に・ほ・ん，第一候选及上屏文字均为日本。
- 原生测试覆盖全部主键假名、候选、两个快捷入口、卡片切换、一次性设置迁移，以及 320/414 宽度下的布局。
- 31 项现有键盘回归通过；拆分后 3 项日语测试、3 项云端偏好测试通过。
- Release 归档通过，已安装到 XR。
- 基于 develop 3cbfeed，保留个人资料和手写高度改动。
