### PR TITLE
chore(engine): advance the gitlink and adopt the autocorrect type mask

### DIFF
--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -26,6 +26,7 @@
 #include "CandidateSelectionState.h"
 #include "InputControllerKeyRouting.h"
 #include <metasequoia/session.h>
+#include "quanpin/quanpin_utils.h"
 #include "../../../vendor/MetasequoiaImeEngine/contracts/punctuation/policy.h"
 
 #import <Carbon/Carbon.h>
@@ -37,6 +38,17 @@
 namespace
 {
 constexpr NSTimeInterval kDictionaryRetryDelay = 2.0;
+
+// The Engine split its single autocorrect flag into a per-type mask. The one preference this app
+// exposes is still a checkbox, and the flag it replaced corrected transpositions and neighbour
+// substitutions together, so an enabled checkbox means every type the Engine offers. Leaving a type
+// out here would silently narrow what an existing user already had switched on.
+constexpr unsigned kAllQuanpinAutocorrectTypes = quanpin::kAutocorrectTransposition | quanpin::kAutocorrectNeighbor;
+
+constexpr unsigned QuanpinAutocorrectTypesFor(bool enabled)
+{
+    return enabled ? kAllQuanpinAutocorrectTypes : 0u;
+}
 
 struct SessionPreferences
 {
@@ -102,7 +114,7 @@ bool SessionMatchesPreferences(const metasequoia::SessionOptions &options, const
     const bool wubiMixedPinyinMatches =
         preferences.scheme != SchemeType::Wubi || options.wubi.mixed_pinyin == preferences.wubiMixedPinyinEnabled;
     return options.scheme == preferences.scheme && shuangpinMatches &&
-           options.autocorrect == preferences.autocorrectEnabled && helpcodeMatches &&
+           options.autocorrect_types == QuanpinAutocorrectTypesFor(preferences.autocorrectEnabled) && helpcodeMatches &&
            options.chinese_punctuation == preferences.chinesePunctuationEnabled &&
            options.learning == preferences.candidateLearningEnabled && wubiMixedPinyinMatches &&
            options.frequency.mode == preferences.frequency.mode &&
@@ -292,7 +304,7 @@ static NSHashTable *LiveDictionaryControllers()
     options.paths = paths;
     options.scheme = preferences.scheme;
     options.shuangpin_profile = GetShuangpinProfile(preferences.shuangpinSchema);
-    options.autocorrect = preferences.autocorrectEnabled;
+    options.autocorrect_types = QuanpinAutocorrectTypesFor(preferences.autocorrectEnabled);
     options.helpcode = preferences.helpcodeEnabled;
     options.helpcode_schema = preferences.helpcodeSchema;
     options.chinese_punctuation = preferences.chinesePunctuationEnabled;

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -312,6 +312,23 @@ class ReleaseConfigurationTests(unittest.TestCase):
         )
         self.assertGreater(len(engine_characters), 10, "the Engine punctuation contract was not parsed")
 
+    def test_every_quanpin_autocorrect_type_reaches_both_apple_products(self):
+        header = (PROJECT_ROOT / "vendor/MetasequoiaImeEngine/quanpin/quanpin_utils.h").read_text()
+        engine_types = set(re.findall(r"inline constexpr unsigned (kAutocorrect\w+)", header))
+        self.assertGreaterEqual(len(engine_types), 2, "the Engine autocorrect mask was not parsed")
+
+        # The Engine replaced one autocorrect flag with a per-type mask whose default is 0. Both
+        # products decide that mask from their own preference, in two places that cannot see each
+        # other, and a type added upstream would be silently dropped by whichever one forgot it --
+        # switching a correction off for users who never changed a setting. Neither site may name a
+        # subset of what the pinned Engine offers.
+        controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
+        bridge = (PROJECT_ROOT / "shared/apple-bridge/InputSessionAdapter.cpp").read_text()
+        for name, source in (("macOS controller", controller), ("Apple bridge", bridge)):
+            named = set(re.findall(r"quanpin::(kAutocorrect\w+)", source))
+            self.assertEqual(named, engine_types, f"{name} does not cover every autocorrect type")
+            self.assertNotIn("options.autocorrect ", source, name)
+
     def test_release_automation_bumps_tags_and_uploads_installable_assets(self):
         config = json.loads((PROJECT_ROOT / "release-please-config.json").read_text())
         package = config["packages"]["."]

--- a/scripts/product_lock_shared.py
+++ b/scripts/product_lock_shared.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import tempfile
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path, PurePosixPath
@@ -78,14 +79,22 @@ def published_checksums(path: Path) -> dict[str, str]:
     return checksums
 
 
-def download_with_retries(url: str, target: Path, *, attempts: int = 3, timeout: int = 120) -> None:
-    """Download one asset atomically, retrying transient URL and filesystem failures."""
-    if attempts < 1 or timeout <= 0:
-        raise ValueError("Download attempts and timeout must be positive")
+def download_with_retries(url: str, target: Path, *, attempts: int = 3, timeout: int = 120,
+                          backoff: float = 5.0, sleep=time.sleep) -> None:
+    """Download one asset atomically, retrying transient URL and filesystem failures.
+
+    Attempts are spaced apart. Back to back they land inside the same outage: a release host that
+    is briefly unreachable answers all three the same way, and the job fails having waited only for
+    its own timeouts. Doubling the gap steps outside a short one instead.
+    """
+    if attempts < 1 or timeout <= 0 or backoff < 0:
+        raise ValueError("Download attempts and timeout must be positive, and backoff non-negative")
     target = Path(target)
     target.parent.mkdir(parents=True, exist_ok=True)
     last_error: Exception | None = None
-    for _ in range(attempts):
+    for attempt in range(attempts):
+        if attempt and backoff:
+            sleep(backoff * (2 ** (attempt - 1)))
         temporary_name: str | None = None
         try:
             with urllib.request.urlopen(url, timeout=timeout) as response:

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -1,6 +1,7 @@
 #include "InputSessionAdapter.h"
 
 #include <metasequoia/session.h>
+#include "quanpin/quanpin_utils.h"
 
 #include <utility>
 
@@ -24,6 +25,11 @@ class InputSessionAdapter::Impl
         session_options.paths = paths;
         session_options.scheme = scheme;
         session_options.shuangpin_profile = GetShuangpinProfile(profile);
+        // This used to ride on SessionOptions::autocorrect, which defaulted to true. The Engine
+        // replaced it with a per-type mask that defaults to 0, so leaving it unset would quietly
+        // switch quanpin autocorrection off for every iOS user who has it today. State the types
+        // the old flag covered instead.
+        session_options.autocorrect_types = quanpin::kAutocorrectTransposition | quanpin::kAutocorrectNeighbor;
         session_options.learning = learning;
         session_options.fuzzy_pinyin.rules = fuzzy;
         session_options.frequency = learning ? frequency : FrequencyAdjustmentOptions{};


### PR DESCRIPTION
## What this bumps

`vendor/MetasequoiaImeEngine` moves from `f3d37d6` to `3b2d52b` — nine commits:

- Engine 0.9.0 and 0.10.0 releases
- metasequoiaime/MSIME-Engine#91, the quanpin autocorrection refactor
- metasequoiaime/MSIME-Engine#94, the product-lock download backoff

## The download backoff comes back on its own

`scripts/product_lock_shared.py` is vendored byte-for-byte from `contracts/product_lock.py`, so the spaced download attempts arrive with the gitlink. That is the change #400 originally carried and had to drop when `Validate the product lock` caught the drift. Nothing here re-edits the helper — it is a copy of the new contract, and `check-product-lock-contract.py` passes.

## The breaking change, and one silent regression it would have caused

`SessionOptions::autocorrect` (a `bool`, defaulting to `true`) is replaced by `autocorrect_types`, a `quanpin::kAutocorrect*` mask defaulting to `0`. The two Apple products consumed it differently, and only one of them failed loudly:

**macOS** set and compared the old flag, so it stopped compiling. Its single checkbox now maps to every type the Engine defines. The flag it replaced corrected transpositions and neighbour substitutions together — verified against the old `quanpin_utils.cpp` — so anything narrower would silently switch off part of what a user already had enabled.

**The Apple bridge** (the iOS session) never set the flag and relied on the default. That one compiles fine and ships: quanpin autocorrection off for every iOS user, delivered by a bump whose description mentions nothing of the sort. It now states the types explicitly.

A test pins both call sites against the pinned Engine's `kAutocorrect*` constants, so a type added upstream cannot be quietly dropped by whichever site forgets it.

## A decision worth a second opinion

The Engine deliberately changed its own default to "off" — `0 keeps the user's spelling untouched, which is the default for a fresh install`. This PR does **not** follow that for Apple; it preserves what macOS and iOS users have today. Adopting the Engine's new default is a product call, and a gitlink bump is the wrong place to make it silently. Say the word and I will flip it.

## Verification

Run locally against the bumped Engine:

- `cmake` configure, full build, `ctest` 51/51
- 79 macOS Python tests, including the new autocorrect-coverage test
- `check-product-lock-contract.py`, `check-dictionary-contract.py`, `ProductLockTests.py` 15/15
- `scripts/format.sh --check`
