### PR TITLE
ci(release): publish only the platforms whose sources changed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       tag_name: ${{ steps.build_release.outputs.tag_name || (!inputs.bump_version && inputs.tag) || steps.finalized_promoted_release.outputs.tag_name || steps.finalized_release.outputs.tag_name || steps.release.outputs.tag_name }}
       target_sha: ${{ steps.build_release.outputs.target_sha || steps.requested_release.outputs.target_sha || steps.promote_release_commit.outputs.target_sha || steps.finalized_release.outputs.sha || steps.release.outputs.sha }}
       build_number: ${{ steps.build_number.outputs.value }}
+      macos: ${{ steps.platforms.outputs.macos }}
+      ios: ${{ steps.platforms.outputs.ios }}
     steps:
       - name: Validate invocation
         env:
@@ -72,6 +74,53 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Select the platforms this release covers
+        id: platforms
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          # A release builds the platforms whose sources moved. Everything both of them compile --
+          # shared code, the engine, the build system, the release automation itself -- reaches
+          # both, and so does anything unrecognised. The bias is deliberate: publishing a platform
+          # that did not change costs one build, while skipping one that did ships a fix that never
+          # reaches its users.
+          macos=false
+          ios=false
+          changed=""
+          if [[ "$GITHUB_EVENT_NAME" == push && "$BEFORE_SHA" =~ ^[0-9a-f]{40}$ &&
+                "$BEFORE_SHA" != 0000000000000000000000000000000000000000 ]]; then
+            if ! changed=$(gh api --paginate "repos/$GH_REPO/compare/$BEFORE_SHA...$AFTER_SHA" \
+              --jq '.files[].filename'); then
+              printf 'Could not compare %s...%s; publishing both platforms.\n' "$BEFORE_SHA" "$AFTER_SHA" >&2
+              changed=""
+            fi
+          fi
+          if [[ -z "$changed" ]]; then
+            # A manual run names a tag rather than a range, and a first push has no predecessor.
+            # Neither can be classified, so both platforms are built.
+            macos=true
+            ios=true
+          else
+            while IFS= read -r path; do
+              [[ -n "$path" ]] || continue
+              case "$path" in
+                platforms/ios/*) ios=true ;;
+                platforms/macos/*) macos=true ;;
+                docs/*|licenses/*|*.md|LICENSE|PRIVACY.md|.mailmap|.gitignore) ;;
+                *) macos=true; ios=true ;;
+              esac
+            done <<< "$changed"
+          fi
+          if [[ "$macos" != true && "$ios" != true ]]; then
+            # A push to main is a deliberate promotion, so publish both rather than nothing.
+            macos=true
+            ios=true
+          fi
+          printf 'Publishing macOS: %s\nPublishing iOS: %s\n' "$macos" "$ios"
+          printf 'macos=%s\nios=%s\n' "$macos" "$ios" >> "$GITHUB_OUTPUT"
       - name: Create automatic build draft
         if: ${{ github.event_name == 'push' }}
         id: build_release
@@ -277,6 +326,7 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure --timeout 20
       - name: Verify input method bundle
+        if: ${{ needs.prepare.outputs.macos == 'true' }}
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           SIGNING_ENABLED: ${{ steps.signing.outputs.signing_enabled }}
@@ -291,6 +341,7 @@ jobs:
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' build/MetasequoiaIME.app/Contents/Info.plist)" = "${version%%-build.*}"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' build/MetasequoiaIME.app/Contents/Info.plist)" = "$METASEQUOIA_BUILD_NUMBER"
       - name: Package release
+        if: ${{ needs.prepare.outputs.macos == 'true' }}
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           METASEQUOIA_REQUIRE_RELEASE_SIGNING: ${{ steps.signing.outputs.signing_enabled }}
@@ -308,12 +359,15 @@ jobs:
       # Build the reproducible iOS artifact first. When App Store Connect and signing secrets are
       # configured, the TestFlight step below also produces the signed release artifacts.
       - name: Package the iOS dictionary
+        if: ${{ needs.prepare.outputs.ios == 'true' }}
         run: python3 platforms/ios/scripts/prepare_dictionary.py
       - name: Build the unsigned iOS archive
+        if: ${{ needs.prepare.outputs.ios == 'true' }}
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
         run: exec platforms/ios/scripts/package_ios_archive.sh "$TAG_NAME" dist
       - name: Prepare App Store Connect API key for TestFlight
+        if: ${{ needs.prepare.outputs.ios == 'true' }}
         id: testflight_credentials
         env:
           IOS_API_KEY_BASE64: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_BASE64 }}
@@ -389,7 +443,7 @@ jobs:
           printf 'enabled=true\nkey_path=%s\napp_profile_path=%s\nkeyboard_profile_path=%s\n' \
             "$key_path" "$app_profile_path" "$keyboard_profile_path" >> "$GITHUB_OUTPUT"
       - name: Upload iOS build to TestFlight
-        if: ${{ steps.testflight_credentials.outputs.enabled == 'true' }}
+        if: ${{ needs.prepare.outputs.ios == 'true' && steps.testflight_credentials.outputs.enabled == 'true' }}
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           IOS_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
@@ -410,6 +464,7 @@ jobs:
           export METASEQUOIA_IOS_RELEASE_DIR="$GITHUB_WORKSPACE/dist"
           exec "$RUNNER_TEMP/package-ios-testflight.sh" "$TAG_NAME"
       - name: Detect the Sparkle update key
+        if: ${{ needs.prepare.outputs.macos == 'true' }}
         id: sparkle
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
@@ -422,7 +477,7 @@ jobs:
             printf 'appcast_enabled=false\n' >> "$GITHUB_OUTPUT"
           fi
       - name: Generate signed Sparkle appcast
-        if: ${{ steps.sparkle.outputs.appcast_enabled == 'true' }}
+        if: ${{ needs.prepare.outputs.macos == 'true' && steps.sparkle.outputs.appcast_enabled == 'true' }}
         env:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
@@ -444,7 +499,7 @@ jobs:
           SPARKLE_TOOLS_DIR="$sparkle_root/bin" \
             exec "$RUNNER_TEMP/generate-sparkle-appcast.sh" "$TAG_NAME" "$update_archive" dist/appcast.xml
       - name: Skip Sparkle appcast without an update key
-        if: ${{ steps.sparkle.outputs.appcast_enabled != 'true' }}
+        if: ${{ needs.prepare.outputs.macos == 'true' && steps.sparkle.outputs.appcast_enabled != 'true' }}
         run: echo 'No SPARKLE_ED_PRIVATE_KEY is configured, so this release ships without an appcast and automatic updates stay paused.' >> "$GITHUB_STEP_SUMMARY"
       - name: Revalidate draft release target
         env:
@@ -464,6 +519,8 @@ jobs:
           ASSET_SUFFIX: ${{ steps.signing.outputs.asset_suffix }}
           SIGNING_ENABLED: ${{ steps.signing.outputs.signing_enabled }}
           IOS_TESTFLIGHT_ENABLED: ${{ steps.testflight_credentials.outputs.enabled }}
+          RELEASE_MACOS: ${{ needs.prepare.outputs.macos }}
+          RELEASE_IOS: ${{ needs.prepare.outputs.ios }}
           # Decides which channel the release is published into: push is an automatic per-merge build, workflow_dispatch is one somebody asked for.
           RELEASE_TRIGGER: ${{ github.event_name }}
         run: exec "$RUNNER_TEMP/publish-release.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
               case "$path" in
                 platforms/ios/*) ios=true ;;
                 platforms/macos/*) macos=true ;;
-                docs/*|licenses/*|*.md|LICENSE|PRIVACY.md|.mailmap|.gitignore) ;;
+                docs/*|licenses/*|*.md|LICENSE|.mailmap|.gitignore) ;;
                 *) macos=true; ios=true ;;
               esac
             done <<< "$changed"

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -6,6 +6,24 @@ set -euo pipefail
 : "${SIGNING_ENABLED:?SIGNING_ENABLED is required}"
 # push means an automatic per-merge build, anything else means somebody asked for this one. GitHub has no channel concept, so the two states it does have carry the two channels: automatic builds are prereleases, deliberate ones are ordinary releases and the newest of those takes the Latest badge. Before this the two were indistinguishable and the badge simply followed whatever merged last. Kept in step with MSIME-Windows#167.
 : "${RELEASE_TRIGGER:?RELEASE_TRIGGER is required}"
+# Which platforms this run publishes. The release workflow decides from the paths that changed;
+# a platform that is not covered contributes no artifacts and no release notes, while a covered
+# one still requires all of its files so a silently failed packaging step is caught here.
+: "${RELEASE_MACOS:?RELEASE_MACOS is required}"
+: "${RELEASE_IOS:?RELEASE_IOS is required}"
+for flag in "$RELEASE_MACOS" "$RELEASE_IOS"; do
+    case "$flag" in
+        true|false) ;;
+        *)
+            printf '%s\n' "RELEASE_MACOS and RELEASE_IOS must be true or false." >&2
+            exit 1
+            ;;
+    esac
+done
+if [[ "$RELEASE_MACOS" != true && "$RELEASE_IOS" != true ]]; then
+    printf '%s\n' "A release must cover at least one platform." >&2
+    exit 1
+fi
 : "${IOS_TESTFLIGHT_ENABLED:=false}"
 if [[ ${ASSET_SUFFIX+x} != x ]]; then
     printf '%s\n' "ASSET_SUFFIX is required." >&2
@@ -63,14 +81,20 @@ else
         "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-testflight.ipa.sha256"
     )
 fi
-artifacts=("$installer" "$installer.sha256" "$archive" "$archive.sha256" "$update_archive" "$update_archive.sha256")
+artifacts=()
+if [[ "$RELEASE_MACOS" == true ]]; then
+    artifacts+=("$installer" "$installer.sha256" "$archive" "$archive.sha256"
+                "$update_archive" "$update_archive.sha256")
+fi
 # The Sparkle appcast is signed with the project's Ed25519 update key, which is independent of Apple code signing, so publish it whenever the release job produced one.
-if [[ -f "$appcast" ]]; then
+if [[ "$RELEASE_MACOS" == true && -f "$appcast" ]]; then
     artifacts+=("$appcast")
 fi
-# Required rather than optional: the iOS build is part of every release run, so a missing archive
-# means the step failed silently rather than that iOS is not being shipped.
-artifacts+=("$ios_archive" "$ios_archive.sha256" "$ios_ipa" "$ios_ipa.sha256")
+# Required rather than optional once iOS is covered: a missing archive then means the packaging
+# step failed silently rather than that iOS is not being shipped by this release.
+if [[ "$RELEASE_IOS" == true ]]; then
+    artifacts+=("$ios_archive" "$ios_archive.sha256" "$ios_ipa" "$ios_ipa.sha256")
+fi
 for artifact in "${artifacts[@]}"; do
     if [[ ! -f "$artifact" ]]; then
         printf 'Release artifact is missing: %s\n' "$artifact" >&2
@@ -94,8 +118,10 @@ done
     verify_checksum_manifest "$(basename "$installer")" "$(basename "$installer.sha256")"
     verify_checksum_manifest "$(basename "$archive")" "$(basename "$archive.sha256")"
     verify_checksum_manifest "$(basename "$update_archive")" "$(basename "$update_archive.sha256")"
-    verify_checksum_manifest "$(basename "$ios_archive")" "$(basename "$ios_archive.sha256")"
-    verify_checksum_manifest "$(basename "$ios_ipa")" "$(basename "$ios_ipa.sha256")"
+    if [[ "$RELEASE_IOS" == true ]]; then
+        verify_checksum_manifest "$(basename "$ios_archive")" "$(basename "$ios_archive.sha256")"
+        verify_checksum_manifest "$(basename "$ios_ipa")" "$(basename "$ios_ipa.sha256")"
+    fi
 )
 
 mode_marker="<!-- metasequoia-release-mode:$release_mode -->"
@@ -142,32 +168,35 @@ if [[ "$current_notes" != *"$mode_marker"* || "$current_notes" != *"$install_gui
         fi
         if [[ "$current_notes" != *"$install_guidance_marker"* ]]; then
             printf '%s\n\n' "$install_guidance_marker"
-            printf '%s\n' '### Install on macOS'
-            printf '%s\n' '- **Recommended: ZIP.** Verify its `.sha256`, extract it, then run `Install.command`. It installs for the current user, registers and enables the exact input source, and does not automatically log out or restart the Mac.'
-            printf '%s\n' '- **PKG option.** The native Installer copies the same app and attempts to register and enable 水杉 for the logged-in GUI user. If no GUI user is logged in or macOS blocks the app, enable it later in System Settings > Keyboard > Text Input > Edit. The package does not force a logout or restart; macOS may still require a later logout before a newly copied input method appears.'
-            printf '\n%s\n' '### iOS'
-            if [[ "$IOS_TESTFLIGHT_ENABLED" == true ]]; then
-                printf '%s\n' '- `-ios-testflight.ipa` and `-ios-testflight.xcarchive.zip` are distribution-signed with the project Team ID; the IPA is uploaded to App Store Connect for TestFlight.'
-                printf '%s\n' '- Install the processed build from TestFlight. Apple may take additional time to finish processing before it appears to testers.'
-            else
-                printf '%s\n' '- Both iOS assets are **unsigned** because App Store Connect and iOS signing secrets were not configured for this run.'
-                printf '%s\n' '- `-ios-unsigned.ipa` is the one to take. Sign it with your own Apple ID using a re-signing tool such as Sideloadly or AltStore and install it; the keyboard is then enabled in Settings > General > Keyboard > Keyboards.'
-                printf '%s\n' '- `-ios-unsigned.xcarchive.zip` is for a maintainer with a Developer Program membership: open it in Xcode Organizer and distribute to TestFlight or the App Store from the exact bits this tag built, without rebuilding.'
+            if [[ "$RELEASE_MACOS" == true ]]; then
+                printf '%s\n' '### Install on macOS'
+                printf '%s\n' '- **Recommended: ZIP.** Verify its `.sha256`, extract it, then run `Install.command`. It installs for the current user, registers and enables the exact input source, and does not automatically log out or restart the Mac.'
+                printf '%s\n' '- **PKG option.** The native Installer copies the same app and attempts to register and enable 水杉 for the logged-in GUI user. If no GUI user is logged in or macOS blocks the app, enable it later in System Settings > Keyboard > Text Input > Edit. The package does not force a logout or restart; macOS may still require a later logout before a newly copied input method appears.'
+            fi
+            if [[ "$RELEASE_IOS" == true ]]; then
+                printf '\n%s\n' '### iOS'
+                if [[ "$IOS_TESTFLIGHT_ENABLED" == true ]]; then
+                    printf '%s\n' '- `-ios-testflight.ipa` and `-ios-testflight.xcarchive.zip` are distribution-signed with the project Team ID; the IPA is uploaded to App Store Connect for TestFlight.'
+                    printf '%s\n' '- Install the processed build from TestFlight. Apple may take additional time to finish processing before it appears to testers.'
+                else
+                    printf '%s\n' '- Both iOS assets are **unsigned** because App Store Connect and iOS signing secrets were not configured for this run.'
+                    printf '%s\n' '- `-ios-unsigned.ipa` is the one to take. Sign it with your own Apple ID using a re-signing tool such as Sideloadly or AltStore and install it; the keyboard is then enabled in Settings > General > Keyboard > Keyboards.'
+                    printf '%s\n' '- `-ios-unsigned.xcarchive.zip` is for a maintainer with a Developer Program membership: open it in Xcode Organizer and distribute to TestFlight or the App Store from the exact bits this tag built, without rebuilding.'
+                fi
             fi
         fi
     } > "$release_notes"
     gh release edit "$TAG_NAME" --repo "$GH_REPO" --notes-file "$release_notes"
 fi
 
+if [[ "$RELEASE_IOS" == true ]]; then
 for opposite_ios_artifact in "${opposite_ios_artifacts[@]}"; do
     opposite_name=$(basename "$opposite_ios_artifact")
     if gh release view "$TAG_NAME" --repo "$GH_REPO" --json assets --jq '.assets[].name' | grep -Fxq "$opposite_name"; then
         gh release delete-asset "$TAG_NAME" --repo "$GH_REPO" "$opposite_name" --yes
     fi
 done
-upload_args=("$installer" "$installer.sha256" "$archive" "$archive.sha256" "$update_archive" "$update_archive.sha256" "$ios_archive" "$ios_archive.sha256" "$ios_ipa" "$ios_ipa.sha256")
-if [[ -f "$appcast" ]]; then
-    upload_args+=("$appcast")
 fi
-gh release upload "$TAG_NAME" --repo "$GH_REPO" "${upload_args[@]}" --clobber
+# The verified list is the uploaded list: keeping two copies is how one of them goes stale.
+gh release upload "$TAG_NAME" --repo "$GH_REPO" "${artifacts[@]}" --clobber
 gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false "${channel[@]}" --title "$release_title"

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -101,6 +101,42 @@ class BuildNumberTests(unittest.TestCase):
                     self.assertEqual(result.returncode, 0, result.stderr)
                     self.assertEqual(result.stdout, expected, name)
 
+    def platforms_for(self, *paths, event="push", before=BASE_SHA):
+        quoted = " ".join('"' + path + '"' for path in paths)
+        stub = 'gh() { printf "%s\\n" ' + quoted + '; }' if paths else "gh() { :; }"
+        result, output = self.run_step(
+            "Select the platforms this release covers", prefix=stub,
+            GITHUB_EVENT_NAME=event, BEFORE_SHA=before, AFTER_SHA=HEAD_SHA)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        values = dict(line.split("=", 1) for line in output.strip().split("\n"))
+        return values["macos"], values["ios"]
+
+    def test_release_covers_only_the_platforms_whose_sources_changed(self):
+        self.assertEqual(self.platforms_for("platforms/ios/App/Sources/App.swift"), ("false", "true"))
+        self.assertEqual(self.platforms_for("platforms/macos/src/Controller.mm"), ("true", "false"))
+        self.assertEqual(
+            self.platforms_for("platforms/ios/App/Sources/App.swift", "platforms/macos/src/Controller.mm"),
+            ("true", "true"))
+
+    def test_shared_and_unrecognised_paths_reach_both_platforms(self):
+        # Anything both platforms compile, and anything this list does not name, must not be
+        # narrowed to one platform: a missed platform ships a fix that never reaches its users.
+        for path in ("shared/apple-bridge/InputSessionAdapter.cpp", "vendor/MetasequoiaImeEngine",
+                     "CMakeLists.txt", "cmake/Toolchain.cmake", "product-lock.json",
+                     ".github/workflows/release.yml", "some/new/directory/file.txt"):
+            self.assertEqual(self.platforms_for(path), ("true", "true"), path)
+
+    def test_documentation_alone_still_publishes_both(self):
+        # A push to main is a deliberate promotion, so a docs-only range publishes rather than
+        # leaving the draft this run already created with nothing attached to it.
+        self.assertEqual(self.platforms_for("README.md", "docs/guide.md", "LICENSE"), ("true", "true"))
+
+    def test_unclassifiable_ranges_publish_both(self):
+        self.assertEqual(self.platforms_for(event="workflow_dispatch"), ("true", "true"))
+        self.assertEqual(self.platforms_for("platforms/ios/a.swift", event="workflow_dispatch"), ("true", "true"))
+        self.assertEqual(self.platforms_for("platforms/ios/a.swift", before="0" * 40), ("true", "true"))
+        self.assertEqual(self.platforms_for(), ("true", "true"))
+
     def test_invalid_build_is_rejected(self):
         for tag in ["v0.48.6-build.1.100.1", "v0.48.6-build.x", "v0.48.6-build.0.1.1"]:
             result, output = self.run_step("Allocate build number", REQUESTED_TAG=tag)
@@ -505,6 +541,8 @@ class ReleasePublicationTests(unittest.TestCase):
         release_trigger="workflow_dispatch",
         ios_testflight=False,
         existing_assets="",
+        release_macos=True,
+        release_ios=True,
     ):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary = Path(temporary_directory)
@@ -583,6 +621,8 @@ fi
                     "FAKE_EXISTING_ASSETS": existing_assets,
                     "FAKE_CAPTURED_NOTES": str(captured_notes),
                     "IOS_TESTFLIGHT_ENABLED": "true" if ios_testflight else "false",
+                    "RELEASE_MACOS": "true" if release_macos else "false",
+                    "RELEASE_IOS": "true" if release_ios else "false",
                 }
             )
             result = subprocess.run(
@@ -596,6 +636,55 @@ fi
                 log.read_text() if log.exists() else "",
                 captured_notes.read_text() if captured_notes.exists() else "",
             )
+
+    def test_macos_only_release_ships_no_ios_assets_or_guidance(self):
+        result, calls, notes = self.run_publication("false", "-unsigned", release_ios=False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("macos-universal-unsigned.pkg", calls)
+        self.assertIn("appcast.xml", calls)
+        # A platform this release does not cover contributes nothing: no asset, and no section
+        # telling a reader to install something that was never built.
+        self.assertNotIn("ios-unsigned.ipa", calls)
+        self.assertNotIn("ios-unsigned.xcarchive.zip", calls)
+        self.assertNotIn("### iOS", notes)
+        self.assertIn("Install on macOS", notes)
+
+    def test_ios_only_release_ships_no_macos_assets_or_guidance(self):
+        result, calls, notes = self.run_publication("false", "-unsigned", release_macos=False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ios-unsigned.ipa", calls)
+        self.assertNotIn("macos-universal-unsigned.pkg", calls)
+        self.assertNotIn("macos-universal-unsigned-update.zip", calls)
+        # The appcast drives macOS automatic updates, so it must not accompany an iOS-only release.
+        self.assertNotIn("appcast.xml", calls)
+        self.assertNotIn("Install on macOS", notes)
+        self.assertIn("### iOS", notes)
+
+    def test_a_covered_platform_still_requires_all_of_its_artifacts(self):
+        # Narrowing the platforms must not weaken the check that catches a packaging step which
+        # failed without failing the job.
+        with tempfile.TemporaryDirectory() as directory:
+            environment = dict(os.environ, GH_REPO="metasequoiaime/MSIME-Apple", TAG_NAME="v1.2.3",
+                               ASSET_SUFFIX="-unsigned", SIGNING_ENABLED="false",
+                               RELEASE_TRIGGER="workflow_dispatch", DIST_DIR=directory,
+                               IOS_TESTFLIGHT_ENABLED="false", RELEASE_MACOS="false", RELEASE_IOS="true")
+            result = subprocess.run([MACOS_ROOT / "scripts/publish-release.sh"],
+                                    capture_output=True, text=True, env=environment)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Release artifact is missing", result.stderr)
+
+    def test_a_release_must_cover_at_least_one_platform(self):
+        with tempfile.TemporaryDirectory() as directory:
+            environment = dict(os.environ, GH_REPO="metasequoiaime/MSIME-Apple", TAG_NAME="v1.2.3",
+                               ASSET_SUFFIX="-unsigned", SIGNING_ENABLED="false",
+                               RELEASE_TRIGGER="workflow_dispatch", DIST_DIR=directory,
+                               IOS_TESTFLIGHT_ENABLED="false", RELEASE_MACOS="false", RELEASE_IOS="false")
+            result = subprocess.run([MACOS_ROOT / "scripts/publish-release.sh"],
+                                    capture_output=True, text=True, env=environment)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("at least one platform", result.stderr)
 
     def test_unsigned_publication_records_mode_before_uploading_labeled_assets(self):
         result, calls, notes = self.run_publication("false", "-unsigned", "Existing notes")

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -345,9 +345,12 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("ios-testflight.xcarchive.zip", publish_script)
         # The .ipa is the asset a tester can actually re-sign and install, so it has to be uploaded
         # rather than only checked for existence — an earlier revision added it to one list and not
-        # the other.
+        # the other. There is only one list now: what is verified is what is uploaded, so the two
+        # cannot drift apart again.
         self.assertIn("ios-unsigned.ipa", publish_script)
-        self.assertIn('"$ios_ipa" "$ios_ipa.sha256")', publish_script.split("upload_args=", 1)[1])
+        self.assertIn('artifacts+=("$ios_archive" "$ios_archive.sha256" "$ios_ipa" "$ios_ipa.sha256")', publish_script)
+        self.assertIn('gh release upload "$TAG_NAME" --repo "$GH_REPO" "${artifacts[@]}"', publish_script)
+        self.assertNotIn("upload_args", publish_script)
         archive_script = (PROJECT_ROOT / "platforms/ios/scripts/package_ios_archive.sh").read_text()
         self.assertIn("CODE_SIGNING_ALLOWED=NO", archive_script)
         # The archive is worthless if it silently drops the extension the product exists for.


### PR DESCRIPTION
Every release built and published both platforms regardless of what moved. #388 changed only `platforms/ios` and still packaged the macOS installer and signed a Sparkle appcast; #381 changed only `platforms/macos` and still archived iOS and pushed a build to TestFlight that testers had no reason to install.

## How a release picks its platforms

`prepare` compares the pushed range and classifies each path:

| path | reaches |
| --- | --- |
| `platforms/ios/**` | iOS |
| `platforms/macos/**` | macOS |
| `shared/**`, `vendor/**`, `cmake/**`, `CMakeLists.txt`, `product-lock.json`, `.github/**` | both |
| `docs/**`, `licenses/**`, `*.md`, `LICENSE` | neither |
| anything else | both |

Unrecognised paths reach both on purpose. Publishing a platform that did not change costs one build; skipping one that did ships a fix that never reaches its users, and nobody notices until a user asks where it went.

Three cases fall back to publishing both:

- a `workflow_dispatch` run, which names a tag rather than a range
- a first push with no predecessor commit
- a range that touched only documentation, because a push to `main` here is a deliberate promotion and the draft release has already been created by the time this step runs

A failed comparison is reported and falls back to both rather than being swallowed — `ReleaseConfigurationTests` forbids `2>/dev/null || true` in this workflow, and the rule is right: a silently failed API call would otherwise read as "nothing changed".

## What the publish job does with it

The macOS packaging, bundle verification and Sparkle steps are gated on macOS; the iOS dictionary, archive, App Store Connect key and TestFlight upload are gated on iOS. `publish-release.sh` takes the two flags and assembles its artifact list, checksum verification, opposite-asset cleanup and release notes from them.

A covered platform still requires **all** of its files, so a packaging step that fails without failing the job is still caught. An uncovered platform contributes nothing, and the notes no longer contain an "Install on macOS" or "### iOS" section for something that was never built.

## One list instead of two

`publish-release.sh` verified one array and then uploaded a second, hand-maintained copy of it. `ReleaseConfigurationTests` had an assertion guarding those two against drifting apart, with a comment recording that an earlier revision had added the `.ipa` to one and not the other.

Upload now uses the verified array, which removes that bug class rather than re-guarding it, so the assertion pins the single list instead.

## Verification

51 release automation tests and 19 release configuration tests pass. New coverage: iOS-only, macOS-only, both, shared and unrecognised paths, documentation-only, `workflow_dispatch`, a missing predecessor commit, a covered platform missing one artifact, and a release that covers no platform at all.

A release pipeline cannot be dry-run, so the tests are the verification. They execute the real classification step and the real publish script rather than asserting on their source text.
