### PR TITLE
fix(ios): name the shoudao scheme as macOS does

### DIFF
--- a/platforms/ios/App/Sources/FeatureSettingsViews.swift
+++ b/platforms/ios/App/Sources/FeatureSettingsViews.swift
@@ -91,7 +91,7 @@ struct DictionarySettingsView: View {
       }
       Section("已安装词库") {
         Label("内置离线多方案词库", systemImage: "checkmark.circle.fill")
-        Text("支持全拼 26 键、全拼 9 键、小鹤／自然码／微软／Shoudao 双拼、86 五笔和日语罗马字；提供英文补全、快捷短语、表情及颜文字。")
+        Text("支持全拼 26 键、全拼 9 键、小鹤／自然码／微软／首道双拼、86 五笔和日语罗马字；提供英文补全、快捷短语、表情及颜文字。")
           .foregroundStyle(.secondary)
         HStack {
           Text("更新方式")

--- a/platforms/ios/SharedUI/InputSchemePreference.swift
+++ b/platforms/ios/SharedUI/InputSchemePreference.swift
@@ -19,7 +19,7 @@ enum ChineseInputScheme: String, CaseIterable {
     case .shuangpin: "小鹤双拼"
     case .ziranma: "自然码双拼"
     case .microsoft: "微软双拼"
-    case .shoudao: "Shoudao 双拼"
+    case .shoudao: "首道双拼"
     case .wubi: "86 五笔"
     case .japanese: "日语 26 键"
     case .japaneseNineKey: "日语 9 键"

--- a/platforms/ios/SharedUI/TypingStatistics.swift
+++ b/platforms/ios/SharedUI/TypingStatistics.swift
@@ -10,7 +10,7 @@ enum TypingSource: String, CaseIterable {
     case .shuangpin: "小鹤双拼"
     case .ziranma: "自然码双拼"
     case .microsoft: "微软双拼"
-    case .shoudao: "Shoudao 双拼"
+    case .shoudao: "首道双拼"
     case .wubi: "86 五笔"
     case .japanese: "日语"
     case .handwriting: "手写"

--- a/shared/backend-ui/CloudCandidatesView.swift
+++ b/shared/backend-ui/CloudCandidatesView.swift
@@ -40,7 +40,7 @@ struct CloudCandidatesView: View {
           if scheme == "shuangpin" {
             Picker("双拼方案", selection: $profile) {
               Text("小鹤").tag("xiaohe"); Text("自然码").tag("ziranma")
-              Text("微软").tag("microsoft"); Text("Shoudao").tag("shoudao")
+              Text("微软").tag("microsoft"); Text("首道").tag("shoudao")
             }
           }
         }

--- a/shared/backend-ui/CloudDictionaryCatalogView.swift
+++ b/shared/backend-ui/CloudDictionaryCatalogView.swift
@@ -27,7 +27,7 @@ struct CloudDictionaryCatalogView: View {
           if scheme == "shuangpin" {
             Picker("双拼方案", selection: $profile) {
               Text("小鹤").tag("xiaohe"); Text("自然码").tag("ziranma")
-              Text("微软").tag("microsoft"); Text("Shoudao").tag("shoudao")
+              Text("微软").tag("microsoft"); Text("首道").tag("shoudao")
             }
           }
         }


### PR DESCRIPTION
macOS calls the scheme 首道双拼 and iOS called it `Shoudao 双拼`, so the same scheme read as two different ones depending on which device the settings happened to be open on. Three of the four double-pinyin names already matched word for word — 小鹤双拼, 自然码双拼, 微软双拼 — and this was the only one that did not.

Found while reviewing #381, which brings all four schemes to macOS. That PR's spelling is the one being kept; this aligns iOS to it so the two do not have to be reconciled later.

Five places carried the old name:

| file | was |
| --- | --- |
| `platforms/ios/SharedUI/InputSchemePreference.swift` | `Shoudao 双拼` |
| `platforms/ios/SharedUI/TypingStatistics.swift` | `Shoudao 双拼` |
| `platforms/ios/App/Sources/FeatureSettingsViews.swift` | `小鹤／自然码／微软／Shoudao 双拼` |
| `shared/backend-ui/CloudCandidatesView.swift` | `Text("Shoudao")` |
| `shared/backend-ui/CloudDictionaryCatalogView.swift` | `Text("Shoudao")` |

The last two are the cloud double-pinyin pickers, where `Shoudao` sat among 小鹤, 自然码 and 微软 as the one English label in a row of Chinese ones.

The engine identifier stays `shoudao`; `GetShoudaoShuangpinProfile()` and every `tag("shoudao")` are untouched. Only what the user reads changes, so nothing persisted or synced moves.

Verified: no `Shoudao` remains in any Swift source, no test pinned the old string, `scripts/format.sh --check` passes and the 45 project configuration tests pass.
