### PR TITLE
test(ios): wait for the switch before the scheme button comes back

### DIFF
--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -1143,7 +1143,11 @@ final class OnboardingUITests: XCTestCase {
     screenshot.lifetime = .deleteOnSuccess
     add(screenshot)
     nine.tap()
-    XCTAssertTrue(wait(app.buttons["inputScheme_nineKey"], until: "isEnabled == true"))
+    // Same two steps as the hide above: the switch commits first and the scheme list is rebuilt
+    // from it, so waiting on the button alone races a rebuild that has not been asked for yet.
+    // Toggling back also follows a screenshot, which leaves the app busy for a moment longer.
+    XCTAssertTrue(wait(nine, until: "value == '1'"))
+    XCTAssertTrue(wait(app.buttons["inputScheme_nineKey"], until: "isEnabled == true", timeout: 15))
   }
 
   @MainActor


### PR DESCRIPTION
The last line of `testInputSchemeVisibilityPersistsAndFallsBack` re-enables the hidden scheme and waits for its button to come back. It timed out on #393, a pull request that changes only the release pipeline and cannot reach the iOS keyboard.

The hide earlier in the same test already waits in two steps — the switch commits, and the scheme list is rebuilt from it — because waiting on the button alone races a rebuild that has not been asked for yet. The show at the end was missing that first step, and it also follows `app.screenshot()`, which leaves the app busy a moment longer.

It now waits for the switch first and gives the button 15 seconds, matching what the hide does.

Worth recording: the keyboard unit suites passed in that same run. When this test failed earlier today it left a scheme hidden in the app group and took 216 assertions in `MetasequoiaKeyboardTests` down with it. The `defer` added in #390 now restores visibility on the failure path, so the flake stayed contained to its own test.

Verified by running the case locally: passes in 33.5s.
