### PR TITLE
fix(ios): drop the candidate ordinal, record the silent scheme downgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ macOS 每次 Engine 动作完成后更新值快照；候选选择必须用当前
 活动组合继续使用创建时的偏好，组合结束后才按新的 SessionOptions 重建会话。
 高亮候选的自动提交调用 Session::finish(index)，剩余分段仍由 Engine 完成。
 
+`InputSchemePreference.scheme` 的 setter 在目标方案不在 `enabledSchemes` 中时静默替换为 `enabledSchemes[0]`，赋值失败不报错；`enabledSchemes` 存在 app group，跨进程与跨 test bundle 持久化。依赖某个方案的测试必须先在 `setUp` 中接管整个方案集合（`enableAllInputSchemes()`），隐藏方案的 UI 测试必须在 `defer` 中经 `--reset-input-schemes-for-ui-tests` 恢复可见性，否则它留下的状态会让后续 bundle 静默跑在错误方案上。
+
 iOS 个人词库通过 Engine `<metasequoia/personal_dictionary.h>` 校验和编辑；SharedUI 同步文件仅传递用户操作、确认和分页快照，不复制拼音解析或 SQL。键盘仅在完全访问开启且会话空闲时处理队列，写入前释放会话，完成后保留方案、九键和学习偏好重建。操作 UUID 作为 Engine 事务回执 ID，确认文件写入中断后的重试必须复用它。
 
 发布构建：push 到 main 保留 version.txt 的语义版本，仅递增独立 build，以 v<version>-build.<build> 发布 Pre-release。正式升版本通过 release.yml 的 workflow_dispatch（bump_version=true、tag 留空）调用 release-please；tag 输入用于发布已有 draft。macOS、iOS 和 Sparkle 使用同一 METASEQUOIA_BUILD_NUMBER，安装器版本也使用 build。正式发布后仍须将 main 回合到 develop。

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -1906,12 +1906,12 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     candidateEmptySpacer.isHidden = !visibleCandidates.isEmpty || visibleDiagnostic != nil
   }
 
-  // The number is the key the chip answers to on the visible page; the index is the engine position
-  // it selects. They only coincide on the first page.
+  // A touch keyboard has no number row to answer with, so the ordinal is spoken rather than drawn;
+  // the index is the engine position the chip selects. The expand panel already showed bare text.
   private func makeCandidateButton(candidate: String, number: Int, index: Int) -> UIButton {
     let display = chineseOutput(candidate)
     var configuration = UIButton.Configuration.plain()
-    configuration.title = "\(number)  \(display)"
+    configuration.title = display
     configuration.baseForegroundColor = KeyboardSkinPreference.selected.keyForeground
     configuration.contentInsets = NSDirectionalEdgeInsets(
       top: 4, leading: 9, bottom: 4, trailing: 9)

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -630,7 +630,12 @@ final class NineKeyKeyboardTests: XCTestCase {
       for digit in "64426" { try button("nineKey\(digit)", in: controller).sendActions(for: .primaryActionTriggered) }
       controller.view.layoutIfNeeded()
       XCTAssertTrue(toolbar.isHidden)
-      XCTAssertTrue(try XCTUnwrap(button("candidate-1", in: controller).configuration?.title).contains("你好"))
+      // The chip carries the candidate and nothing else: a touch keyboard has no number row, so a
+      // leading ordinal is noise that reads as part of the word.
+      let chip = try XCTUnwrap(button("candidate-1", in: controller).configuration?.title)
+      XCTAssertTrue(chip.contains("你好"))
+      XCTAssertFalse(chip.contains(where: \.isNumber), chip)
+      XCTAssertEqual(chip, chip.trimmingCharacters(in: .whitespaces), chip)
       XCTAssertEqual(key.convert(key.bounds, to: controller.view), frame)
       try button("nineKeyClear", in: controller).sendActions(for: .primaryActionTriggered)
       controller.view.layoutIfNeeded()

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -186,7 +186,7 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         # converting before selection would break the engine index the candidate chips carry.
         self.assertIn("insertOwnText(source == .japanese ? commitText : chineseOutput(commitText), source: source)", controller)
         self.assertIn("let display = chineseOutput(candidate)", controller)
-        self.assertIn('configuration.title = "\\(number)  \\(display)"', controller)
+        self.assertIn("configuration.title = display", controller)
         self.assertIn("self.render(self.session.selectCandidate(at: UInt(index)))", controller)
 
         preedit = controller.split("private func updatePreeditButton", 1)[1].split("\n  }", 1)[0]
@@ -495,12 +495,16 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         self.assertIn("handleCandidateKey", bridge_header)
         self.assertIn("handlePunctuation", bridge_header)
 
-    def test_candidate_surface_exposes_numbered_native_chips(self):
+    def test_candidate_surface_exposes_native_chips_numbered_only_for_voiceover(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
         self.assertIn("candidate: candidate, number: offset + 1, index: offset", controller)
-        self.assertIn('configuration.title = "\\(number)  \\(display)"', controller)
         self.assertIn("configuration.background.cornerRadius", controller)
+
+        # A touch keyboard has no number row for the ordinal to answer to, so it is spoken rather
+        # than drawn: the chip shows the candidate alone and VoiceOver still hears the position.
+        self.assertIn("configuration.title = display", controller)
+        self.assertNotIn('configuration.title = "\\(number)', controller)
         self.assertIn('button.accessibilityLabel = "候选词 \\(number)：\\(display)"', controller)
 
     def test_apostrophe_reaches_the_engine_before_punctuation_conversion(self):


### PR DESCRIPTION
## Candidate chips lose the ordinal

A touch keyboard has no number row for the ordinal to answer to, so the leading digit was noise that reads as part of the word. The expand panel already drew bare text, so the strip was the odd one out. VoiceOver still hears the position, and the `candidate-N` accessibility identifier the tests address chips by is unchanged.

## The silent input scheme downgrade, recorded

Assigning `InputSchemePreference.scheme` substitutes `enabledSchemes[0]` when the target scheme is hidden, and reports nothing. The hidden set lives in the app group, so it outlives the process that hid it and reaches other test bundles.

A test that reads that state without writing it therefore runs against a different scheme than the one it asked for. On CI a UI test failed before re-enabling the scheme it had hidden, and the keyboard unit tests four minutes later produced 216 assertion failures against a nine-key layout that had quietly become the 26-key one, while the same commit stayed green on every local simulator.

Recorded alongside the rule the fix in #388 established: claim the whole scheme set in `setUp`, and restore visibility in a `defer` when a UI test hides one.
