### PR TITLE
docs: split the release badge into macOS and iOS

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -5,7 +5,8 @@
 <!-- badges:start -->
 [![CI](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/ci.yml?branch=develop&label=CI)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/codeql.yml?branch=develop&label=CodeQL)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/codeql.yml)
-[![Release](https://img.shields.io/github/v/release/metasequoiaime/MSIME-Apple?include_prereleases&label=release)](https://github.com/metasequoiaime/MSIME-Apple/releases)
+[![macOS](https://img.shields.io/github/v/release/metasequoiaime/MSIME-Apple?include_prereleases&filter=macos-*&label=macOS)](https://github.com/metasequoiaime/MSIME-Apple/releases)
+[![iOS](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmetasequoiaime%2FMSIME-Apple%2Fdevelop%2Fplatforms%2Fios%2Fproject.yml&query=%24.settings.base.MARKETING_VERSION&prefix=v&label=iOS&color=inactive)](docs/ios-distribution.md)
 [![License](https://img.shields.io/github/license/metasequoiaime/MSIME-Apple)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/metasequoiaime/MSIME-Apple?style=flat)](https://github.com/metasequoiaime/MSIME-Apple/stargazers)
 <!-- badges:end -->

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 <!-- badges:start -->
 [![CI](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/ci.yml?branch=develop&label=CI)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/metasequoiaime/MSIME-Apple/codeql.yml?branch=develop&label=CodeQL)](https://github.com/metasequoiaime/MSIME-Apple/actions/workflows/codeql.yml)
-[![Release](https://img.shields.io/github/v/release/metasequoiaime/MSIME-Apple?include_prereleases&label=release)](https://github.com/metasequoiaime/MSIME-Apple/releases)
+[![macOS](https://img.shields.io/github/v/release/metasequoiaime/MSIME-Apple?include_prereleases&filter=macos-*&label=macOS)](https://github.com/metasequoiaime/MSIME-Apple/releases)
+[![iOS](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmetasequoiaime%2FMSIME-Apple%2Fdevelop%2Fplatforms%2Fios%2Fproject.yml&query=%24.settings.base.MARKETING_VERSION&prefix=v&label=iOS&color=inactive)](docs/ios-distribution.md)
 [![Downloads](https://img.shields.io/github/downloads/metasequoiaime/MSIME-Apple/total?label=downloads)](https://github.com/metasequoiaime/MSIME-Apple/releases)
 [![License](https://img.shields.io/github/license/metasequoiaime/MSIME-Apple)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/metasequoiaime/MSIME-Apple?style=flat)](https://github.com/metasequoiaime/MSIME-Apple/stargazers)


### PR DESCRIPTION
## What

Replaces the single `release` badge in both READMEs with one badge per platform.

- **macOS** — `github/v/release` with `filter=macos-*`, so it tracks the platform-prefixed tags the release workflow creates (`.github/workflows/release.yml:175-179`). Currently renders `macos-v0.48.6-build.1002.61.1`.
- **iOS** — a `dynamic/yaml` badge reading `settings.base.MARKETING_VERSION` from `platforms/ios/project.yml` on `develop`, the field release-please bumps. It links to `docs/ios-distribution.md` rather than the releases page, and is grey rather than green.

## Why iOS is not a release badge

There is no published iOS release, and per `docs/ios-distribution.md` there is deliberately no plan for one while the App Store terms conflict with GPL-3.0. A `filter=ios-*` release badge renders `no matching releases found` today, since the only `ios-*` releases are maintainer drafts. Reading the source version keeps the badge truthful and self-updating.

Known limit of the macOS badge: a build covering both platforms still gets a bare `v*` tag, which `filter=macos-*` does not match, so the badge holds at the last macOS-only build until the next one. `filter=!ios-*` is the semantically correct filter but reports an *older* version, because shields' sort prefers tags it can parse as semver and the prefixed ones lose.

## Verification

Both badge URLs were fetched from shields.io and render as described: `macos-v0.48.6-build.1002.61.1` and `v0.48.6`. No code or workflow changes.
