### PR TITLE
ci(ios): give the interface suite a budget it fits inside

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_only != true }}
     # ML Kit ships x86_64 simulator binaries; run them natively instead of under Rosetta.
     runs-on: macos-15-intel
-    timeout-minutes: 120
+    timeout-minutes: 130
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
@@ -169,14 +169,23 @@ jobs:
           pod install --deployment --project-directory=platforms/ios
       - name: Test native iOS keyboard and settings
         # A pull request runs the unit suites and a handful of interface cases; a merge into develop
-        # or main runs everything. The interface suite is 96% of this job -- 45 minutes for 37 cases
+        # or main runs everything. The interface suite is 96% of this step -- 45 minutes for 37 cases
         # against one minute for 111 unit cases -- because each case is a cold launch and a walk
         # through the app on a Simulator that is half the speed of an arm64 one. Paying that on
         # every push made the step time out at 80 minutes; paying it per merge keeps the coverage
         # and takes it off the critical path. Interface regressions surface at merge, not review.
+        #
+        # 80 was the number this used to die at, not a budget the suite fits inside. The last merge
+        # it passed on finished the step in 78m13s: under two minutes of margin, which is noise on a
+        # shared Intel runner. The three merges after it lost the coin flip -- two killed at the cap
+        # mid-suite, and the failures they reported were different cases each time, which is what a
+        # suite cut off partway through looks like rather than a regression. Twenty-five of those
+        # minutes are the test build, before a case has run at all. The job cap is the real ceiling
+        # and it had 35 spare minutes; the step now gets 110, leaving the job 13 beyond its worst
+        # observed run.
         env:
           MSIME_TEST_SCOPE: ${{ github.event_name == 'pull_request' && 'pr' || 'all' }}
-        timeout-minutes: 80
+        timeout-minutes: 110
         run: bash platforms/ios/scripts/run_ui_tests.sh
       - name: Upload iOS test results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## The measurement

The `iOS Simulator` step caps at 80 minutes. On `e7e71fa`, the last merge where it passed, the step took **78m13s**.

| | passing run (`e7e71fa`) | cap |
|---|---|---|
| steps 1–7 | 5m | — |
| step 8 (test build + suites) | **78m13s** | 80m |
| steps 9+ | 2m | — |
| whole job | 85m25s | 120m |

Under two minutes of margin, on a shared `macos-15-intel` runner. That is not a budget, it is a coin flip.

## What happened

The three merge runs after it lost that flip. Two were killed at the cap partway through the interface suite; the cases they reported as failures were **different each time** — `testCancelledSkinGenerationDoesNotShowLateResult` on one, `testInputSchemeVisibilityPersistsAndFallsBack` on the next — which is what a suite cut off mid-run looks like, not a regression.

The suite did not meaningfully change: 44 minutes on the run that passed, 49 on one that did not, for 37 cases that each cold-launch the app on a Simulator running at half an arm64 one's speed. Twenty-five of the 80 minutes go to the test build before a single case runs.

I checked the obvious suspect and ruled it out: the engine bump in #403 is not on any of these code paths, and its new autocorrect tables are 150 and 649 entries built once per process — microseconds, not minutes.

## The change

The job cap was the real ceiling and was never the binding one — the passing run used 85 of its 120 minutes. The step goes to 110 and the job to 130, leaving 13 minutes past the worst run observed.

## What this deliberately does not do

`testCancelledSkinGenerationDoesNotShowLateResult` is fragile on its own terms. It taps `取消` inside the 5-second window `-skinGenerationSlowFixture` opens, and on a contended runner XCTest spent 13 seconds resolving that tap and missed it — `waitForExistence` on the line above had already succeeded, so the button was there and the tap arrived late.

Widening that fixture would also have to widen the 6-second inverted wait that proves the late result never lands, which is the assertion the test exists for. That deserves its own change rather than a bigger wall clock here.

## Verification

`actionlint` clean at the severity `quality.yml` uses; 79 macOS Python tests pass.
