### PR TITLE
fix(ci): correct the interface slice filter and two racing assertions

### DIFF
--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -40,15 +40,12 @@ final class OnboardingUITests: XCTestCase {
         predicate: NSPredicate(format: "value == %@", "使用中"), object: button)
       XCTAssertEqual(XCTWaiter.wait(for: [selected], timeout: 10), .completed)
     }
-    for style in ["sky", "dusk", "vermilion", "forest"] {
-      select(style)
-      // Exercise OS persistence for every icon and finish the previous system notification
-      // session before requesting another change.
-      app.terminate()
-      app.launch()
-      openIcons()
-      XCTAssertEqual(app.buttons["appIcon_\(style)"].value as? String, "使用中")
-    }
+    // One change only. A Simulator applies the first alternate icon it is given and then refuses
+    // every later request, relaunching the app included, so asking for a second one would test the
+    // Simulator rather than the app. A fresh CI runner always exercises a real change; a Simulator
+    // reused locally may already hold this icon, in which case select returns and the assertion
+    // below still describes what the system reports.
+    select("sky")
     let selectedScreenshot = XCTAttachment(screenshot: app.screenshot())
     selectedScreenshot.name = "App icon selected"
     selectedScreenshot.lifetime = .keepAlways
@@ -56,8 +53,7 @@ final class OnboardingUITests: XCTestCase {
     app.terminate()
     app.launch()
     openIcons()
-    XCTAssertEqual(app.buttons["appIcon_forest"].value as? String, "使用中")
-    select("classic")
+    XCTAssertEqual(app.buttons["appIcon_sky"].value as? String, "使用中")
   }
 
   @MainActor
@@ -1329,7 +1325,9 @@ final class OnboardingUITests: XCTestCase {
       return
     }
     tryoutField.typeText("test")
-    XCTAssertEqual(tryoutField.value as? String, "test")
+    // A loaded runner reports the field's value while it is still catching up with the keystrokes,
+    // which reads as a prefix of the typed text rather than a lost character.
+    XCTAssertTrue(wait(tryoutField, until: "value == 'test'"))
 
     // The field had no way to put the keyboard away without leaving the app.
     let dismissButton = app.buttons["dismissKeyboardButton"]

--- a/platforms/ios/scripts/run_ui_tests.sh
+++ b/platforms/ios/scripts/run_ui_tests.sh
@@ -111,7 +111,7 @@ while IFS= read -r argument; do
 done < <(
   MSIME_UI_SHARD_INDEX="${ui_shard_index}" \
   MSIME_UI_SHARD_COUNT="${ui_shard_count}" \
-  python3 "$(dirname "$0")/select_ui_test_shard.py" "${enumerated}"
+  python3 "$(dirname "$0")/select_ui_test_shard.py" "${enumerated}" "${ui_target}"
 )
 
 echo "Interface slice ${ui_shard_index}/${ui_shard_count}: ${#shard_arguments[@]} cases"

--- a/platforms/ios/scripts/select_ui_test_shard.py
+++ b/platforms/ios/scripts/select_ui_test_shard.py
@@ -5,6 +5,9 @@ Reads the JSON produced by `xcodebuild -enumerate-tests -test-enumeration-format
 the cases out one runner at a time in identifier order. Neighbouring identifiers share a prefix and
 usually exercise the same screen, so dealing them to different runners keeps the expensive screens
 away from a single slice.
+
+The target is filtered here rather than trusted to `-only-testing`. Xcode 26.3 enumerates the whole
+scheme regardless of that flag, which handed every slice a mix of interface and unit cases.
 """
 
 import json
@@ -12,13 +15,14 @@ import os
 import sys
 
 
-def identifiers(payload):
+def identifiers(payload, target):
+    prefix = target + "/"
     found = []
 
     def walk(node):
         if isinstance(node, dict):
             identifier = node.get("identifier")
-            if isinstance(identifier, str) and identifier.endswith("()"):
+            if isinstance(identifier, str) and identifier.endswith("()") and identifier.startswith(prefix):
                 found.append(identifier)
             for value in node.values():
                 walk(value)
@@ -31,8 +35,8 @@ def identifiers(payload):
 
 
 def main():
-    if len(sys.argv) != 2:
-        raise SystemExit("usage: select_ui_test_shard.py <enumeration.json>")
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: select_ui_test_shard.py <enumeration.json> <test-target>")
 
     index = int(os.environ.get("MSIME_UI_SHARD_INDEX", "1"))
     count = int(os.environ.get("MSIME_UI_SHARD_COUNT", "1"))
@@ -42,9 +46,10 @@ def main():
     with open(sys.argv[1], encoding="utf-8") as handle:
         payload = json.load(handle)
 
-    cases = identifiers(payload)
+    target = sys.argv[2]
+    cases = identifiers(payload, target)
     if not cases:
-        raise SystemExit("The enumeration listed no test cases; the suite would run empty")
+        raise SystemExit(f"The enumeration listed no {target} cases; the slice would run empty")
     if len(cases) < count:
         raise SystemExit(f"{len(cases)} cases cannot fill {count} slices")
 


### PR DESCRIPTION
Three failures from the first sharded run on main (34297262068). Each one is unrelated to the others.

## The slices were not slicing

Every slice reported `37 cases` and ran a mix of interface and unit tests:

```
Interface slice 4/4: 37 cases
-only-testing:MetasequoiaImeIOSUITests/OnboardingUITests/testAppIcons...
-only-testing:MetasequoiaKeyboardTests/NineKeyKeyboardTests/testJapanese...
-only-testing:MetasequoiaServiceTests/CustomServiceTests/testVoicePresets...
```

Xcode 26.3 ignores `-only-testing` while enumerating and lists the whole scheme, which is 148 cases, and 148 ÷ 4 is 37. Xcode 26.6 honours the flag, so the local check that this shipped with saw a correct 40 and the difference never showed.

The target is filtered in `select_ui_test_shard.py` now rather than trusted to `xcodebuild`, which makes the split independent of the toolchain version.

Reproduced by enumerating locally without `-only-testing`: 148 cases, matching CI exactly, split into `MetasequoiaKeyboardTests` 96, `MetasequoiaImeIOSUITests` 40, `MetasequoiaServiceTests` 12. Running the fixed script against that same document yields four slices of 10, no non-interface cases, and a union of exactly 40.

## The app icon case asked the Simulator for something it will not do

`testAppIconsAreAvailableFromMyTabAndPersist` failed on the second icon, not the first. From the activity trace:

```
t = 85.14s  Tap "appIcon_dusk"      sky had already been applied, terminated and relaunched
t = 89.27s  Checking "暂时无法更换图标" Alert
```

A Simulator applies the first alternate icon it is given, reporting a POSIX I/O error from the completion handler while doing so, and then refuses every later request. Relaunching the app does not clear that. `alternateIconName` was still `AppIconSky` when dusk was requested, so the app was right to report a failure and the assertion was right to fire. What is wrong is the loop asking for four icons in a row: past the first one it tests the Simulator rather than the app.

The case now changes one icon and checks it survives a relaunch. A fresh CI runner always exercises a real change; a Simulator reused locally may already hold the icon, in which case the selection returns early and the assertion still describes what the system reports.

Coverage narrows here. Verifying all five icons round-trip through the OS is not something a Simulator can answer.

## Reading a text field mid-keystroke

`testSettingsPersistAndExposeGuideAndTryout` failed with `("Optional("te")") is not equal to ("Optional("test")")`. A loaded runner reports the field's value while it is still catching up, so the read lands on a prefix. Replaced with the same waiting helper the neighbouring assertions use. The other nine `typeText` call sites already tap something and wait on the result, so this was the only one exposed.

## Verification

Local, iOS 26.0 x86_64 Simulator erased first so it starts with no alternate icon, matching a fresh runner.

- `testAppIconsAreAvailableFromMyTabAndPersist` passed in 38.4s, and the trace confirms it tapped `appIcon_sky` and performed a real change rather than returning early
- `testSettingsPersistAndExposeGuideAndTryout` passed in 77.8s
- Shard filter against a 148-case enumeration: 10 + 10 + 10 + 10, zero non-interface cases, union 40
- `actionlint` with `SHELLCHECK_OPTS=--severity=warning`, `shellcheck`, and `py_compile` all clean
- `ProjectConfigurationTests.py`, `DictionaryPackagingTests.py`, `ReleaseConfigurationTests.py`, `ReleaseAutomationTests.py` all pass

## Worth knowing

`iOS Interface 1/4` took 25m47s on the intel runner even while running 37 cases. With 10 the slices should land near the 11 to 14 minutes the split was designed around.

The account caps macOS jobs at 5 concurrent, which was visible during that run: exactly five macOS jobs ran while everything else queued. A CI run now asks for 8 macOS jobs, so the slices queue rather than all starting at once. Expect roughly 40 minutes rather than the 31 the sharding change predicted. Under that cap the four slices each repeating an 11 minute setup and build is no longer free parallelism; building once and passing the products between jobs would take about 33 minutes of duplicated work out of the pool. That is a separate change.
