### PR TITLE
perf(ci): slice the iOS interface suite across parallel runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_only != true }}
     # ML Kit ships x86_64 simulator binaries; run them natively instead of under Rosetta.
     runs-on: macos-15-intel
-    timeout-minutes: 120
+    timeout-minutes: 60
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
@@ -180,14 +180,66 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
       - name: Test native iOS keyboard and settings
-        # Includes simulator boot, test-bundle compilation, and the full UI/unit suite.
-        # Includes the expanded skin, community, account, and handwriting suites.
-        timeout-minutes: 80
+        # Interface tests run in the ios-ui matrix; this covers the keyboard, service and backend
+        # suites, which finish in about a minute once the test bundles are compiled.
+        env:
+          MSIME_TEST_SCOPE: unit
+        timeout-minutes: 30
         run: bash platforms/ios/scripts/run_ui_tests.sh
       - name: Upload iOS test results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ios-test-results
+          name: ios-test-results-unit
+          path: build/ios-derived/Logs/Test/*.xcresult
+          retention-days: 7
+
+  ios-ui:
+    # The interface suite is 40 cases and roughly 48 minutes of simulator time, so it decides how
+    # long CI takes. Slice it across runners instead of letting one runner walk the whole list.
+    name: iOS Interface ${{ matrix.slice }}/4
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_only != true }}
+    # ML Kit ships x86_64 simulator binaries; run them natively instead of under Rosetta.
+    runs-on: macos-15-intel
+    timeout-minutes: 90
+    strategy:
+      # A failure in one slice says nothing about the others, and cancelling them throws away the
+      # evidence needed to tell a real regression from a flake.
+      fail-fast: false
+      matrix:
+        slice: [1, 2, 3, 4]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+      - name: Install project generator
+        run: |
+          brew install boost fmt spdlog nlohmann-json xcodegen
+          if ! command -v pod >/dev/null 2>&1; then
+            brew install cocoapods
+          fi
+          pod --version
+      - name: Package iOS dictionary
+        run: python3 platforms/ios/scripts/prepare_dictionary.py
+      - name: Generate Xcode project
+        run: |
+          mkdir -p build/ios
+          xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
+          pod install --deployment --project-directory=platforms/ios
+      - name: Test the iOS interface slice
+        env:
+          MSIME_TEST_SCOPE: ui
+          MSIME_UI_SHARD_INDEX: ${{ matrix.slice }}
+          MSIME_UI_SHARD_COUNT: 4
+        timeout-minutes: 70
+        run: bash platforms/ios/scripts/run_ui_tests.sh
+      - name: Upload iOS interface results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ios-test-results-ui-${{ matrix.slice }}
           path: build/ios-derived/Logs/Test/*.xcresult
           retention-days: 7

--- a/platforms/ios/scripts/run_ui_tests.sh
+++ b/platforms/ios/scripts/run_ui_tests.sh
@@ -4,10 +4,25 @@ set -euo pipefail
 project_path="${1:-build/ios/MetasequoiaImeIOS.xcworkspace}"
 derived_data_path="${2:-build/ios-derived}"
 
+# all: every target. unit: everything except the interface suite. ui: the interface suite alone,
+# optionally split into MSIME_UI_SHARD_COUNT slices so CI can run them on parallel runners.
+test_scope="${MSIME_TEST_SCOPE:-all}"
+ui_shard_index="${MSIME_UI_SHARD_INDEX:-1}"
+ui_shard_count="${MSIME_UI_SHARD_COUNT:-1}"
+ui_target="MetasequoiaImeIOSUITests"
+
 if [[ ! -d "${project_path}" ]]; then
   echo "Generated Xcode project not found: ${project_path}" >&2
   exit 1
 fi
+
+case "${test_scope}" in
+  all | unit | ui) ;;
+  *)
+    echo "Unknown MSIME_TEST_SCOPE: ${test_scope} (expected all, unit or ui)" >&2
+    exit 1
+    ;;
+esac
 
 if [[ -n "${IOS_SIMULATOR_UDID:-}" ]]; then
   test_device_id="${IOS_SIMULATOR_UDID}"
@@ -48,11 +63,56 @@ xcrun simctl shutdown "${test_device_id}" >/dev/null 2>&1 || true
 xcrun simctl boot "${test_device_id}"
 xcrun simctl bootstatus "${test_device_id}" -b
 
-xcodebuild \
-  -workspace "${project_path}" \
-  -scheme MetasequoiaImeIOS \
-  -configuration Debug \
-  -destination "platform=iOS Simulator,id=${test_device_id},arch=x86_64" \
-  -derivedDataPath "${derived_data_path}" \
-  BREW_PREFIX="$(brew --prefix)" \
-  test
+xcodebuild_common=(
+  -workspace "${project_path}"
+  -scheme MetasequoiaImeIOS
+  -configuration Debug
+  -destination "platform=iOS Simulator,id=${test_device_id},arch=x86_64"
+  -derivedDataPath "${derived_data_path}"
+  BREW_PREFIX="$(brew --prefix)"
+)
+
+if [[ "${test_scope}" == "all" ]]; then
+  xcodebuild "${xcodebuild_common[@]}" test
+  exit 0
+fi
+
+if [[ "${test_scope}" == "unit" ]]; then
+  xcodebuild "${xcodebuild_common[@]}" -skip-testing:"${ui_target}" test
+  exit 0
+fi
+
+if [[ "${ui_shard_count}" -le 1 ]]; then
+  xcodebuild "${xcodebuild_common[@]}" -only-testing:"${ui_target}" test
+  exit 0
+fi
+
+# Splitting by class would not help: the interface suite is one class, and xcodebuild distributes
+# parallel work per class. Enumerate the cases instead and deal them out one runner at a time, so a
+# new test joins a slice without anyone editing the workflow.
+xcodebuild "${xcodebuild_common[@]}" build-for-testing
+
+enumerated="${derived_data_path}/ui-test-enumeration.json"
+mkdir -p "${derived_data_path}"
+# Write to a file rather than standard out: xcodebuild interleaves its own progress into the
+# stream and corrupts the document.
+xcodebuild "${xcodebuild_common[@]}" \
+  -only-testing:"${ui_target}" \
+  -enumerate-tests \
+  -test-enumeration-style flat \
+  -test-enumeration-format json \
+  -test-enumeration-output-path "${enumerated}" \
+  test-without-building
+
+# macOS still ships bash 3.2, which has no mapfile.
+shard_arguments=()
+while IFS= read -r argument; do
+  shard_arguments+=("${argument}")
+done < <(
+  MSIME_UI_SHARD_INDEX="${ui_shard_index}" \
+  MSIME_UI_SHARD_COUNT="${ui_shard_count}" \
+  python3 "$(dirname "$0")/select_ui_test_shard.py" "${enumerated}"
+)
+
+echo "Interface slice ${ui_shard_index}/${ui_shard_count}: ${#shard_arguments[@]} cases"
+xcodebuild "${xcodebuild_common[@]}" "${shard_arguments[@]}" test-without-building

--- a/platforms/ios/scripts/select_ui_test_shard.py
+++ b/platforms/ios/scripts/select_ui_test_shard.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Print the -only-testing arguments for one slice of the enumerated interface suite.
+
+Reads the JSON produced by `xcodebuild -enumerate-tests -test-enumeration-format json` and deals
+the cases out one runner at a time in identifier order. Neighbouring identifiers share a prefix and
+usually exercise the same screen, so dealing them to different runners keeps the expensive screens
+away from a single slice.
+"""
+
+import json
+import os
+import sys
+
+
+def identifiers(payload):
+    found = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            identifier = node.get("identifier")
+            if isinstance(identifier, str) and identifier.endswith("()"):
+                found.append(identifier)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(payload)
+    return sorted(set(found))
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: select_ui_test_shard.py <enumeration.json>")
+
+    index = int(os.environ.get("MSIME_UI_SHARD_INDEX", "1"))
+    count = int(os.environ.get("MSIME_UI_SHARD_COUNT", "1"))
+    if count < 1 or not 1 <= index <= count:
+        raise SystemExit(f"Slice {index}/{count} is out of range")
+
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    cases = identifiers(payload)
+    if not cases:
+        raise SystemExit("The enumeration listed no test cases; the suite would run empty")
+    if len(cases) < count:
+        raise SystemExit(f"{len(cases)} cases cannot fill {count} slices")
+
+    for position, case in enumerate(cases):
+        if position % count == index - 1:
+            print("-only-testing:" + case.removesuffix("()"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The iOS job takes 1 h 25 m, and almost all of it is one suite. Step timings from a recent run:

```
  0m43s  Check out source
  0m52s  Install project generator
  2m31s  Test shared account transport and session lifecycle
  0m44s  Generate Xcode project
  5m06s  Build host app and keyboard extension
 73m35s  Test native iOS keyboard and settings
```

Inside that 73 minutes, roughly 4 minutes compile the test bundles and boot the simulator, 54 minutes execute tests, and the rest assembles the result bundle. The execution time splits like this:

```
 47.9 min    40 cases   OnboardingUITests
  1.9 min    31 cases   NineKeyKeyboardTests
  0.6 min   121 cases   everything else
```

96% of the wall clock is the interface suite. Its slowest cases are `testCustomSkinTemplatesLibraryAndUndo` at 5.9 minutes and `testCuratedSkinCollectionShowsFullPreviewsAndUndo` at 4.3 minutes.

## What this does

Splitting by class would not help, because all 40 cases live in one class and `xcodebuild` distributes parallel work per class. So the slices are decided at run time instead:

1. `xcodebuild build-for-testing`
2. `xcodebuild -enumerate-tests -test-enumeration-output-path …` lists the cases
3. `select_ui_test_shard.py` deals them out one runner at a time in identifier order
4. `xcodebuild test-without-building -only-testing:…` runs that runner's slice

Dealing rather than chunking matters: neighbouring identifiers share a prefix and usually exercise the same screen, so the expensive screens land on different runners. Against today's suite the four slices come out at 11.3, 11.4, 11.4 and 13.8 minutes.

Nobody has to maintain a list of test names. A new case is enumerated automatically and joins a slice on its own.

`run_ui_tests.sh` gains `MSIME_TEST_SCOPE`:

- `all` (default) keeps the current behaviour, so running the script by hand is unchanged
- `unit` skips the interface target, which is what the existing `iOS Simulator` job now runs
- `ui` with `MSIME_UI_SHARD_INDEX` / `MSIME_UI_SHARD_COUNT` runs one interface slice

The workflow keeps the `iOS Simulator` job under its current name and adds an `iOS Interface N/4` matrix.

Expected wall clock is about 31 minutes, down from 85. It costs more runner minutes: five macOS Intel runners instead of one, roughly 110 minutes against 85. That is the trade being made.

## Verification

Run locally against an iOS 26.0 x86_64 simulator.

- Slice 1 end to end through the modified script: `Interface slice 1/4: 10 cases`, all 10 passed, exit 0
- `MSIME_TEST_SCOPE=unit`: 111 cases passed, zero interface cases executed, exit 0
- Enumeration writes valid JSON to the output path and lists all 40 cases. Note that `-test-enumeration-format json` alone is not enough: xcodebuild interleaves its own progress into standard out and corrupts the document, so `-test-enumeration-output-path` is required.
- Slice union covers all 40 cases exactly once, at 10 cases per slice
- `actionlint` with `SHELLCHECK_OPTS=--severity=warning`, and `shellcheck` on the script, both clean
- `ProjectConfigurationTests.py`, `DictionaryPackagingTests.py`, `ReleaseConfigurationTests.py`, `ReleaseAutomationTests.py` all pass

## Needs a repository setting

`iOS Interface 1/4` through `4/4` are new checks and are not in the required set on `main` or `develop`. Until they are added, a broken interface test will not block a merge. The `iOS Simulator` check keeps its name, so nothing that is required today changes.

## Not addressed here

Those two multi-minute cases are worth their own investigation. A UI test that runs for six minutes is usually waiting on something rather than exercising it.
