### PR TITLE
perf(ci): stop compiling the iOS tests twice and boot while building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,18 +167,6 @@ jobs:
           mkdir -p build/ios
           xcodegen generate --spec platforms/ios/project.yml --project build/ios --project-root .
           pod install --deployment --project-directory=platforms/ios
-      - name: Build host app and keyboard extension
-        run: |
-          xcodebuild \
-            -workspace build/ios/MetasequoiaImeIOS.xcworkspace \
-            -scheme MetasequoiaImeIOS \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -destination 'generic/platform=iOS Simulator' \
-            -derivedDataPath build/ios-derived \
-            BREW_PREFIX="$(brew --prefix)" \
-            CODE_SIGNING_ALLOWED=NO \
-            build
       - name: Test native iOS keyboard and settings
         # A pull request runs the unit suites and a handful of interface cases; a merge into develop
         # or main runs everything. The interface suite is 96% of this job -- 45 minutes for 37 cases

--- a/platforms/ios/scripts/run_ui_tests.sh
+++ b/platforms/ios/scripts/run_ui_tests.sh
@@ -45,8 +45,10 @@ fi
 # A stale booted runner can accept status requests while its app installation service is wedged.
 # Restarting the selected device is bounded by bootstatus and preserves its installed data.
 xcrun simctl shutdown "${test_device_id}" >/dev/null 2>&1 || true
+# `boot` starts the simulator and returns; the wait is in `bootstatus`, which runs after the build
+# below. The build needs no simulator, so booting first lets the two spend the same minutes rather
+# than consecutive ones -- coming up takes about four of them on a hosted runner.
 xcrun simctl boot "${test_device_id}"
-xcrun simctl bootstatus "${test_device_id}" -b
 
 scope_arguments=()
 if [[ "${MSIME_TEST_SCOPE:-all}" == "pr" ]]; then
@@ -68,6 +70,23 @@ elif [[ "${MSIME_TEST_SCOPE:-all}" != "all" ]]; then
   exit 1
 fi
 
+# Build and run as two actions against one destination. A single `test` rebuilt everything the
+# workflow had just built, because that build targeted `generic/platform=iOS Simulator` and this
+# one targets a specific x86_64 device: different products, so nothing was reused.
+#
+# The scope belongs to the run rather than the build. Building every test target costs the same as
+# before and keeps `test-without-building` from failing on a target the narrower build skipped.
+xcodebuild \
+  -workspace "${project_path}" \
+  -scheme MetasequoiaImeIOS \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,id=${test_device_id},arch=x86_64" \
+  -derivedDataPath "${derived_data_path}" \
+  BREW_PREFIX="$(brew --prefix)" \
+  build-for-testing
+
+xcrun simctl bootstatus "${test_device_id}" -b
+
 xcodebuild \
   -workspace "${project_path}" \
   -scheme MetasequoiaImeIOS \
@@ -76,4 +95,4 @@ xcodebuild \
   -derivedDataPath "${derived_data_path}" \
   BREW_PREFIX="$(brew --prefix)" \
   ${scope_arguments[@]+"${scope_arguments[@]}"} \
-  test
+  test-without-building

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -631,6 +631,27 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
         self.assertIn('xcrun simctl boot "${test_device_id}"', runner)
         self.assertNotIn("sleep ", runner)
 
+        # Build and run are two actions against one destination. A single `test` action rebuilt
+        # everything a separate workflow build step had just produced, because that step targeted
+        # `generic/platform=iOS Simulator` while this targets a specific x86_64 device -- different
+        # products, so nothing was reused and the job paid for the same compile twice.
+        self.assertIn("build-for-testing", runner)
+        self.assertIn("test-without-building", runner)
+        self.assertNotIn("generic/platform=iOS Simulator", workflow)
+        self.assertEqual(workflow.count("xcodebuild"), 0)
+        # Booting returns immediately and the build needs no simulator, so the wait belongs after
+        # the build rather than before it. Compare the commands rather than the file: prose that
+        # names a step would otherwise decide the order this reads.
+        commands = "\n".join(line for line in runner.splitlines() if not line.lstrip().startswith("#"))
+        order = [commands.index(fragment) for fragment in (
+            'xcrun simctl boot "${test_device_id}"', "build-for-testing",
+            "simctl bootstatus", "test-without-building")]
+        self.assertEqual(order, sorted(order), commands)
+        # The scope narrows the run, not the build: a narrower build would skip a target that
+        # test-without-building then fails to find.
+        build_invocation = commands.split("build-for-testing", 1)[0].rsplit("xcodebuild", 1)[1]
+        self.assertNotIn("scope_arguments", build_invocation)
+
     def test_ui_tests_are_main_actor_isolated_for_swift_6(self):
         ui_tests = (IOS_ROOT / "UITests/OnboardingUITests.swift").read_text()
 


### PR DESCRIPTION
The iOS Simulator job took **39m37s** — more than the other three jobs combined (macOS arm64 8m03s, x86_64 9m37s, Sanitizers 9m04s). 30.9 of those minutes went to one step, and this is what was inside it:

| | time | share |
| --- | --- | --- |
| compiling | ~19 min | 61% |
| running the 160 tests | **7.9 min** | 26% |
| waiting for the simulator | ~4 min | 13% |

## The compile happened twice

A workflow step built the app and extension against `generic/platform=iOS Simulator`. `run_ui_tests.sh` then ran `test` against `platform=iOS Simulator,id=…,arch=x86_64`. Different products, so nothing was reused — and the second build additionally compiled every test target, which is the bulk of it.

Nothing consumed the first build's output. That step is removed.

`run_ui_tests.sh` now runs `build-for-testing` and `test-without-building` as two actions against the one destination it already picks for itself.

The scope stays on the run rather than the build. Building every test target costs what it did before and keeps `test-without-building` from failing on a target a narrower build had skipped.

## The boot waited for nothing

`simctl boot` returns as soon as the simulator starts coming up; the wait is in `bootstatus`. The build needs no simulator, so that wait moved from before the build to after it, and the four minutes are now spent alongside the compile.

## Verification

Ran the script locally end to end against a real simulator: 99, 5, 7 and 12 tests pass across the four bundles, so the split actions and the moved wait work rather than merely parse.

`ProjectConfigurationTests` pins the two actions, their order against the boot and the wait, and that the workflow no longer invokes `xcodebuild` itself. The order is checked against the commands with comments stripped — prose naming a step would otherwise decide the order the test reads.

## Not in this change

The ~19 minute compile still starts from scratch every run. Caching DerivedData is the larger win and the riskier one: a stale artifact fails in ways that look like a code bug. That belongs in its own change, with a miss falling back to a full build, so it can be reverted on its own if it misbehaves.
