### PR TITLE
release: 让 Latest 徽章只落在 Sparkle 能用的版本上

### DIFF
--- a/platforms/macos/scripts/publish-release.sh
+++ b/platforms/macos/scripts/publish-release.sh
@@ -144,7 +144,18 @@ if [[ "$RELEASE_TRIGGER" == push ]]; then
     needs_channel_note=true
 else
     release_title="$TAG_NAME"
-    channel=(--prerelease=false --latest)
+    # The Latest badge is not decoration: SUFeedURL is
+    # releases/latest/download/appcast.xml, so whichever release holds the badge is the one every
+    # macOS copy asks for its updates. A release that does not cover macOS carries no appcast, and
+    # letting it take the badge turns that URL into a 404 -- updates stop for everyone, silently,
+    # until some later macOS release takes the badge back. Passing the flag off explicitly matters:
+    # omitted, the API defaults make_latest to true and the badge moves anyway.
+    channel=(--prerelease=false)
+    if [[ "$RELEASE_MACOS" == true ]]; then
+        channel+=(--latest)
+    else
+        channel+=(--latest=false)
+    fi
     needs_channel_note=false
 fi
 current_notes=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq '.body // ""')

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -907,8 +907,35 @@ fi
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("--prerelease=false", calls)
         self.assertIn("--latest", calls)
+        self.assertNotIn("--latest=false", calls)
         self.assertNotIn("（自动构建）", calls)
         self.assertNotIn("metasequoia-build-channel", notes)
+
+    def test_a_release_without_macos_does_not_take_the_latest_badge(self):
+        # SUFeedURL is releases/latest/download/appcast.xml, so the badge decides which release
+        # every macOS copy asks for its updates. An iOS-only release has no appcast: taking the
+        # badge would 404 that URL and stop updates for everyone until a macOS release took it back.
+        # It is still an ordinary release, just not the one Sparkle is pointed at.
+        result, calls, _ = self.run_publication(
+            "false", "-unsigned", release_trigger="workflow_dispatch", release_macos=False
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--prerelease=false", calls)
+        self.assertIn("--latest=false", calls)
+        # Omitting the flag is not the same thing: the API defaults make_latest to true.
+        edit = [line for line in calls.splitlines() if "release edit" in line and "--draft=false" in line]
+        self.assertTrue(edit, calls)
+        self.assertIn("--latest=false", edit[-1])
+
+    def test_a_macos_release_still_takes_the_latest_badge(self):
+        result, calls, _ = self.run_publication(
+            "false", "-unsigned", release_trigger="workflow_dispatch", release_ios=False
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--latest", calls)
+        self.assertNotIn("--latest=false", calls)
 
     def test_build_channel_note_is_not_repeated_on_a_retry(self):
         _, _, notes = self.run_publication(


### PR DESCRIPTION
Cherry-picks #409 onto `main` on its own, without the rest of `develop`.

## Why narrow

The publish job sparse-checks `publish-release.sh` out of `main`, not out of the release tag, so the Latest-badge fix has to be on `main` before the iOS release can be dispatched. That is the only reason this is here.

Taking all of `develop` instead would also bring #407, a wubi code-hint feature on both platforms. `macos-v0.48.6-build.1002.61.1` is already published from `91dd069`; building its iOS counterpart from a tree that has a feature the macOS build does not would leave the pair describing different products. The product content stays exactly where the published macOS build left it, and `develop` merges into `main` on its own schedule.

## What it fixes

`SUFeedURL` is `releases/latest/download/appcast.xml`, so the release holding the Latest badge is the one every macOS copy asks for its updates. Publishing chose that badge from the trigger alone, which was safe only while every deliberate release covered both platforms. An iOS-only release carries no appcast, so it would 404 that URL and stop macOS updates until a macOS release took the badge back. The iOS dispatch was cancelled seconds before doing that.

A release that does not cover macOS stays an ordinary published release; it just does not take the badge. The flag is passed off explicitly, because the API defaults `make_latest` to true.

## Note on what merging this publishes

Only `platforms/macos/**` changed here, so the automatic build this merge triggers covers macOS alone and is tagged `macos-`. It is a near-duplicate of the build already out, and it takes the badge legitimately because it does carry an appcast.

## Verification

60 release automation tests pass on this branch. The new case fails on the pre-#409 script with the exact `release edit --latest` call that would have moved the badge.
