### PR TITLE
feat: show the code left to type on wubi candidates

### DIFF
--- a/platforms/ios/App/Sources/OnboardingView.swift
+++ b/platforms/ios/App/Sources/OnboardingView.swift
@@ -50,6 +50,8 @@ struct InputSettingsView: View {
   private var hapticStrength = KeyboardHapticStrength.medium.rawValue
   @AppStorage(WubiMixedPinyinPreference.enabledKey, store: WubiMixedPinyinPreference.defaults)
   private var wubiMixedPinyin = false
+  @AppStorage(WubiCodeHintPreference.enabledKey, store: WubiCodeHintPreference.defaults)
+  private var wubiCodeHint = true
   @State private var previewFeedback: UIImpactFeedbackGenerator?
   @State private var inputScheme = InputSchemePreference.scheme
   @State private var enabledSchemes = InputSchemePreference.enabledSchemes
@@ -116,6 +118,10 @@ struct InputSettingsView: View {
             Toggle("编码打不出时用拼音候选", isOn: $wubiMixedPinyin)
               .accessibilityIdentifier("wubiMixedPinyin")
             Text("五笔词库答不上当前编码时，用同一串字母查全拼。词库答得上的编码不受影响。")
+              .font(.footnote).foregroundStyle(.secondary)
+            Toggle("候选显示剩余编码", isOn: $wubiCodeHint)
+              .accessibilityIdentifier("wubiCodeHint")
+            Text("在候选后面标出还要再打哪几个字母才能单独打出它。已经打完整码的候选不标。")
               .font(.footnote).foregroundStyle(.secondary)
           }
         }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardCandidatePanelView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardCandidatePanelView.swift
@@ -7,15 +7,19 @@ import UIKit
 // the word not being in the dictionary. This shows the whole list at once instead.
 final class KeyboardCandidatePanelView: UIView {
   private let candidates: [String]
+  // The keys still to press for each candidate, parallel to candidates and empty where none applies.
+  private let hints: [String]
   private let display: (String) -> String
   private let onSelect: (Int) -> Void
   private let rows = UIStackView()
   private let scrollView = UIScrollView()
   private var laidOutWidth: CGFloat = 0
 
-  init(candidates: [String], preedit: String, display: @escaping (String) -> String,
+  init(candidates: [String], hints: [String] = [], preedit: String,
+       display: @escaping (String) -> String,
        onSelect: @escaping (Int) -> Void, onClose: @escaping () -> Void) {
     self.candidates = candidates
+    self.hints = hints
     self.display = display
     self.onSelect = onSelect
     super.init(frame: .zero)
@@ -98,7 +102,9 @@ final class KeyboardCandidatePanelView: UIView {
     var row = makeRow(spacing: spacing)
     var used: CGFloat = 0
     for (offset, candidate) in candidates.enumerated() {
-      let chip = makeChip(candidate: candidate, number: offset + 1)
+      let chip = makeChip(
+        candidate: candidate, hint: hints.indices.contains(offset) ? hints[offset] : "",
+        number: offset + 1)
       let width = chip.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
       if used > 0, used + spacing + width > available {
         rows.addArrangedSubview(row)
@@ -119,10 +125,20 @@ final class KeyboardCandidatePanelView: UIView {
     return row
   }
 
-  private func makeChip(candidate: String, number: Int) -> UIButton {
+  private func makeChip(candidate: String, hint: String, number: Int) -> UIButton {
     let text = display(candidate)
     var configuration = UIButton.Configuration.plain()
     configuration.title = text
+    if !hint.isEmpty {
+      configuration.attributedTitle = AttributedString(
+        text, attributes: AttributeContainer([.font: UIFont.preferredFont(forTextStyle: .body)]))
+        + AttributedString(
+          " " + hint,
+          attributes: AttributeContainer([
+            .font: UIFont.preferredFont(forTextStyle: .caption1),
+            .foregroundColor: KeyboardSkinPreference.selected.keyForeground.withAlphaComponent(0.55),
+          ]))
+    }
     configuration.baseForegroundColor = KeyboardSkinPreference.selected.keyForeground
     configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 11, bottom: 6, trailing: 11)
     configuration.background.backgroundColor = KeyboardSkinPreference.selected.keyBackground
@@ -135,7 +151,8 @@ final class KeyboardCandidatePanelView: UIView {
       configuration: configuration,
       primaryAction: UIAction { [weak self] _ in self?.onSelect(index) })
     chip.accessibilityIdentifier = "panelCandidate-\(number)"
-    chip.accessibilityLabel = "候选词 \(number)：\(text)"
+    chip.accessibilityLabel =
+      hint.isEmpty ? "候选词 \(number)：\(text)" : "候选词 \(number)：\(text)，还需输入 \(hint)"
     return chip
   }
 }

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -97,6 +97,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var visiblePreedit = ""
   private var candidateRevision: UInt64 = 0
   private var visibleCandidates: [String] = []
+  // The code each visible candidate was found by, parallel to visibleCandidates.
+  private var visibleCandidateCodes: [String] = []
   private var visibleDiagnostic: String?
   private var diagnosticDismissTimer: Timer?
   private var shuangpinKeyHints: [String: String] = [:]
@@ -1482,7 +1484,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     closeKeyboardPicker()
     playInputClick()
     let panel = KeyboardCandidatePanelView(
-      candidates: visibleCandidates, preedit: visiblePreedit,
+      candidates: visibleCandidates,
+      hints: visibleCandidates.indices.map { wubiCodeHint(at: $0) }, preedit: visiblePreedit,
       display: { [weak self] in self?.chineseOutput($0) ?? $0 },
       onSelect: { [weak self] index in
         guard let self else { return }
@@ -1885,7 +1888,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     hasComposition = !snapshot.preedit.isEmpty
     if !hasComposition { applyLearningPreferences() }
     showDiagnostic(snapshot.diagnosticText)
-    updateCandidateStrip(preedit: snapshot.preedit, candidates: snapshot.candidates)
+    updateCandidateStrip(
+      preedit: snapshot.preedit, candidates: snapshot.candidates,
+      candidateCodes: snapshot.candidateCodes)
     updateSpellingStrip()
   }
 
@@ -1910,9 +1915,10 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     diagnosticDismissTimer = timer
   }
 
-  private func updateCandidateStrip(preedit: String, candidates: [String]) {
+  private func updateCandidateStrip(preedit: String, candidates: [String], candidateCodes: [String] = []) {
     visiblePreedit = preedit
     visibleCandidates = candidates
+    visibleCandidateCodes = candidateCodes
     // Any new candidate list is a different composition or a different set of matches, so the page
     // it was showing no longer describes anything.
     // A horizontal offset belongs to the previous matches, just like the page index.
@@ -1936,7 +1942,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     for (offset, candidate) in page.enumerated() {
       candidateStack.addArrangedSubview(
         makeCandidateButton(
-          candidate: candidate, number: offset + 1, index: offset))
+          candidate: candidate, hint: wubiCodeHint(at: offset), number: offset + 1, index: offset))
     }
     updateExpandControl()
 
@@ -1949,10 +1955,29 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
 
   // A touch keyboard has no number row to answer with, so the ordinal is spoken rather than drawn;
   // the index is the engine position the chip selects. The expand panel already showed bare text.
-  private func makeCandidateButton(candidate: String, number: Int, index: Int) -> UIButton {
+  // The keys that still single this candidate out, for a wubi composition that asked for them. A
+  // local mode synthesises its candidates and has no code behind them, and a candidate the
+  // mixed-pinyin fallback answered is keyed by spelling, which the prefix check drops on its own.
+  private func wubiCodeHint(at index: Int) -> String {
+    guard inputScheme == .wubi, !session.isInLocalMode, WubiCodeHintPreference.isEnabled,
+          visibleCandidateCodes.indices.contains(index) else { return "" }
+    return WubiCodeHintPreference.hint(code: visibleCandidateCodes[index], typed: visiblePreedit)
+  }
+
+  private func makeCandidateButton(candidate: String, hint: String, number: Int, index: Int) -> UIButton {
     let display = chineseOutput(candidate)
     var configuration = UIButton.Configuration.plain()
     configuration.title = display
+    if !hint.isEmpty {
+      configuration.attributedTitle = AttributedString(
+        display, attributes: AttributeContainer([.font: UIFont.preferredFont(forTextStyle: .body)]))
+        + AttributedString(
+          " " + hint,
+          attributes: AttributeContainer([
+            .font: UIFont.preferredFont(forTextStyle: .caption1),
+            .foregroundColor: KeyboardSkinPreference.selected.keyForeground.withAlphaComponent(0.55),
+          ]))
+    }
     configuration.baseForegroundColor = KeyboardSkinPreference.selected.keyForeground
     configuration.contentInsets = NSDirectionalEdgeInsets(
       top: 4, leading: 9, bottom: 4, trailing: 9)
@@ -1968,7 +1993,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
         self.playInputClick()
         self.render(self.session.selectCandidate(at: UInt(index)))
       })
-    button.accessibilityLabel = "候选词 \(number)：\(display)"
+    button.accessibilityLabel =
+      hint.isEmpty ? "候选词 \(number)：\(display)" : "候选词 \(number)：\(display)，还需输入 \(hint)"
     button.accessibilityIdentifier = "candidate-\(number)"
     if isChineseMode && !inputScheme.isJapanese && !session.isInLocalMode {
       let revision = candidateRevision

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -926,6 +926,57 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
+  // An unfinished wubi code answers with the codes it can still become, so the strip has to say
+  // which keys single each candidate out. The code rides along the snapshot; the strip draws its
+  // tail past what has been typed.
+  func testWubiCandidatesCarryAndShowTheCodeLeftToType() throws {
+    let bridge = MetasequoiaInputSessionBridge()
+    _ = bridge.switchToWubi()
+    _ = bridge.handleCharacter("w")
+    let snapshot = bridge.handleCharacter("q")
+    XCTAssertEqual(snapshot.candidateCodes.count, snapshot.candidates.count)
+    let leading = try XCTUnwrap(snapshot.candidateCodes.first)
+    XCTAssertEqual(leading, "wq", "The code that was typed in full did not lead the list.")
+    XCTAssertTrue(
+      snapshot.candidateCodes.contains { $0.count > 2 && $0.hasPrefix("wq") },
+      "The snapshot carried no candidate reached by a longer code.")
+    _ = bridge.cancel()
+
+    XCTAssertEqual(WubiCodeHintPreference.hint(code: "wqb", typed: "wq"), "b")
+    XCTAssertEqual(WubiCodeHintPreference.hint(code: "wq", typed: "wq"), "")
+    XCTAssertEqual(WubiCodeHintPreference.hint(code: "wqb", typed: ""), "")
+    // What the mixed-pinyin fallback produces: keyed by spelling, and those letters lead nowhere in
+    // wubi, so the candidate is left unannotated.
+    XCTAssertEqual(WubiCodeHintPreference.hint(code: "ni'hao", typed: "nihao"), "")
+
+    let previous = InputSchemePreference.scheme
+    let previousHint = WubiCodeHintPreference.isEnabled
+    defer {
+      InputSchemePreference.scheme = previous
+      WubiCodeHintPreference.isEnabled = previousHint
+    }
+    XCTAssertTrue(previousHint, "The wubi code hint did not ship on.")
+    InputSchemePreference.scheme = .wubi
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    func type(_ code: String) throws {
+      for character in code {
+        let key = try XCTUnwrap(descendants(controller.view).first {
+          $0.accessibilityLabel == "字母 \(String(character).uppercased())"
+        } as? UIButton)
+        key.sendActions(for: .primaryActionTriggered)
+      }
+    }
+    try type("wq")
+    let annotated = try descendants(controller.view).compactMap { $0 as? UIButton }.filter {
+      ($0.accessibilityIdentifier ?? "").hasPrefix("candidate-")
+    }
+    XCTAssertFalse(annotated.isEmpty, "Typing a wubi code produced no candidates.")
+    XCTAssertTrue(
+      annotated.contains { ($0.accessibilityLabel ?? "").contains("还需输入") },
+      "No candidate on the strip said which keys were left to press.")
+  }
+
   func testAdditionalEngineSchemesAndLocalProviders() throws {
     let bridge = MetasequoiaInputSessionBridge()
     _ = bridge.switchToWubi()

--- a/platforms/ios/SharedUI/WubiCodeHintPreference.swift
+++ b/platforms/ios/SharedUI/WubiCodeHintPreference.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+// Marks each wubi candidate with the keys that still single it out. An unfinished code answers with
+// the codes it can still become, so without this the strip is a row of words with nothing to choose
+// between them. On unless it was turned off, the way a wubi table is normally read. Lives in the app
+// group because the keyboard extension reads what the host app writes.
+@MainActor
+enum WubiCodeHintPreference {
+  static let enabledKey = "wubi.codeHint"
+  static var defaults: UserDefaults {
+    UserDefaults(suiteName: InputSchemePreference.appGroupIdentifier) ?? .standard
+  }
+
+  static var isEnabled: Bool {
+    get { defaults.object(forKey: enabledKey) as? Bool ?? true }
+    set { defaults.set(newValue, forKey: enabledKey) }
+  }
+
+  // The part of a candidate's own code that has not been typed yet. A candidate reached by the code
+  // in full has nothing left, and a candidate whose code does not extend what was typed -- what the
+  // mixed-pinyin fallback answers with, keyed by spelling -- would send the user nowhere, so both
+  // come back empty.
+  static func hint(code: String, typed: String) -> String {
+    guard !typed.isEmpty, code.count > typed.count, code.hasPrefix(typed) else { return "" }
+    return String(code.dropFirst(typed.count))
+  }
+}

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -214,6 +214,40 @@ void TestRuntimeGenerationUpgrade(const std::filesystem::path &root)
     }
 }
 
+// A wubi candidate is reached by its own code, and an unfinished code answers with the codes it can
+// still become, so the frontend needs each candidate's code to say which keys single it out. The
+// words alone cannot carry that.
+void TestWubiCandidateCodes(const std::filesystem::path &root)
+{
+    std::filesystem::create_directories(root);
+    if (setenv("METASEQUOIA_IME_DATA_DIR", root.c_str(), 1) != 0)
+    {
+        throw std::runtime_error("Failed to set the wubi adapter test data directory.");
+    }
+    sqlite3 *database = nullptr;
+    Require(sqlite3_open((root / "msime.db").c_str(), &database) == SQLITE_OK, "Cannot create the wubi fixture.");
+    Require(sqlite3_exec(database,
+                         "CREATE TABLE wubi86(key TEXT,value TEXT,weight INTEGER);"
+                         "INSERT INTO wubi86 VALUES('wq','你',10),('wqb','爷',20),('wqbb','父子',30)",
+                         nullptr, nullptr, nullptr) == SQLITE_OK,
+            "Cannot populate the wubi fixture.");
+    sqlite3_close(database);
+
+    metasequoia::apple::InputSessionAdapter adapter;
+    adapter.switch_to_wubi();
+    adapter.handle_character('w');
+    const auto snapshot = adapter.handle_character('q');
+    Require(snapshot.candidate_codes.size() == snapshot.candidates.size(),
+            "A candidate came back without the code it was found by.");
+    Require(!snapshot.candidates.empty() && snapshot.candidates.front() == "你" &&
+                snapshot.candidate_codes.front() == "wq",
+            "The wubi snapshot did not carry the code of the candidate that answered the typed code.");
+    const auto longer = std::find(snapshot.candidates.begin(), snapshot.candidates.end(), "爷");
+    Require(longer != snapshot.candidates.end() &&
+                snapshot.candidate_codes.at(static_cast<std::size_t>(longer - snapshot.candidates.begin())) == "wqb",
+            "A candidate reached by a longer code did not carry that code.");
+}
+
 int RunTest()
 {
     const std::filesystem::path dataDirectory =
@@ -590,6 +624,7 @@ int RunTest()
     }
 
     TestRuntimeGenerationUpgrade(dataDirectory / "upgrade");
+    TestWubiCandidateCodes(dataDirectory / "wubi");
     user_dictionary::close_default_user_database();
     std::filesystem::remove_all(dataDirectory);
     return 0;

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -341,8 +341,11 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
 
         # Without a page offset the chip numbers and the engine's own numbering agree, so a digit
         # and the chip carrying it name the same candidate again.
-        self.assertIn("makeCandidateButton(candidate: String, number: Int, index: Int)", controller)
-        self.assertIn("candidate: candidate, number: offset + 1, index: offset))", controller)
+        self.assertIn(
+            "makeCandidateButton(candidate: String, hint: String, number: Int, index: Int)", controller)
+        self.assertIn(
+            "candidate: candidate, hint: wubiCodeHint(at: offset), number: offset + 1, index: offset))",
+            controller)
         self.assertIn("self.render(self.session.selectCandidate(at: UInt(index)))", controller)
 
         # The control is for reaching what the strip cannot show, so it appears exactly then.
@@ -533,14 +536,22 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
     def test_candidate_surface_exposes_native_chips_numbered_only_for_voiceover(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
-        self.assertIn("candidate: candidate, number: offset + 1, index: offset", controller)
+        self.assertIn(
+            "candidate: candidate, hint: wubiCodeHint(at: offset), number: offset + 1, index: offset",
+            controller)
         self.assertIn("configuration.background.cornerRadius", controller)
 
         # A touch keyboard has no number row for the ordinal to answer to, so it is spoken rather
         # than drawn: the chip shows the candidate alone and VoiceOver still hears the position.
         self.assertIn("configuration.title = display", controller)
         self.assertNotIn('configuration.title = "\\(number)', controller)
-        self.assertIn('button.accessibilityLabel = "候选词 \\(number)：\\(display)"', controller)
+        self.assertIn('"候选词 \\(number)：\\(display)"', controller)
+
+        # The one thing drawn beside a candidate is the wubi code still to type, and only where it
+        # leads somewhere: the wubi scheme, the setting on, and no local mode synthesising the list.
+        self.assertIn("，还需输入 \\(hint)", controller)
+        self.assertIn("guard inputScheme == .wubi, !session.isInLocalMode, WubiCodeHintPreference.isEnabled",
+                      controller)
 
     def test_apostrophe_reaches_the_engine_before_punctuation_conversion(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()

--- a/platforms/macos/src/CandidateDisplay.h
+++ b/platforms/macos/src/CandidateDisplay.h
@@ -27,9 +27,36 @@ inline bool ScriptConversionAppliesToLocalMode(LocalInputMode mode)
     return mode != LocalInputMode::Unicode;
 }
 
-inline std::string CandidateDisplayText(const WordItem &candidate, SchemeType scheme, bool helpcodeEnabled,
-                                        const HelpcodeUtils::Keymap *keymap = nullptr)
+// What is still to be typed to reach this candidate on its own. A wubi candidate carries the code
+// it was found by, and an unfinished code answers with the codes it can still become, so the tail
+// of each candidate's code is the keystrokes that single it out. The candidate typed in full has no
+// tail and gets no hint, and a code that is not an extension of what was typed -- a word the pinyin
+// fallback answered with, a user entry keyed differently -- gets none either, since its letters
+// would not take the user there.
+inline std::string WubiCodeHint(const WordItem &candidate, const std::string &typedCode)
 {
+    if (typedCode.empty() || candidate.pinyin.size() <= typedCode.size() ||
+        candidate.pinyin.compare(0, typedCode.size(), typedCode) != 0)
+    {
+        return {};
+    }
+    return candidate.pinyin.substr(typedCode.size());
+}
+
+// typedCode is the wubi code already entered, and is left empty wherever a code hint does not
+// apply: any other scheme, the hint switched off, or a composition the pinyin fallback answered.
+inline std::string CandidateDisplayText(const WordItem &candidate, SchemeType scheme, bool helpcodeEnabled,
+                                        const HelpcodeUtils::Keymap *keymap = nullptr,
+                                        const std::string &typedCode = {})
+{
+    if (scheme == SchemeType::Wubi)
+    {
+        const auto hint = WubiCodeHint(candidate, typedCode);
+        // A space, not the bare append the helpcodes use: a wubi code is the same run of latin
+        // letters as the one in the preedit, and 爷b reads as one word rather than a word and the
+        // keys that finish it.
+        return hint.empty() ? candidate.word : candidate.word + " " + hint;
+    }
     if (!helpcodeEnabled || keymap == nullptr || (scheme != SchemeType::Quanpin && scheme != SchemeType::Shuangpin))
     {
         return candidate.word;

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -209,6 +209,10 @@ static NSHashTable *LiveDictionaryControllers()
                                                          name:notificationName
                                                        object:nil];
         }
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(wubiCodeHintPreferenceDidChange:)
+                                                     name:@"MetasequoiaWubiCodeHintDidChangeNotification"
+                                                   object:nil];
     }
     return self;
 }
@@ -243,6 +247,17 @@ static NSHashTable *LiveDictionaryControllers()
     [self refreshFloatingToolbar];
     if ([notification.name isEqualToString:MetasequoiaTraditionalChineseOutputDidChangeNotification] && _serverActive &&
         _session != nullptr && !_sessionSnapshot.preedit.empty())
+    {
+        [self refreshCandidatePanelPreservingSelection];
+    }
+}
+
+// The hint is drawn from the snapshot already on screen, so a composition in progress can take the
+// new setting where a session option would have had to wait for the composition to end.
+- (void)wubiCodeHintPreferenceDidChange:(NSNotification *)notification
+{
+    (void)notification;
+    if (_serverActive && _session != nullptr && !_sessionSnapshot.preedit.empty())
     {
         [self refreshCandidatePanelPreservingSelection];
     }
@@ -862,11 +877,20 @@ static NSHashTable *LiveDictionaryControllers()
         [self traditionalChineseOutputActive] && metasequoia::mac::ScriptConversionAppliesToLocalMode(localMode);
     const bool annotateHelpcodes = (_sessionOptions.helpcode && SchemeUsesHelpcodes(_sessionSnapshot.scheme)) &&
                                    metasequoia::mac::HelpcodesAnnotateLocalMode(localMode);
+    // The preedit of a wubi composition is the code as typed, which is what each candidate's own
+    // code is measured against. A local input mode synthesises its candidates and the pinyin
+    // fallback answers with pinyin keys, and in neither case do the letters left over lead
+    // anywhere, so the hint is withheld by handing the display an empty code.
+    const bool annotateWubiCodes = _sessionSnapshot.scheme == SchemeType::Wubi &&
+                                   localMode == metasequoia::LocalInputMode::None &&
+                                   !_sessionSnapshot.answered_by_pinyin_fallback &&
+                                   [MetasequoiaPreferencesWindowController storedWubiCodeHintEnabled];
+    const std::string wubiTypedCode = annotateWubiCodes ? _sessionSnapshot.preedit : std::string{};
     NSUInteger candidateIndex = 0;
     for (const WordItem &candidate : _sessionSnapshot.candidates)
     {
         NSString *display = MetasequoiaStringFromUtf8(metasequoia::mac::CandidateDisplayText(
-            candidate, _sessionSnapshot.scheme, annotateHelpcodes, _activeHelpcodeKeymap.get()));
+            candidate, _sessionSnapshot.scheme, annotateHelpcodes, _activeHelpcodeKeymap.get(), wubiTypedCode));
         NSString *convertedDisplay = MetasequoiaChineseOutputString(display, traditionalOutput);
         [data addObject:MetasequoiaIndexedCandidateString(convertedDisplay, candidateIndex)];
         ++candidateIndex;

--- a/platforms/macos/src/PreferencesWindowController.h
+++ b/platforms/macos/src/PreferencesWindowController.h
@@ -61,6 +61,8 @@ bool MetasequoiaShouldShowPreferences(int argc, const char *argv[]);
 + (void)setWubiAutoCommitUniqueEnabled:(BOOL)enabled;
 + (BOOL)storedWubiMixedPinyinEnabled;
 + (void)setWubiMixedPinyinEnabled:(BOOL)enabled;
++ (BOOL)storedWubiCodeHintEnabled;
++ (void)setWubiCodeHintEnabled:(BOOL)enabled;
 + (BOOL)storedShuangpinKeymapEnabled;
 + (void)setShuangpinKeymapEnabled:(BOOL)enabled;
 + (BOOL)storedLocalInputModesEnabled;

--- a/platforms/macos/src/PreferencesWindowController.mm
+++ b/platforms/macos/src/PreferencesWindowController.mm
@@ -67,6 +67,8 @@ NSString *const kWubiAutoCommitUniquePreferenceKey = @"MetasequoiaImeWubiAutoCom
 // know, and the download side refuses a snapshot whose key count does not match, so
 // syncing this early would break settings sync entirely rather than just this option.
 NSString *const kWubiMixedPinyinPreferenceKey = @"MetasequoiaImeWubiMixedPinyin";
+// Absent from the cloud snapshot for the same reason as the key above.
+NSString *const kWubiCodeHintPreferenceKey = @"MetasequoiaImeWubiCodeHint";
 NSString *const kShuangpinKeymapPreferenceKey = @"MetasequoiaImeShuangpinKeymapEnabled";
 NSString *const kLocalInputModesPreferenceKey = @"MetasequoiaImeLocalInputModesEnabled";
 
@@ -254,6 +256,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     NSButton *_floatingToolbarButton;
     NSButton *_wubiAutoCommitButton;
     NSButton *_wubiMixedPinyinButton;
+    NSButton *_wubiCodeHintButton;
     NSButton *_resetLearningButton;
     NSTextField *_statusLabel;
     NSTextField *_versionLabel;
@@ -787,6 +790,21 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                                                         object:@(enabled)];
 }
 
+// On unless it was turned off: a wubi table is read by code, and a candidate list that shows the
+// keys still to press is what every wubi frontend puts in front of a typist.
++ (BOOL)storedWubiCodeHintEnabled
+{
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:kWubiCodeHintPreferenceKey];
+    return value == nil ? YES : [value boolValue];
+}
+
++ (void)setWubiCodeHintEnabled:(BOOL)enabled
+{
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kWubiCodeHintPreferenceKey];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MetasequoiaWubiCodeHintDidChangeNotification"
+                                                        object:@(enabled)];
+}
+
 + (BOOL)storedWubiAutoCommitUniqueEnabled
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:kWubiAutoCommitUniquePreferenceKey];
@@ -1016,10 +1034,19 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                                                   action:@selector(wubiMixedPinyinChanged:)];
     _wubiMixedPinyinButton.accessibilityLabel = @"编码打不出时用拼音候选";
     _wubiMixedPinyinButton.toolTip = @"五笔词库答不上当前编码时，用同一串字母查全拼。词库答得上的编码不受影响。";
+    _wubiCodeHintButton = [NSButton checkboxWithTitle:@"候选显示剩余编码"
+                                               target:self
+                                               action:@selector(wubiCodeHintChanged:)];
+    _wubiCodeHintButton.accessibilityLabel = @"候选显示剩余编码";
+    _wubiCodeHintButton.toolTip = @"在候选后面标出还要再打哪几个字母才能单独打出它。已经打完整码的候选不标。";
     NSTextField *wubiSchemeLabel = [NSTextField labelWithString:@"86 五笔"];
     wubiSchemeLabel.textColor = [NSColor secondaryLabelColor];
     NSBox *wubiOptionsCard = CardWithViews(
-        @[ PreferenceRow(@"编码方案", wubiSchemeLabel), _wubiAutoCommitButton, _wubiMixedPinyinButton ], 8.0);
+        @[
+            PreferenceRow(@"编码方案", wubiSchemeLabel), _wubiAutoCommitButton, _wubiMixedPinyinButton,
+            _wubiCodeHintButton
+        ],
+        8.0);
     wubiOptionsCard.accessibilityLabel = @"五笔选项卡片";
     NSView *wubiPage = PreferencesPage(@"五笔设置", @"调整 86 五笔的输入与上屏行为。",
                                        @[ backToKeyboardButton, SectionLabel(@"输入行为"), wubiOptionsCard ]);
@@ -1475,6 +1502,9 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     _wubiAutoCommitButton.state = [MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled]
                                       ? NSControlStateValueOn
                                       : NSControlStateValueOff;
+    _wubiCodeHintButton.state = [MetasequoiaPreferencesWindowController storedWubiCodeHintEnabled]
+                                    ? NSControlStateValueOn
+                                    : NSControlStateValueOff;
 }
 
 - (void)refreshDictionaryStatus
@@ -1702,6 +1732,12 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     [MetasequoiaPreferencesWindowController setWubiMixedPinyinEnabled:button.state == NSControlStateValueOn];
 }
 
+- (void)wubiCodeHintChanged:(id)sender
+{
+    NSButton *button = sender;
+    [MetasequoiaPreferencesWindowController setWubiCodeHintEnabled:button.state == NSControlStateValueOn];
+}
+
 - (void)wubiAutoCommitUniqueChanged:(id)sender
 {
     NSButton *button = (NSButton *)sender;
@@ -1783,6 +1819,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
              kInputModeShortcutPreferenceKey,
              kWubiAutoCommitUniquePreferenceKey,
              kWubiMixedPinyinPreferenceKey,
+             kWubiCodeHintPreferenceKey,
              kShuangpinKeymapPreferenceKey,
              kLocalInputModesPreferenceKey,
              kFullWidthInputPreferenceKey,
@@ -1828,6 +1865,8 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                                  object:@([MetasequoiaPreferencesWindowController storedWubiMixedPinyinEnabled])];
     [notifications postNotificationName:@"MetasequoiaWubiAutoCommitUniqueDidChangeNotification"
                                  object:@([MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled])];
+    [notifications postNotificationName:@"MetasequoiaWubiCodeHintDidChangeNotification"
+                                 object:@([MetasequoiaPreferencesWindowController storedWubiCodeHintEnabled])];
     [notifications postNotificationName:@"MetasequoiaShuangpinKeymapDidChangeNotification"
                                  object:@([MetasequoiaPreferencesWindowController storedShuangpinKeymapEnabled])];
     [notifications postNotificationName:@"MetasequoiaFullWidthInputDidChangeNotification"

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -176,6 +176,25 @@ int main()
                 CandidateDisplayText(WordItem{"abcd", "你", 1}, SchemeType::Wubi, true) == "你",
             "Candidate display exposed auxiliary codes when the feature or scheme did not allow them.");
 
+    // A wubi candidate is annotated with the keys that still single it out, so the hint is the tail
+    // of its own code. Helpcodes have no say in it: they annotate a word with how to reach it in
+    // pinyin, which is a different question than which key finishes the code in hand.
+    using metasequoia::mac::WubiCodeHint;
+    require(CandidateDisplayText(WordItem{"wqb", "爷", 1}, SchemeType::Wubi, false, nullptr, "wq") == "爷 b" &&
+                CandidateDisplayText(WordItem{"wqbb", "父子", 1}, SchemeType::Wubi, true, lantian.get(), "wq") ==
+                    "父子 bb",
+            "A wubi candidate did not show the code that is left to type.");
+    require(CandidateDisplayText(WordItem{"wq", "你", 1}, SchemeType::Wubi, false, nullptr, "wq") == "你",
+            "A wubi candidate typed in full was annotated with an empty hint.");
+    require(CandidateDisplayText(WordItem{"wqb", "爷", 1}, SchemeType::Wubi, false, nullptr, "") == "爷",
+            "A wubi candidate was annotated with the hint switched off.");
+    // The pinyin fallback keys its candidates by spelling, and those letters do not lead to the word
+    // in wubi. The controller withholds the typed code there; this is the second line of defence.
+    require(WubiCodeHint(WordItem{"ni'hao", "你好", 1}, "nihao").empty(),
+            "A candidate keyed outside the typed code was annotated as though it extended it.");
+    require(WubiCodeHint(WordItem{"wqb", "爷", 1}, "wq") == "b" && WubiCodeHint(WordItem{"wqb", "爷", 1}, "").empty(),
+            "The wubi hint did not report the keys that are left to press.");
+
     const auto dictionarySuffix = std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     const std::filesystem::path dictionaryDirectory =
         std::filesystem::temp_directory_path() / ("metasequoia-wubi-routing-" + dictionarySuffix);

--- a/platforms/macos/tests/PreferencesWindowTests.mm
+++ b/platforms/macos/tests/PreferencesWindowTests.mm
@@ -245,6 +245,12 @@ int main()
                 "Mixed wubi input was on before anyone asked for it.");
         require(![MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled],
                 "The disabled Wubi auto-commit preference was not stored.");
+        require([MetasequoiaPreferencesWindowController storedWubiCodeHintEnabled],
+                "The Wubi code hint was off without anyone turning it off.");
+        [MetasequoiaPreferencesWindowController setWubiCodeHintEnabled:NO];
+        require(![MetasequoiaPreferencesWindowController storedWubiCodeHintEnabled],
+                "The disabled Wubi code-hint preference was not stored.");
+        [MetasequoiaPreferencesWindowController setWubiCodeHintEnabled:YES];
 
         PreferencesFakeUpdateDriver *updateDriver = [[PreferencesFakeUpdateDriver alloc] init];
         updateDriver.canCheckForUpdates = YES;
@@ -449,6 +455,19 @@ int main()
                     [MetasequoiaPreferencesWindowController storedWubiMixedPinyinEnabled],
                 "The Wubi mixed-pinyin option did not persist its enabled state.");
         [MetasequoiaPreferencesWindowController setWubiMixedPinyinEnabled:NO];
+
+        // The code hint is the one wubi option that ships on, so the box opens checked and the
+        // click being tested is the one that turns it off.
+        NSView *wubiCodeHintView = FindViewWithAccessibilityLabel(controller.window.contentView, @"候选显示剩余编码");
+        require([wubiCodeHintView isKindOfClass:[NSButton class]] &&
+                    ((NSButton *)wubiCodeHintView).state == NSControlStateValueOn,
+                "The Wubi detail page did not reflect the stored code-hint preference.");
+        NSButton *wubiCodeHintButton = (NSButton *)wubiCodeHintView;
+        wubiCodeHintButton.state = NSControlStateValueOff;
+        require([NSApp sendAction:wubiCodeHintButton.action to:wubiCodeHintButton.target from:wubiCodeHintButton] &&
+                    ![MetasequoiaPreferencesWindowController storedWubiCodeHintEnabled],
+                "The Wubi code-hint option did not persist its disabled state.");
+        [MetasequoiaPreferencesWindowController setWubiCodeHintEnabled:YES];
 
         NSButton *backToKeyboardButton = FindButtonWithTitle(controller.window.contentView, @"返回键盘输入");
         [backToKeyboardButton performClick:nil];
@@ -876,6 +895,7 @@ int main()
         [MetasequoiaPreferencesWindowController setEnglishInputMode:YES];
         [MetasequoiaPreferencesWindowController setWubiAutoCommitUniqueEnabled:YES];
         [MetasequoiaPreferencesWindowController setWubiMixedPinyinEnabled:YES];
+        [MetasequoiaPreferencesWindowController setWubiCodeHintEnabled:NO];
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"MetasequoiaImeShuangpinKeymapEnabled"];
         NSButton *restoreDefaultsButton = FindButtonWithTitle(controller.window.contentView, @"恢复默认设置");
         require(restoreDefaultsButton != nil, "The settings window did not expose the restore-defaults button.");
@@ -900,6 +920,7 @@ int main()
                 ![MetasequoiaPreferencesWindowController storedTraditionalChineseOutputEnabled] &&
                 ![MetasequoiaPreferencesWindowController storedWubiAutoCommitUniqueEnabled] &&
                 ![MetasequoiaPreferencesWindowController storedWubiMixedPinyinEnabled] &&
+                [MetasequoiaPreferencesWindowController storedWubiCodeHintEnabled] &&
                 ![[NSUserDefaults standardUserDefaults] boolForKey:@"MetasequoiaImeShuangpinKeymapEnabled"] &&
                 [[MetasequoiaPreferencesWindowController storedShuangpinSchema] isEqualToString:@"xiaohe"],
             "Restoring defaults did not restore every visible setting.");
@@ -926,6 +947,7 @@ int main()
             @"MetasequoiaImeTraditionalChineseOutput",
             @"MetasequoiaImeWubiAutoCommitUnique",
             @"MetasequoiaImeWubiMixedPinyin",
+            @"MetasequoiaImeWubiCodeHint",
             @"MetasequoiaImeShuangpinKeymapEnabled",
         ];
         for (NSString *key in preferenceKeys)

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -64,9 +64,11 @@ InputSnapshot MakeSnapshot(const Session &session, KeyResult result)
     const auto view = session.snapshot();
     snapshot.preedit = view.preedit;
     snapshot.candidates.reserve(view.candidates.size());
+    snapshot.candidate_codes.reserve(view.candidates.size());
     for (const auto &candidate : view.candidates)
     {
         snapshot.candidates.push_back(candidate.word);
+        snapshot.candidate_codes.push_back(candidate.pinyin);
     }
     return snapshot;
 }

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -30,6 +30,10 @@ struct InputSnapshot
     std::optional<std::string> commit;
     std::string preedit;
     std::vector<std::string> candidates;
+    // The dictionary key each candidate was found by, in the same order. A wubi frontend needs it to
+    // say which keys still single a candidate out, since an unfinished code answers with the codes
+    // it can still become. Empty for a candidate that has no key of its own.
+    std::vector<std::string> candidate_codes;
     // Set when the engine could answer the key but something behind it failed, such as a local input
     // mode whose table is missing or a word that could not be learned. Input stays usable, so a
     // frontend reports it rather than treating it as an error.

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -24,6 +24,10 @@ typedef NS_ENUM(NSInteger, MetasequoiaFrequencyAdjustmentMode) {
 @property(nonatomic, copy, readonly, nullable) NSString *commitText;
 @property(nonatomic, copy, readonly) NSString *preedit;
 @property(nonatomic, copy, readonly) NSArray<NSString *> *candidates;
+/// The dictionary key each candidate was found by, in the same order and of the same count. A wubi
+/// code shorter than four letters answers with the codes it can still become, and this is what says
+/// which keys single a candidate out.
+@property(nonatomic, copy, readonly) NSArray<NSString *> *candidateCodes;
 /// Set when the key was handled but something behind it failed, such as a local input mode whose
 /// table is missing. Input stays usable, so a frontend reports this rather than failing.
 @property(nonatomic, copy, readonly, nullable) NSString *diagnosticText;

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -80,6 +80,7 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
                      commitText:(nullable NSString *)commitText
                         preedit:(NSString *)preedit
                      candidates:(NSArray<NSString *> *)candidates
+                 candidateCodes:(NSArray<NSString *> *)candidateCodes
                  diagnosticText:(nullable NSString *)diagnosticText;
 
 @end
@@ -90,6 +91,7 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
                      commitText:(nullable NSString *)commitText
                         preedit:(NSString *)preedit
                      candidates:(NSArray<NSString *> *)candidates
+                 candidateCodes:(NSArray<NSString *> *)candidateCodes
                  diagnosticText:(nullable NSString *)diagnosticText
 {
     self = [super init];
@@ -99,6 +101,7 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
         _commitText = [commitText copy];
         _preedit = [preedit copy];
         _candidates = [candidates copy];
+        _candidateCodes = [candidateCodes copy];
         _diagnosticText = [diagnosticText copy];
     }
     return self;
@@ -196,6 +199,7 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
                                                   commitText:nil
                                                      preedit:@""
                                                   candidates:@[]
+                                              candidateCodes:@[]
                                               diagnosticText:nil];
 }
 
@@ -584,6 +588,11 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
     {
         [candidates addObject:StringFromUTF8(candidate)];
     }
+    NSMutableArray<NSString *> *candidateCodes = [NSMutableArray arrayWithCapacity:snapshot.candidate_codes.size()];
+    for (const auto &code : snapshot.candidate_codes)
+    {
+        [candidateCodes addObject:StringFromUTF8(code)];
+    }
 
     NSString *commitText = snapshot.commit.has_value() ? StringFromUTF8(*snapshot.commit) : nil;
     const auto &diagnostic = snapshot.diagnostic ? snapshot.diagnostic : _installationDiagnostic;
@@ -592,6 +601,7 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
                                                   commitText:commitText
                                                      preedit:StringFromUTF8(snapshot.preedit)
                                                   candidates:candidates
+                                              candidateCodes:candidateCodes
                                               diagnosticText:diagnosticText];
 }
 


### PR DESCRIPTION
## Why

An unfinished wubi code now answers with the codes it can still become (MSIME-Engine#99), so `wq` offers 你, 爷, 釜, 低 … — and a list of bare words does not say which of them is one keystroke away. Every wubi frontend puts that code in front of the typist; this adds it on both platforms.

Each wubi candidate carries the code it was found by, so the tail of that code past what has been typed is exactly the keys that single it out:

```
wq → 你   爷 b   釜 f   低 a   像 j   父子 bb   低头 ud
```

## macOS

- `CandidateDisplayText` grows an optional typed-code argument and a `WubiCodeHint` helper.
- The controller passes the code only for a wubi composition with no local input mode that the pinyin fallback did not answer.
- New preference `MetasequoiaImeWubiCodeHint`, shown as 候选显示剩余编码 in the wubi settings pane, on by default. It is read from the snapshot already on screen rather than carried on the session, so flipping it reaches a composition in progress instead of waiting for the next one.

## iOS

- The bridge snapshot gains `candidate_codes` / `candidateCodes`, parallel to the candidates: the frontend had only the words and no way to answer the question.
- The strip and the expanded panel draw the tail in a smaller, quieter font. VoiceOver reads it as 还需输入 b.
- `WubiCodeHintPreference` in the app group, with 候选显示剩余编码 in the wubi section of the app settings, on by default.

## Where the hint is withheld

A candidate whose code does not extend what was typed gets nothing, which is what keeps the mixed-pinyin fallback unannotated — those candidates are keyed by spelling, and 你好 under `ni'hao` is not reachable by typing anything after `nihao` in wubi. Local input modes synthesise their candidates and get nothing either. Both platforms check this at the source and again in the hint itself.

Like `MetasequoiaImeWubiMixedPinyin` beside it, the macOS key stays out of `cloudSettingsSnapshot`: the backend rejects the whole upload for a key its schema does not know, and the download side refuses a snapshot whose key count does not match.

## Engine gitlink

Advanced 3b2d52b → 2b98fa9, which carries #99. Without it every candidate's key equals the preedit and the hint is empty everywhere, so the adapter test asserting that a longer code rides along could not pass. The range also brings #96/#97 (punctuation modes, paired punctuation) and releases 0.11.0 and 0.12.0; no platform adaptation was needed — the full macOS suite passes against it unchanged.

## Verification

- `ctest --test-dir build --output-on-failure` — 52/52 against the advanced gitlink, including the new wubi assertions in `input_controller_key_routing`, `preferences_window` and `apple_input_session_adapter`
- `python3 platforms/ios/tests/ProjectConfigurationTests.py` — 46/46, with the candidate-surface contracts updated for the new call shape
- `scripts/format.sh --check` clean
- The iOS Simulator suite was not run locally: the project excludes the arm64 simulator slice (ML Kit Digital Ink ships x86_64 only) and this machine has no x86_64 runtime, so that coverage comes from CI.
