### PR TITLE
ci(release): name the platform in a single-platform build tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -510,7 +510,9 @@ jobs:
             "$sparkle_archive" | shasum -a 256 --check
           mkdir -p "$sparkle_root"
           tar -xJf "$sparkle_archive" -C "$sparkle_root"
-          update_archive="dist/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX-update.zip"
+          asset_tag=${TAG_NAME#macos-}
+          asset_tag=${asset_tag#ios-}
+          update_archive="dist/MetasequoiaIME-$asset_tag-macos-universal$ASSET_SUFFIX-update.zip"
           SPARKLE_TOOLS_DIR="$sparkle_root/bin" \
             exec "$RUNNER_TEMP/generate-sparkle-appcast.sh" "$TAG_NAME" "$update_archive" dist/appcast.xml
       - name: Skip Sparkle appcast without an update key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,13 +128,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BUILD_NUMBER: ${{ steps.build_number.outputs.value }}
+          RELEASE_MACOS: ${{ steps.platforms.outputs.macos }}
+          RELEASE_IOS: ${{ steps.platforms.outputs.ios }}
         run: |
           version=$(cat version.txt)
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version.txt" >&2
             exit 1
           fi
+          # A build that covers one platform says so in its tag. Sharing one sequence across two
+          # products that now release apart leaves a reader scanning the list to find which entries
+          # carry the platform they run. A build covering both keeps the bare name, which reads as
+          # the complete release it is; only the promoted versions have no -build. suffix, so the
+          # two cannot be confused.
           tag="v$version-build.$BUILD_NUMBER"
+          case "$RELEASE_MACOS:$RELEASE_IOS" in
+            true:false) tag="macos-$tag" ;;
+            false:true) tag="ios-$tag" ;;
+          esac
           gh release create "$tag" --target "$GITHUB_SHA" --title "$tag" --generate-notes --draft --prerelease
           printf 'release_created=true\ntag_name=%s\ntarget_sha=%s\n' "$tag" "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
       - name: Capture existing release branch
@@ -202,7 +213,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ inputs.tag }}
         run: |
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+          if [[ ! "$TAG_NAME" =~ ^(macos-|ios-)?v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
             echo "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
             exit 1
           fi
@@ -219,7 +230,9 @@ jobs:
           fi
           target_sha=$target
           version=$(gh api "repos/$GH_REPO/contents/version.txt?ref=$target_sha" --jq .content | base64 --decode)
-          if [[ "${TAG_NAME%%-build.*}" != "v$version" ]]; then
+          bare=${TAG_NAME#macos-}
+          bare=${bare#ios-}
+          if [[ "${bare%%-build.*}" != "v$version" ]]; then
             echo "Release $TAG_NAME does not match version.txt ($version)." >&2
             exit 1
           fi
@@ -337,7 +350,9 @@ jobs:
             echo 'Unsigned release: skipping Developer ID signature verification before packaging.'
           fi
           lipo build/MetasequoiaIME.app/Contents/MacOS/MetasequoiaIME -verify_arch arm64 x86_64
-          version=${TAG_NAME#v}
+          version=${TAG_NAME#macos-}
+          version=${version#ios-}
+          version=${version#v}
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' build/MetasequoiaIME.app/Contents/Info.plist)" = "${version%%-build.*}"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' build/MetasequoiaIME.app/Contents/Info.plist)" = "$METASEQUOIA_BUILD_NUMBER"
       - name: Package release

--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -142,7 +142,12 @@ if [[ "$extension_version" != "$version" ]]; then
     exit 1
 fi
 
-bundle="$output_dir/MetasequoiaIME-$tag_name-ios-unsigned.xcarchive.zip"
+# The platform already appears later in every artifact name, so a prefixed tag would repeat it:
+# MetasequoiaIME-macos-v0.48.6-...-macos-universal.pkg. The prefix belongs to the tag, which
+# distinguishes releases from each other, not to files inside one release.
+asset_tag=${tag_name#macos-}
+asset_tag=${asset_tag#ios-}
+bundle="$output_dir/MetasequoiaIME-$asset_tag-ios-unsigned.xcarchive.zip"
 rm -f -- "$bundle" "$bundle.sha256"
 ditto -c -k --keepParent "$archive_path" "$bundle"
 
@@ -164,7 +169,7 @@ if [[ ! -x "$staged_extension/MetasequoiaKeyboard" || ! -s "$staged_extension/ms
     exit 1
 fi
 
-ipa="$output_dir/MetasequoiaIME-$tag_name-ios-unsigned.ipa"
+ipa="$output_dir/MetasequoiaIME-$asset_tag-ios-unsigned.ipa"
 rm -f -- "$ipa" "$ipa.sha256"
 # zip rather than ditto: ditto writes AppleDouble ._ entries beside the payload, and an .ipa is
 # consumed by tools that do not expect them.

--- a/platforms/ios/scripts/package_ios_archive.sh
+++ b/platforms/ios/scripts/package_ios_archive.sh
@@ -23,11 +23,15 @@ if [[ "$output_dir" != /* ]]; then
     output_dir="$(pwd)/$output_dir"
 fi
 
-if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+if [[ ! "$tag_name" =~ ^(macos-|ios-)?v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
     printf '%s\n' "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
     exit 1
 fi
-version=${tag_name#v}
+# A single-platform build carries its platform ahead of the v, so it has to come off before the
+# version does: ${tag_name#v} alone would leave macos-v0.48.6 and ship that as a version.
+version=${tag_name#macos-}
+version=${version#ios-}
+version=${version#v}
 version=${version%%-build.*}
 
 for tool in git pod xcodegen xcodebuild ditto shasum; do

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -196,8 +196,10 @@ fi
 
 if [[ -n "${METASEQUOIA_IOS_RELEASE_DIR:-}" ]]; then
     release_dir=$(cd "$METASEQUOIA_IOS_RELEASE_DIR" && pwd)
-    signed_archive="$release_dir/MetasequoiaIME-$tag_name-ios-testflight.xcarchive.zip"
-    signed_ipa="$release_dir/MetasequoiaIME-$tag_name-ios-testflight.ipa"
+    asset_tag=${tag_name#macos-}
+    asset_tag=${asset_tag#ios-}
+    signed_archive="$release_dir/MetasequoiaIME-$asset_tag-ios-testflight.xcarchive.zip"
+    signed_ipa="$release_dir/MetasequoiaIME-$asset_tag-ios-testflight.ipa"
     ditto -c -k --keepParent "$archive_path" "$signed_archive"
     cp "$ipa" "$signed_ipa"
     (

--- a/platforms/ios/scripts/package_ios_testflight.sh
+++ b/platforms/ios/scripts/package_ios_testflight.sh
@@ -15,7 +15,7 @@ tag_name=${1:-}
 : "${METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH:?METASEQUOIA_IOS_APP_PROVISIONING_PROFILE_PATH is required}"
 : "${METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH:?METASEQUOIA_IOS_KEYBOARD_PROVISIONING_PROFILE_PATH is required}"
 
-if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+if [[ ! "$tag_name" =~ ^(macos-|ios-)?v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
     printf '%s\n' 'Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix.' >&2
     exit 1
 fi
@@ -50,7 +50,11 @@ if [[ ! -s "$dictionary" ]]; then
     exit 1
 fi
 
-version=${tag_name#v}
+# A single-platform build carries its platform ahead of the v, so it has to come off before the
+# version does: ${tag_name#v} alone would leave macos-v0.48.6 and ship that as a version.
+version=${tag_name#macos-}
+version=${version#ios-}
+version=${version#v}
 version=${version%%-build.*}
 
 # CFBundleVersion has to be unique and strictly increasing within one CFBundleShortVersionString.

--- a/platforms/macos/scripts/generate-sparkle-appcast.sh
+++ b/platforms/macos/scripts/generate-sparkle-appcast.sh
@@ -33,9 +33,11 @@ if [[ "$tag_name" == *-build.* ]]; then
 fi
 
 archive_name=$(basename "$archive_path")
+asset_tag=${tag_name#macos-}
+asset_tag=${asset_tag#ios-}
 case "$archive_name" in
-    "MetasequoiaIME-$tag_name-macos-universal-update.zip" | \
-        "MetasequoiaIME-$tag_name-macos-universal-unsigned-update.zip") ;;
+    "MetasequoiaIME-$asset_tag-macos-universal-update.zip" | \
+        "MetasequoiaIME-$asset_tag-macos-universal-unsigned-update.zip") ;;
     *)
         printf 'Update archive does not match release tag %s: %s\n' "$tag_name" "$archive_name" >&2
         exit 1

--- a/platforms/macos/scripts/generate-sparkle-appcast.sh
+++ b/platforms/macos/scripts/generate-sparkle-appcast.sh
@@ -9,7 +9,7 @@ tag_name=${1:-}
 archive_path=${2:-}
 output_path=${3:-}
 
-if [[ ! "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+if [[ ! "$tag_name" =~ ^(macos-|ios-)?v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
     printf '%s\n' "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
     exit 1
 fi
@@ -22,7 +22,11 @@ if [[ -z "$output_path" ]]; then
     exit 1
 fi
 
-version=${tag_name#v}
+# A single-platform build carries its platform ahead of the v, so it has to come off before the
+# version does: ${tag_name#v} alone would leave macos-v0.48.6 and ship that as a version.
+version=${tag_name#macos-}
+version=${version#ios-}
+version=${version#v}
 build_number=${METASEQUOIA_BUILD_NUMBER:-$version}
 if [[ "$tag_name" == *-build.* ]]; then
     build_number=${tag_name##*-build.}

--- a/platforms/macos/scripts/package_release.sh
+++ b/platforms/macos/scripts/package_release.sh
@@ -27,14 +27,18 @@ tag_name=${1:-}
 source_bundle=${2:-$project_root/build/MetasequoiaIME.app}
 output_dir=${3:-$project_root/dist}
 
-if [[ ! "$tag_name" =~ '^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$' ]]; then
+if [[ ! "$tag_name" =~ '^(macos-|ios-)?v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$' ]]; then
     print -u2 "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix."
     exit 1
 fi
 
 source_bundle=${source_bundle:A}
 output_dir=${output_dir:A}
-version=${tag_name#v}
+# A single-platform build carries its platform ahead of the v, so it has to come off before the
+# version does: ${tag_name#v} alone would leave macos-v0.48.6 and ship that as a version.
+version=${tag_name#macos-}
+version=${version#ios-}
+version=${version#v}
 version=${version%%-build.*}
 build_number=${METASEQUOIA_BUILD_NUMBER:-$version}
 if [[ "$tag_name" == *-build.* ]]; then

--- a/platforms/macos/scripts/package_release.sh
+++ b/platforms/macos/scripts/package_release.sh
@@ -129,10 +129,15 @@ else
 fi
 mkdir -p "$output_dir"
 staging_root=$(mktemp -d "$output_dir/.package.XXXXXX")
-package_root="$staging_root/MetasequoiaIME-$tag_name"
-archive_name="MetasequoiaIME-$tag_name-macos-universal$asset_suffix.zip"
-update_archive_name="MetasequoiaIME-$tag_name-macos-universal$asset_suffix-update.zip"
-installer_name="MetasequoiaIME-$tag_name-macos-universal$asset_suffix.pkg"
+# The platform already appears later in every artifact name, so a prefixed tag would repeat it:
+# MetasequoiaIME-macos-v0.48.6-...-macos-universal.pkg. The prefix belongs to the tag, which
+# distinguishes releases from each other, not to files inside one release.
+asset_tag=${tag_name#macos-}
+asset_tag=${asset_tag#ios-}
+package_root="$staging_root/MetasequoiaIME-$asset_tag"
+archive_name="MetasequoiaIME-$asset_tag-macos-universal$asset_suffix.zip"
+update_archive_name="MetasequoiaIME-$asset_tag-macos-universal$asset_suffix-update.zip"
+installer_name="MetasequoiaIME-$asset_tag-macos-universal$asset_suffix.pkg"
 archive_path="$staging_root/$archive_name"
 checksum_path="$archive_path.sha256"
 update_archive_path="$staging_root/$update_archive_name"

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -58,27 +58,31 @@ if [[ ! "$TAG_NAME" =~ ^(macos-|ios-)?v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]
     exit 1
 fi
 
-archive="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.zip"
-update_archive="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX-update.zip"
-installer="$dist_dir/MetasequoiaIME-$TAG_NAME-macos-universal$ASSET_SUFFIX.pkg"
+# Must match how the packaging scripts name their output: the platform prefix stays on the tag and
+# out of the file names, which already carry a platform segment of their own.
+asset_tag=${TAG_NAME#macos-}
+asset_tag=${asset_tag#ios-}
+archive="$dist_dir/MetasequoiaIME-$asset_tag-macos-universal$ASSET_SUFFIX.zip"
+update_archive="$dist_dir/MetasequoiaIME-$asset_tag-macos-universal$ASSET_SUFFIX-update.zip"
+installer="$dist_dir/MetasequoiaIME-$asset_tag-macos-universal$ASSET_SUFFIX.pkg"
 appcast="$dist_dir/appcast.xml"
 if [[ "$IOS_TESTFLIGHT_ENABLED" == true ]]; then
-    ios_archive="$dist_dir/MetasequoiaIME-$TAG_NAME-ios-testflight.xcarchive.zip"
-    ios_ipa="$dist_dir/MetasequoiaIME-$TAG_NAME-ios-testflight.ipa"
+    ios_archive="$dist_dir/MetasequoiaIME-$asset_tag-ios-testflight.xcarchive.zip"
+    ios_ipa="$dist_dir/MetasequoiaIME-$asset_tag-ios-testflight.ipa"
     opposite_ios_artifacts=(
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.xcarchive.zip"
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.xcarchive.zip.sha256"
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.ipa"
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.ipa.sha256"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-unsigned.xcarchive.zip"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-unsigned.xcarchive.zip.sha256"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-unsigned.ipa"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-unsigned.ipa.sha256"
     )
 else
-    ios_archive="$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.xcarchive.zip"
-    ios_ipa="$dist_dir/MetasequoiaIME-$TAG_NAME-ios-unsigned.ipa"
+    ios_archive="$dist_dir/MetasequoiaIME-$asset_tag-ios-unsigned.xcarchive.zip"
+    ios_ipa="$dist_dir/MetasequoiaIME-$asset_tag-ios-unsigned.ipa"
     opposite_ios_artifacts=(
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-testflight.xcarchive.zip"
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-testflight.xcarchive.zip.sha256"
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-testflight.ipa"
-        "$dist_dir/MetasequoiaIME-$TAG_NAME-ios-testflight.ipa.sha256"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-testflight.xcarchive.zip"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-testflight.xcarchive.zip.sha256"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-testflight.ipa"
+        "$dist_dir/MetasequoiaIME-$asset_tag-ios-testflight.ipa.sha256"
     )
 fi
 artifacts=()

--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -53,7 +53,7 @@ case "$SIGNING_ENABLED:$ASSET_SUFFIX" in
         ;;
 esac
 
-if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
+if [[ ! "$TAG_NAME" =~ ^(macos-|ios-)?v[0-9]+\.[0-9]+\.[0-9]+(-build\.[1-9][0-9]{0,3}\.[0-9]{1,2}\.[0-9]{1,2})?$ ]]; then
     printf '%s\n' "Tag must use vMAJOR.MINOR.PATCH with an optional -build.X.Y.Z suffix." >&2
     exit 1
 fi

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -137,6 +137,44 @@ class BuildNumberTests(unittest.TestCase):
         self.assertEqual(self.platforms_for("platforms/ios/a.swift", before="0" * 40), ("true", "true"))
         self.assertEqual(self.platforms_for(), ("true", "true"))
 
+    def test_a_single_platform_build_names_its_platform_in_the_tag(self):
+        for macos, ios, expected in [("true", "true", "v0.48.6-build.2.23.1"),
+                                     ("true", "false", "macos-v0.48.6-build.2.23.1"),
+                                     ("false", "true", "ios-v0.48.6-build.2.23.1")]:
+            _, output = self.run_step(
+                "Create automatic build draft",
+                prefix='cat() { printf "0.48.6\\n"; }; gh() { :; }',
+                BUILD_NUMBER="2.23.1", GITHUB_SHA=HEAD_SHA,
+                RELEASE_MACOS=macos, RELEASE_IOS=ios)
+            self.assertIn(f"tag_name={expected}\n", output, f"{macos}/{ios}")
+
+    def test_the_version_survives_a_platform_prefix(self):
+        # The prefix sits ahead of the v, so ${tag#v} alone leaves macos-v0.48.6 and ships that as
+        # a version. A truncated version has reached a real build once already.
+        for script, variable in [("platforms/ios/scripts/package_ios_archive.sh", "version"),
+                                 ("platforms/ios/scripts/package_ios_testflight.sh", "version"),
+                                 ("platforms/macos/scripts/package_release.sh", "version"),
+                                 ("platforms/macos/scripts/generate-sparkle-appcast.sh", "version")]:
+            body = (MACOS_ROOT.parents[1] / script).read_text()
+            self.assertIn("version=${tag_name#macos-}", body, script)
+            self.assertIn("version=${version#ios-}", body, script)
+            for tag, expected in [("macos-v0.48.6-build.2.23.1", "0.48.6"),
+                                  ("ios-v0.48.6-build.2.23.1", "0.48.6"),
+                                  ("v0.48.6-build.2.23.1", "0.48.6")]:
+                result = subprocess.run(
+                    ["bash", "-c", f'tag_name={tag}\n' + "\n".join(
+                        line for line in body.splitlines()
+                        if line.startswith(("version=${tag_name#", "version=${version#"))
+                    ) + f'\nversion=${{version%%-build.*}}\nprintf %s "${variable}"'],
+                    capture_output=True, text=True)
+                self.assertEqual(result.stdout, expected, f"{script} {tag}")
+
+    def test_a_promoted_release_still_refuses_a_platform_prefix(self):
+        # Promotions feed Sparkle and release-please, which key on the bare vX.Y.Z name.
+        body = (MACOS_ROOT / "scripts/create-promoted-release.sh").read_text()
+        self.assertIn(r"^v[0-9]+\.[0-9]+\.[0-9]+$", body)
+        self.assertNotIn("macos-", body)
+
     def test_invalid_build_is_rejected(self):
         for tag in ["v0.48.6-build.1.100.1", "v0.48.6-build.x", "v0.48.6-build.0.1.1"]:
             result, output = self.run_step("Allocate build number", REQUESTED_TAG=tag)

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -169,6 +169,24 @@ class BuildNumberTests(unittest.TestCase):
                     capture_output=True, text=True)
                 self.assertEqual(result.stdout, expected, f"{script} {tag}")
 
+    def test_artifact_names_carry_the_platform_once(self):
+        # Every artifact name already ends in a platform segment, so building it from the prefixed
+        # tag produced MetasequoiaIME-macos-v0.48.6-...-macos-universal.pkg. Worse, the packaging
+        # and publishing sides derive the name separately: fixing one and not the other would have
+        # the upload look for a file that packaging no longer writes.
+        root = MACOS_ROOT.parents[1]
+        for script in ["platforms/macos/scripts/package_release.sh",
+                       "platforms/macos/scripts/publish-release.sh",
+                       "platforms/macos/scripts/generate-sparkle-appcast.sh",
+                       "platforms/ios/scripts/package_ios_archive.sh",
+                       "platforms/ios/scripts/package_ios_testflight.sh"]:
+            body = (root / script).read_text()
+            self.assertNotIn("MetasequoiaIME-$TAG_NAME", body, script)
+            self.assertNotIn("MetasequoiaIME-$tag_name", body, script)
+            self.assertIn("MetasequoiaIME-$asset_tag", body, script)
+        workflow = (root / ".github/workflows/release.yml").read_text()
+        self.assertNotIn("MetasequoiaIME-$TAG_NAME", workflow)
+
     def test_a_promoted_release_still_refuses_a_platform_prefix(self):
         # Promotions feed Sparkle and release-please, which key on the bare vX.Y.Z name.
         body = (MACOS_ROOT / "scripts/create-promoted-release.sh").read_text()


### PR DESCRIPTION
自从 #393 让发布按改动路径选择平台之后，一次构建可能只覆盖一个平台，但所有构建仍然都叫 `v<version>-build.<n>`。想找 macOS 构建的人只能逐个点开看里面有没有 macOS 产物。

## 命名

| tag | 含义 |
| --- | --- |
| `macos-v0.48.6-build.60` | 仅 macOS |
| `ios-v0.48.6-build.61` | 仅 iOS |
| `v0.48.6-build.62` | 两个平台都有 |
| `v0.48.6` | 正式版（无 `-build.` 后缀） |

双平台保留无前缀的名字，读作"完整发布"很自然；正式版没有 `-build.` 后缀，两者不会混。

## 正式版 tag 不动

查过下游：Sparkle 客户端拉的是 `releases/latest/download/appcast.xml`，而 `releases/latest` **不会选中预发布**（实测当前指向 `v0.46.0`，每日 build 全是 Pre-release）。release-please 也按 `include-v-in-tag: true` / `include-component-in-tag: false` 管理正式版 tag。

所以两者都不该见到前缀。`create-promoted-release.sh` 的严格正则**保持不变**，正好挡住误用，并有测试钉住这一点。

## 一个必须处理的陷阱

前缀在 `v` 左边，所以七处 `${tag_name#v}` 会剥不掉它，得出 `macos-v0.48.6` 并把它当版本号发出去。

这类问题在这个仓里发生过——之前有一次版本被截断成 `0.48` 进了真实构建。所以：

- 每个脚本先剥平台前缀再剥 `v`
- 测试**实际执行各脚本自己的推导语句**，而不是断言源码文本
- 已验证这条测试有效：故意删掉其中一行 `version=${version#ios-}`，测试立即变红

## 验证

`ReleaseAutomationTests`（54 项）、`ReleaseConfigurationTests`、`ProjectConfigurationTests` 全过，`actionlint` 通过。
