### PR TITLE
fix(ios): give the scheme picker the product's own accent

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardSchemePickerView.swift
@@ -2,9 +2,11 @@ import UIKit
 
 final class KeyboardSchemePickerView: UIView {
   private var glyphBorders: [(UILabel, Bool)] = []
-  private let accent = UIColor { $0.userInterfaceStyle == .dark
-    ? UIColor(red: 1, green: 0.62, blue: 0.28, alpha: 1)
-    : UIColor(red: 1, green: 0.47, blue: 0.10, alpha: 1) }
+  // The one place in the keyboard that invented its own accent. Orange against a product that is
+  // forest green read as a different app's control, and white on it measured 2.6:1 in light mode
+  // and 2.1:1 in dark -- below the large-text floor, let alone AA.
+  private let accent = MetasequoiaTheme.forestUIColor
+  private let onAccent = MetasequoiaTheme.onForestUIColor
 
   init(selected: ChineseInputScheme, isChineseMode: Bool = true,
        onSelect: @escaping (ChineseInputScheme) -> Void,
@@ -41,7 +43,7 @@ final class KeyboardSchemePickerView: UIView {
       button.setTitleColor(.label, for: .normal)
     }
     keyboardTab.backgroundColor = accent
-    keyboardTab.setTitleColor(.white, for: .normal)
+    keyboardTab.setTitleColor(onAccent, for: .normal)
 
     let settings = UIButton(type: .system)
     settings.setImage(UIImage(systemName: "gearshape"), for: .normal)
@@ -134,8 +136,8 @@ final class KeyboardSchemePickerView: UIView {
       scroll.isHidden = showThemes
       keyboardTab.backgroundColor = showThemes ? .clear : accent
       themeTab.backgroundColor = showThemes ? accent : .clear
-      keyboardTab.setTitleColor(showThemes ? .label : .white, for: .normal)
-      themeTab.setTitleColor(showThemes ? .white : .label, for: .normal)
+      keyboardTab.setTitleColor(showThemes ? .label : onAccent, for: .normal)
+      themeTab.setTitleColor(showThemes ? onAccent : .label, for: .normal)
       keyboardTab.accessibilityTraits = showThemes ? [.button] : [.button, .selected]
       themeTab.accessibilityTraits = showThemes ? [.button, .selected] : [.button]
       content.subviews.filter { $0 !== scroll }.forEach { $0.removeFromSuperview() }

--- a/platforms/ios/KeyboardTests/KeyboardSkinTests.swift
+++ b/platforms/ios/KeyboardTests/KeyboardSkinTests.swift
@@ -236,4 +236,24 @@ final class KeyboardSkinTests: XCTestCase {
       }
     }
   }
+
+  private func packed(_ color: UIColor) -> UInt32 {
+    var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+    color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    let channel = { (value: CGFloat) in UInt32((value * 255).rounded()) }
+    return channel(red) << 16 | channel(green) << 8 | channel(blue)
+  }
+
+  func testSchemePickerAccentStaysReadableInBothAppearances() {
+    // The picker used to carry its own orange, which measured 2.6:1 against white in light mode
+    // and 2.1:1 in dark -- below the large-text floor. Both shades of forest are on opposite sides
+    // of that line, so the foreground has to follow the appearance rather than be picked once.
+    for style in [UIUserInterfaceStyle.light, .dark] {
+      let traits = UITraitCollection(userInterfaceStyle: style)
+      let background = packed(MetasequoiaTheme.forestUIColor.resolvedColor(with: traits))
+      let foreground = packed(MetasequoiaTheme.onForestUIColor.resolvedColor(with: traits))
+      XCTAssertGreaterThanOrEqual(CustomKeyboardSkin.contrast(foreground, background), 4.5,
+                                  "\(style) 下选中态文字对比度不足")
+    }
+  }
 }

--- a/platforms/ios/SharedUI/MetasequoiaTheme.swift
+++ b/platforms/ios/SharedUI/MetasequoiaTheme.swift
@@ -20,6 +20,15 @@ enum MetasequoiaTheme {
   static let cone = Color(red: 167 / 255, green: 103 / 255, blue: 59 / 255)
   static let ink = Color(red: 20 / 255, green: 35 / 255, blue: 29 / 255)
 
+  // Text and glyphs drawn on top of forestUIColor. The two shades of forest sit on opposite sides
+  // of the contrast line, so a single foreground fails one of them: white reads 7.9:1 on the light
+  // shade but 2.5:1 on the dark one, which is below even the large-text floor.
+  static let onForestUIColor = UIColor { traits in
+    traits.userInterfaceStyle == .dark
+      ? UIColor(red: 20 / 255, green: 35 / 255, blue: 29 / 255, alpha: 1)
+      : .white
+  }
+
   static let forestUIColor = UIColor { traits in
     traits.userInterfaceStyle == .dark
       ? UIColor(red: 97 / 255, green: 180 / 255, blue: 145 / 255, alpha: 1)


### PR DESCRIPTION
方案选择器是键盘里唯一自造颜色的地方：`KeyboardSchemePickerView.swift` 在自己文件里硬编码了一个橙色，既不来自调色板，也不是调色板里那个偏棕的球果色 `cone`。产品整体是森林绿，它看起来像是从别的 app 借来的控件。

## 它还不可读

| 背景 | 前景 | 对比度 | |
| --- | --- | --- | --- |
| 原橙色 浅色 `rgb(255,120,26)` | 白 | **2.64** | 低于大字下限 3.0 |
| 原橙色 深色 `rgb(255,158,71)` | 白 | **2.05** | 低于大字下限 |

AA 要求 4.5。这不只是配色问题。

## 为什么不能直接换成 forest

`forestUIColor` 的深浅两档正好落在对比度线的两侧：

| 背景 | 前景 | 对比度 |
| --- | --- | --- |
| forest 浅色 `rgb(24,92,72)` | 白 | 7.89 |
| forest 深色 `rgb(97,180,145)` | 白 | **2.49** |
| forest 深色 `rgb(97,180,145)` | `ink` `rgb(20,35,29)` | **6.56** |

所以前景色必须跟着外观走。调色板新增 `onForestUIColor`：浅色模式白字，深色模式用已有的 `ink`。

## 波及范围比标签页更广

`accent` 在这个文件里还用于选中卡片的背景、勾选图标和边框，不只是顶部两个标签页，所以那些也一并回到产品色。

## 验证

新增测试钉住两种外观都 ≥ 4.5，复用皮肤测试已在用的 `CustomKeyboardSkin.contrast`（它收的是打包 `UInt32`，测试里把解析后的 `UIColor` 转过去）。100 项键盘测试通过。
