### PR TITLE
Revert "feat(ios)!: ship x.y as the marketing version"

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ GitHub 没有自定义频道，只有 Latest / Pre-release / Draft 三种状态�
 
 这两个开关**只在版本号小于 `1.0.0` 时生效**。真发布 1.0.0 之后它们自动失效，退回 release-please 的默认行为（`feat:` 推 y、`!` 推 x），届时要重新决定这一段怎么写。
 
-iOS 的版本号有一处刻意的偏离：发布脚本把 `MARKETING_VERSION` 截断成 **x.y** 再归档，第三位交给 `CURRENT_PROJECT_VERSION`（取 `git rev-list --count HEAD`）承载。TestFlight 按 `CFBundleShortVersionString` 分组并逐组做 Beta App Review，带上 z 就等于每发一版重审一次；截断之后只有 y 变才开新组。macOS 与 Linux 不受影响，产物文件名也照旧使用完整的 tag。
-
 发布 PR 里带的产物：
 
 - `MetasequoiaIME-vX.Y.Z-macos-universal.pkg`

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -15,9 +15,6 @@ settings:
     CURRENT_PROJECT_VERSION: 1
     # Bumped by release-please alongside CMakeLists.txt. It used to be pinned at 0.1.0 while the
     # project shipped 0.45.x, so any iOS artifact would have carried a version that matched nothing.
-    # The release scripts truncate this to x.y before archiving, because TestFlight reviews each
-    # CFBundleShortVersionString separately and the patch digit would buy a review per release. The
-    # full value stays here: it is what release-please writes, and local builds never upload.
     MARKETING_VERSION: 0.48.6 # x-release-please-version
     # ML Kit Digital Ink 4.x provides x86_64 simulator binaries.
     EXCLUDED_ARCHS[sdk=iphonesimulator*]: arm64

--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -62,13 +62,6 @@ else
     build_number=$(git -C "$project_root" rev-list --count HEAD)
 fi
 
-# TestFlight groups builds by CFBundleShortVersionString and reviews each group on its own, so
-# carrying the patch digit here bought a fresh Beta App Review for every release. iOS ships x.y and
-# lets the build number carry the rest; only a minor bump opens a new group now. This archive has to
-# agree with the signed path, or a maintainer uploading it from Organizer would open a second group
-# for the same release. The release artifacts still take their names from the full tag.
-marketing_version=${version%.*}
-
 spec="$project_root/platforms/ios/project.yml"
 if [[ ! -f "$spec" ]]; then
     printf 'iOS project spec not found at %s\n' "$spec" >&2
@@ -94,8 +87,8 @@ mkdir -p "$build_root" "$output_dir"
 xcodegen generate --spec "$spec" --project "$build_root" --project-root "$project_root"
 MSIME_IOS_BUILD_ROOT="$build_root" pod install --deployment --project-directory="$project_root/platforms/ios"
 
-# The version settings are passed on the command line as well as being bumped in project.yml, so the
-# archive follows the tag being built even when the spec is momentarily behind it.
+# MARKETING_VERSION is passed on the command line as well as being bumped in project.yml, so the
+# archive carries the release version even when the spec is momentarily behind the tag being built.
 xcodebuild archive \
     -workspace "$build_root/MetasequoiaImeIOS.xcworkspace" \
     -scheme MetasequoiaImeIOS \
@@ -103,7 +96,7 @@ xcodebuild archive \
     -destination 'generic/platform=iOS' \
     -archivePath "$archive_path" \
     -derivedDataPath "$build_root/derived" \
-    MARKETING_VERSION="$marketing_version" \
+    MARKETING_VERSION="$version" \
     CURRENT_PROJECT_VERSION="$build_number" \
     CODE_SIGNING_ALLOWED=NO \
     CODE_SIGNING_REQUIRED=NO \
@@ -131,16 +124,16 @@ fi
 for bundle in "$archive_path/Products/Applications/MetasequoiaIME.app" \
     "$archive_path/Products/Applications/MetasequoiaIME.app/PlugIns/MetasequoiaKeyboard.appex"; do
     test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$bundle/Info.plist")" = "$build_number"
-    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$bundle/Info.plist")" = "$marketing_version"
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$bundle/Info.plist")" = "$version"
 done
 
 archive_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$application/Info.plist")
-if [[ "$archive_version" != "$marketing_version" ]]; then
+if [[ "$archive_version" != "$version" ]]; then
     printf 'Archive version %s does not match tag %s.\n' "$archive_version" "$tag_name" >&2
     exit 1
 fi
 extension_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$extension/Info.plist")
-if [[ "$extension_version" != "$marketing_version" ]]; then
+if [[ "$extension_version" != "$version" ]]; then
     printf 'Keyboard extension version %s does not match tag %s.\n' "$extension_version" "$tag_name" >&2
     exit 1
 fi

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -80,12 +80,6 @@ else
     build_number=$(git -C "$project_root" rev-list --count HEAD)
 fi
 
-# TestFlight groups builds by CFBundleShortVersionString and reviews each group on its own, so
-# carrying the patch digit here bought a fresh Beta App Review for every release. iOS ships x.y and
-# lets the build number carry the rest; only a minor bump opens a new group now. The release
-# artifacts still take their names from the full tag.
-marketing_version=${version%.*}
-
 build_root="$project_root/build/ios-testflight"
 archive_path="$build_root/MetasequoiaIME.xcarchive"
 export_path="$build_root/export"
@@ -118,7 +112,7 @@ xcodebuild archive \
     -destination 'generic/platform=iOS' \
     -archivePath "$archive_path" \
     -derivedDataPath "$build_root/derived" \
-    MARKETING_VERSION="$marketing_version" \
+    MARKETING_VERSION="$version" \
     CURRENT_PROJECT_VERSION="$build_number" \
     CODE_SIGNING_ALLOWED=YES \
     CODE_SIGNING_REQUIRED=YES \
@@ -146,7 +140,7 @@ fi
 for bundle in "$archive_path/Products/Applications/MetasequoiaIME.app" \
     "$archive_path/Products/Applications/MetasequoiaIME.app/PlugIns/MetasequoiaKeyboard.appex"; do
     test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$bundle/Info.plist")" = "$build_number"
-    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$bundle/Info.plist")" = "$marketing_version"
+    test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$bundle/Info.plist")" = "$version"
 done
 
 export_options="$build_root/ExportOptions.plist"

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -1,6 +1,7 @@
 import os
 import json
 import plistlib
+import re
 import struct
 import subprocess
 import tempfile
@@ -709,6 +710,36 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
             self.assertIn('CURRENT_PROJECT_VERSION="$build_number"', script, name)
             self.assertNotIn('CURRENT_PROJECT_VERSION="$version"', script, name)
             self.assertIn('MARKETING_VERSION="$version"', script, name)
+
+        # Assert the number the scripts produce, not the shape of the line producing it. A previous
+        # change truncated the marketing version to x.y and rewrote the assertions above to match, so
+        # the suite stayed green while iOS shipped 0.48 against a 0.48.6 product version -- which
+        # sorts below it in TestFlight. Replay each script's own derivation and compare the result
+        # with the version the project spec declares.
+        spec_version = re.search(r"MARKETING_VERSION:\s*(\S+)", (IOS_ROOT / "project.yml").read_text())
+        self.assertIsNotNone(spec_version, "project.yml must declare MARKETING_VERSION")
+        product_version = spec_version.group(1)
+        for name, script in scripts.items():
+            setting = re.search(r'MARKETING_VERSION="\$(\w+)"', script)
+            self.assertIsNotNone(setting, name)
+            # Walk back from the variable the archive is given, collecting the assignments it is
+            # built from. tag_name is the input and comes from the environment below.
+            wanted, collected = {setting.group(1)}, []
+            for line in reversed(script.splitlines()):
+                assignment = re.match(r"^(\w+)=(.*)$", line)
+                if not assignment or assignment.group(1) in {"tag_name"}:
+                    continue
+                if assignment.group(1) in wanted:
+                    collected.append(line)
+                    wanted |= set(re.findall(r"\$\{?(\w+)", assignment.group(2)))
+            derivation = "\n".join(reversed(collected))
+            archived = subprocess.run(
+                ["bash", "-eu", "-c", derivation + f'\nprintf "%s" "${setting.group(1)}"'],
+                env=dict(os.environ, tag_name=f"v{product_version}-build.1002.57.1"),
+                text=True, capture_output=True,
+            )
+            self.assertEqual(archived.returncode, 0, archived.stderr)
+            self.assertEqual(archived.stdout, product_version, name)
 
         start = 'if ! git -C "$project_root" rev-parse --git-dir'
         end = 'build_number=$(git -C "$project_root" rev-list --count HEAD)'

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -708,18 +708,7 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         for name, script in scripts.items():
             self.assertIn('CURRENT_PROJECT_VERSION="$build_number"', script, name)
             self.assertNotIn('CURRENT_PROJECT_VERSION="$version"', script, name)
-            # TestFlight reviews each CFBundleShortVersionString on its own, so shipping the patch
-            # digit meant a Beta App Review per release. Both paths must truncate alike, or an
-            # archive uploaded from Organizer opens a second group for the same release.
-            self.assertIn("marketing_version=${version%.*}", script, name)
-            self.assertIn('MARKETING_VERSION="$marketing_version"', script, name)
-            self.assertNotIn('MARKETING_VERSION="$version"', script, name)
-
-        truncation = subprocess.run(
-            ["bash", "-c", 'version="0.48.6"; printf "%s" "${version%.*}"'],
-            capture_output=True, text=True, check=True,
-        )
-        self.assertEqual(truncation.stdout, "0.48")
+            self.assertIn('MARKETING_VERSION="$version"', script, name)
 
         start = 'if ! git -C "$project_root" rev-parse --git-dir'
         end = 'build_number=$(git -C "$project_root" rev-list --count HEAD)'

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -82,7 +82,9 @@ class BuildNumberTests(unittest.TestCase):
         for name in ("package_ios_archive.sh", "package_ios_testflight.sh"):
             script = (root / "platforms/ios/scripts" / name).read_text()
             fragment = script.split("# CI supplies the shared build.", 1)[1]
-            fragment = "# CI supplies the shared build." + fragment.split("marketing_version=", 1)[0]
+            # The block closes on the only unindented fi. Everything past it needs a real checkout,
+            # and the two scripts diverge there, so neither offers a shared name to cut on.
+            fragment = "# CI supplies the shared build." + fragment.split("\nfi\n", 1)[0] + "\nfi"
             for tag, supplied, expected in [
                 ("v0.48.6-build.1001.23.1", "1001.23.1", "1001.23.1"),
                 ("v0.48.6", "1001.24.1", "1001.24.1"),


### PR DESCRIPTION
Reverts f91ecbf. iOS shipped `0.48` where the product version is `0.48.6`.

The release policy is to hold the version and increment only the build. f91ecbf truncated `MARKETING_VERSION` to x.y in both packaging scripts, so `CFBundleShortVersionString` lost its patch digit at archive time even though `project.yml` still carried `0.48.6`.

Two consequences showed up in App Store Connect:

- The build uploaded on 09-09 landed as version `0.48`, while the previous one from 09-07 is `0.48.6`. `0.48` sorts below `0.48.6`, so the new build sat under a stale train instead of on top of it, and testers were still offered the older build.
- Every later 0.48.x release would have joined the same `0.48` train and stayed below `0.48.6` until a minor bump.

The `0.48` build has been expired in App Store Connect. The next CI upload will carry `0.48.6`.

## What f91ecbf was buying

Its reasoning was real: TestFlight reviews each `CFBundleShortVersionString` separately, so carrying the patch digit means a Beta App Review per release. Reverting brings that cost back. Worth deciding separately how to handle it, because the truncation as written conflicts with the version policy and produced a version that moves backwards.

## Changes

- `package_ios_archive.sh` and `package_ios_testflight.sh` pass `MARKETING_VERSION="$version"` again, and the later `CFBundleShortVersionString` verification lines follow
- `ProjectConfigurationTests.py` drops the assertions f91ecbf added for the truncated form
- `ReleaseAutomationTests.py` cut its build-number fragment at `marketing_version=`, which no longer exists. It now cuts at the block's own unindented `fi`; the two scripts diverge past that point and share no name to cut on

## Verification

- `ProjectConfigurationTests.py`, `DictionaryPackagingTests.py`, `ReleaseAutomationTests.py`, `ReleaseConfigurationTests.py` all pass
- `shellcheck --severity=warning` clean on both packaging scripts
- `ReleasePackageTests.py` fails on this branch and on `develop` alike, so it is untouched by this change
