### PR TITLE
fix(ios): say why the typing statistics are empty

### DIFF
--- a/platforms/ios/App/Sources/TypingStatisticsView.swift
+++ b/platforms/ios/App/Sources/TypingStatisticsView.swift
@@ -16,6 +16,24 @@ struct TypingStatisticsView: View {
   @State private var selectedDay: Date?
   private let store = TypingStatisticsStore()
   private let colors: [Color] = [.teal, .blue, .indigo, .orange, .pink, .purple, .brown, .gray]
+  @State private var availability = TypingStatisticsStore.Availability.neverWritten
+  // The old copy asked for Full Access unconditionally, so it said the same thing whether the
+  // setting was the problem or not and carried no information. Each case here is a different
+  // answer to "why is this empty", and a run that is working says nothing at all.
+  private var storageAdvice: String? {
+    switch availability {
+    case .containerUnavailable:
+      return "无法访问共享存储，键盘与本 app 之间没有可用的数据通道。重装水杉输入法可以重建它。"
+    case .neverWritten:
+      return "键盘从未写入过统计。请在系统设置 → 通用 → 键盘 → 键盘 → 水杉输入法中开启“允许完全访问”，"
+        + "然后用水杉键盘输入几个字再回来刷新。未开启时仍可正常打字，只是不记录统计。"
+    case .ready(let lastWritten):
+      guard statistics.total == 0 else { return nil }
+      guard let lastWritten else { return "统计文件存在但还没有计数，请用水杉键盘输入几个字再刷新。" }
+      return "统计文件最后写入于 \(lastWritten.formatted(.dateTime.month().day().hour().minute()))，但计数为零。"
+        + "若此前清空过统计，这是正常的；否则请附上这条信息反馈。"
+    }
+  }
   private var dates: [Date] {
     (0..<(period == 0 ? 30 : period)).reversed().compactMap {
       Calendar.current.date(byAdding: .day, value: -$0, to: Calendar.current.startOfDay(for: Date()))
@@ -95,11 +113,13 @@ struct TypingStatisticsView: View {
       } footer: {
         Text("仅统计水杉键盘提交的字符，含标点及表情，不含空格、换行和未上屏拼音。组合表情计为一个字符，删除文字不扣减。仅在本机保存分类计数，不保存输入内容。每日明细保留最近 366 个有记录的日期，累计分类持续保留。")
       }
-      Section("开启统计") {
-        Text("请在系统设置 → 通用 → 键盘 → 键盘 → 水杉输入法中开启“允许完全访问”，以便键盘将统计写入本机。未开启时仍可正常打字，但不会记录统计。")
-        Button("前往系统设置") {
-          guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-          UIApplication.shared.open(url)
+      if let advice = storageAdvice {
+        Section("统计没有数据") {
+          Text(advice)
+          Button("前往系统设置") {
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            UIApplication.shared.open(url)
+          }
         }
       }
       if !errorMessage.isEmpty { Section { Text(errorMessage).foregroundStyle(.secondary) } }
@@ -179,10 +199,15 @@ struct TypingStatisticsView: View {
   }
   private func reload() { update {} }
   private func update(_ operation: () throws -> Void) {
+    availability = store.availability()
     do {
       try operation()
       statistics = try store.load()
       errorMessage = ""
-    } catch { errorMessage = "暂时无法读取或保存统计，请解锁设备后重试。" }
+    } catch {
+      // A locked device is one reason among several, and naming only that one sent a reader
+      // looking in the wrong place. Carry what actually failed.
+      errorMessage = "无法读取或保存统计：\(error.localizedDescription)"
+    }
   }
 }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -92,6 +92,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private let spellingScrollView = UIScrollView()
   private let spellingStack = UIStackView()
   private var usesTraditionalOutput = false
+  private var reportedStatisticsFailure = false
   private var visiblePreedit = ""
   private var candidateRevision: UInt64 = 0
   private var visibleCandidates: [String] = []
@@ -1830,7 +1831,21 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private func insertOwnText(_ text: String, source: TypingSource? = nil) {
     pendingOwnEdits += 1
     textDocumentProxy.insertText(text)
-    if hasFullAccess { try? TypingStatisticsStore().record(text, source: source ?? typingSource) }
+    recordTypingStatistics(text, source: source ?? typingSource)
+  }
+
+  // Swallowing this left the settings screen showing zeros with nothing to explain them, which is
+  // how it reached a bug report rather than the person typing. The reason does not change between
+  // keystrokes and a banner on each one would bury the composition, so it is said once per session.
+  private func recordTypingStatistics(_ text: String, source: TypingSource) {
+    guard hasFullAccess else { return }
+    do {
+      try TypingStatisticsStore().record(text, source: source)
+    } catch {
+      guard !reportedStatisticsFailure else { return }
+      reportedStatisticsFailure = true
+      showDiagnostic("统计未能写入：\(error.localizedDescription)")
+    }
   }
 
   private func deleteOwnBackward() {

--- a/platforms/ios/KeyboardTests/TypingStatisticsTests.swift
+++ b/platforms/ios/KeyboardTests/TypingStatisticsTests.swift
@@ -91,4 +91,24 @@ final class TypingStatisticsTests: XCTestCase {
     XCTAssertEqual(snapshot.detail.characters["han"], 470)
     XCTAssertEqual(snapshot.detail.sources["unknown"], 470)
   }
+
+  func testAvailabilityTellsAnEmptyRunApartFromABrokenOne() throws {
+    // The three answers to "why is this empty" are different actions for the reader, so the store
+    // has to distinguish them rather than return one emptiness.
+    XCTAssertEqual(TypingStatisticsStore(directory: nil).availability(), .containerUnavailable)
+
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("stats-availability-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let store = TypingStatisticsStore(directory: directory)
+    XCTAssertEqual(store.availability(), .neverWritten)
+
+    try store.record("水杉")
+    guard case .ready(let lastWritten) = store.availability() else {
+      return XCTFail("A written store still reported that the keyboard had never written.")
+    }
+    XCTAssertNotNil(lastWritten)
+  }
 }

--- a/platforms/ios/SharedUI/TypingStatistics.swift
+++ b/platforms/ios/SharedUI/TypingStatistics.swift
@@ -141,6 +141,24 @@ struct TypingStatisticsStore {
     try transaction(write: false) { $0 }
   }
 
+  // Why the numbers are empty, answered without going through the write path that may be the thing
+  // at fault. The app can always reach the group container; the keyboard extension is the side that
+  // can be denied, so an unreachable directory or an absent file each mean something different.
+  enum Availability: Equatable {
+    case ready(lastWritten: Date?)
+    case containerUnavailable
+    case neverWritten
+  }
+
+  func availability() -> Availability {
+    guard let directory else { return .containerUnavailable }
+    let url = directory.appendingPathComponent("typing-statistics.json")
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+      return .neverWritten
+    }
+    return .ready(lastWritten: attributes[.modificationDate] as? Date)
+  }
+
   func record(_ text: String, source: TypingSource = .unknown, at date: Date = Date(), calendar: Calendar = .current) throws {
     var addition = TypingBreakdown()
     for character in text where !character.isWhitespace {


### PR DESCRIPTION
统计页显示全零变成了一次 bug 反馈，因为屏幕上没有任何东西能区分"没数据"和"坏了"。

- 键盘用 `try?` 包住写入，失败无声无息
- 设置页那段"请开启完全访问"是无条件常显的，开没开都是同一句，不携带信息
- 所有读取失败都报成"请解锁设备后重试"，把读者引向错误的方向

## 现在怎么回答这个问题

`TypingStatisticsStore.availability()` 从文件系统直接回答，而不是走那条本身可能有故障的写入路径。app 侧总能访问 App Group 容器，键盘扩展才是可能被拒的一侧，所以三种状态各自意味着不同的处置：

| 状态 | 含义 |
| --- | --- |
| `containerUnavailable` | 共享存储不可达，重装可重建 |
| `neverWritten` | 键盘一次都没写成功，去开完全访问再打几个字 |
| `ready(lastWritten:)` | 文件在。计数为零时附上最后写入时间，让读者能判断是不是自己清空过 |

**一切正常时这一段完全不显示**，而旧文案两种情况说同一句话。

## 其余两处

键盘一个会话报一次写入失败。每次按键都报会淹没输入，而失败原因在会话内不会变。

读取失败带出真实错误，不再只点名一种可能。

## 说明

**这不修复坏掉的统计，只是让它可读。** 遇到问题的人下次能直接看到原因，而不是像这次一样只能靠手动试。

100 项键盘测试通过，含新增的一条覆盖三种状态互不混淆。
