### PR TITLE
fix(ios): close the reply panel once a reply is inserted

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -92,6 +92,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private let spellingScrollView = UIScrollView()
   private let spellingStack = UIStackView()
   private var usesTraditionalOutput = false
+  private var replyPanelSuppressed = false
   private var visiblePreedit = ""
   private var candidateRevision: UInt64 = 0
   private var visibleCandidates: [String] = []
@@ -1256,13 +1257,11 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private func synchronizeReplyKeyboard() {
     guard inputScheme == .thoughtfulReply, isChineseMode else {
       replyModel.resetResults()
-      if let panel = replyPanel {
-        panel.willMove(toParent: nil); panel.view.removeFromSuperview(); panel.removeFromParent()
-        replyPanel = nil
-      }
+      replyPanelSuppressed = false
+      dismissReplyPanel()
       return
     }
-    guard replyPanel == nil else { return }
+    guard replyPanel == nil, !replyPanelSuppressed else { return }
     let panel = UIHostingController(rootView: ReplyKeyboardView(model: replyModel,
       paste: { [weak self] in
         guard let self else { return }
@@ -1285,6 +1284,14 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       panel.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
     ])
     panel.didMove(toParent: self)
+  }
+
+  private func dismissReplyPanel() {
+    guard let panel = replyPanel else { return }
+    panel.willMove(toParent: nil)
+    panel.view.removeFromSuperview()
+    panel.removeFromParent()
+    replyPanel = nil
   }
 
   private func generateReply(style: String) {
@@ -1317,12 +1324,23 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     }, insert: { [weak self] result in
       guard let self, matches() else { return false }
       insertOwnText(result, source: .reply)
+      // The panel is pinned to every edge, so it covers the text that was just inserted and the
+      // backspace that would fix it -- the only delete it leaves on screen edits the pasted source
+      // instead. Its own status asks the reader to go and check the chat app, so it gets out of the
+      // way and behaves like the other pickers, which close once a choice is made. The reply
+      // shortcut brings it back.
+      replyPanelSuppressed = true
+      dismissReplyPanel()
       return true
     })
   }
 
   private func showKeyboardAI() {
-    if inputScheme == .thoughtfulReply { synchronizeReplyKeyboard(); return }
+    if inputScheme == .thoughtfulReply {
+      replyPanelSuppressed = false
+      synchronizeReplyKeyboard()
+      return
+    }
     guard hasFullAccess else { showDiagnostic("AI 需要开启键盘的“允许完全访问”。"); return }
     guard let configuration = KeyboardAIService.configuration() else {
       showDiagnostic("请在水杉 App 的 AI 设置中启用键盘 AI 并保存配置。"); return

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -111,6 +111,15 @@ final class NineKeyKeyboardTests: XCTestCase {
     XCTAssertEqual(InputSchemePreference.scheme, .quanpin)
     XCTAssertEqual(try button("scriptShortcut", in: controller).accessibilityIdentifier, "scriptShortcut")
     XCTAssertFalse(descendants(controller.view).contains { $0.accessibilityIdentifier == "replyKeyboard" })
+
+    // Inserting a reply takes the panel away so the text it just wrote, and the backspace that
+    // edits it, are reachable. The reply shortcut is what brings it back, so that path has to work
+    // even when the panel is already gone.
+    InputSchemePreference.enabledSchemes = [.quanpin, .thoughtfulReply]
+    InputSchemePreference.scheme = .thoughtfulReply
+    controller.viewWillAppear(false)
+    try button("replyShortcut", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertTrue(descendants(controller.view).contains { $0.accessibilityIdentifier == "replyKeyboard" })
   }
 
   func testDisabledSchemesAreHiddenAndCurrentSchemeFallsBack() throws {


### PR DESCRIPTION
回复面板四边都钉在键盘上，所以 `use(_:)` 把回复写进宿主文档之后，面板仍然盖着那段文字**和能改它的退格键**。屏幕上唯一剩下的删除是面板自己的那个，它改的是粘贴进来的源文字而不是文档——这就是反馈里说的"删除按钮删的是内部的，输入框的内容删不掉"。

## 改法

面板的状态提示本来就是"已插入，请在聊天应用中确认发送"——它让读者去看聊天应用，自己却挡在前面。现在它在没事可做时让开，和方案/布局/皮肤选择器选完即关是同一个行为。回复快捷键把它唤回来。

## 为什么不是加一个删除按钮

那一行已经有"删除源文字"和"清空"两个删除类控件。再加第三个就要教用户区分两个"删除"分别作用于什么，而收起面板让退格键自然回来，不需要解释。

## 覆盖范围

插入路径需要 AI 服务，单元测试里触发不了。已覆盖的是**快捷键能在面板消失后重新唤起它**——这一半如果坏了，读者会被困在一个回不去的键盘上。99 项键盘测试通过。
