### PR TITLE
fix(release): keep the Latest badge on a release Sparkle can use

### DIFF
--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -144,7 +144,18 @@ if [[ "$RELEASE_TRIGGER" == push ]]; then
     needs_channel_note=true
 else
     release_title="$TAG_NAME"
-    channel=(--prerelease=false --latest)
+    # The Latest badge is not decoration: SUFeedURL is
+    # releases/latest/download/appcast.xml, so whichever release holds the badge is the one every
+    # macOS copy asks for its updates. A release that does not cover macOS carries no appcast, and
+    # letting it take the badge turns that URL into a 404 -- updates stop for everyone, silently,
+    # until some later macOS release takes the badge back. Passing the flag off explicitly matters:
+    # omitted, the API defaults make_latest to true and the badge moves anyway.
+    channel=(--prerelease=false)
+    if [[ "$RELEASE_MACOS" == true ]]; then
+        channel+=(--latest)
+    else
+        channel+=(--latest=false)
+    fi
     needs_channel_note=false
 fi
 current_notes=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq '.body // ""')

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -907,8 +907,35 @@ fi
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("--prerelease=false", calls)
         self.assertIn("--latest", calls)
+        self.assertNotIn("--latest=false", calls)
         self.assertNotIn("（自动构建）", calls)
         self.assertNotIn("metasequoia-build-channel", notes)
+
+    def test_a_release_without_macos_does_not_take_the_latest_badge(self):
+        # SUFeedURL is releases/latest/download/appcast.xml, so the badge decides which release
+        # every macOS copy asks for its updates. An iOS-only release has no appcast: taking the
+        # badge would 404 that URL and stop updates for everyone until a macOS release took it back.
+        # It is still an ordinary release, just not the one Sparkle is pointed at.
+        result, calls, _ = self.run_publication(
+            "false", "-unsigned", release_trigger="workflow_dispatch", release_macos=False
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--prerelease=false", calls)
+        self.assertIn("--latest=false", calls)
+        # Omitting the flag is not the same thing: the API defaults make_latest to true.
+        edit = [line for line in calls.splitlines() if "release edit" in line and "--draft=false" in line]
+        self.assertTrue(edit, calls)
+        self.assertIn("--latest=false", edit[-1])
+
+    def test_a_macos_release_still_takes_the_latest_badge(self):
+        result, calls, _ = self.run_publication(
+            "false", "-unsigned", release_trigger="workflow_dispatch", release_ios=False
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--latest", calls)
+        self.assertNotIn("--latest=false", calls)
 
     def test_build_channel_note_is_not_repeated_on_a_retry(self):
         _, _, notes = self.run_publication(


### PR DESCRIPTION
## The problem

`SUFeedURL` in `platforms/macos/resources/Info.plist` is:

```
https://github.com/metasequoiaime/MSIME-Apple/releases/latest/download/appcast.xml
```

So whichever release holds the **Latest** badge is the one every macOS copy asks for its updates. Publishing picked that badge from the trigger alone — anything that was not a `push` got `--prerelease=false --latest`.

That was fine while every deliberate release covered both platforms. It stopped being fine the moment a manual run could build one platform on its own (#402): an iOS-only release carries no `appcast.xml`, so taking the badge turns that URL into a **404** and stops macOS updates for everyone, silently, until some later macOS release takes the badge back.

This is not hypothetical. `macos-v0.48.6-build.1002.61.1` published and took the badge correctly; the iOS dispatch queued behind it was cancelled seconds before it would have taken the badge away from it.

## The change

A release that does not cover macOS is still an ordinary release — published, not a prerelease, listed normally. It just is not the one Sparkle is pointed at.

```bash
channel=(--prerelease=false)
if [[ "$RELEASE_MACOS" == true ]]; then
    channel+=(--latest)
else
    channel+=(--latest=false)
fi
```

Passing the flag off explicitly matters rather than omitting it: the API defaults `make_latest` to true, so an omitted flag moves the badge anyway.

## Verification

60 release automation tests pass. The new case, `test_a_release_without_macos_does_not_take_the_latest_badge`, fails on the previous script with exactly the call that would have moved the badge:

```
release edit v1.2.3 --draft=false --prerelease=false --latest --title v1.2.3
```

## Note

This must reach `main` before the iOS release can be re-dispatched — the publish job sparse-checks `publish-release.sh` out of `main`, not out of the release tag.
