### PR TITLE
feat(macos): gloss candidates through the account's own model

### DIFF
--- a/cmake/BackendAccount.cmake
+++ b/cmake/BackendAccount.cmake
@@ -12,6 +12,7 @@ set(MSIME_ACCOUNT_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/shared/backend/BackendPreferencesClient.swift"
     "${CMAKE_CURRENT_SOURCE_DIR}/shared/backend/BackendDictionaryClient.swift"
     "${CMAKE_CURRENT_SOURCE_DIR}/shared/backend/BackendCandidateClient.swift"
+    "${CMAKE_CURRENT_SOURCE_DIR}/shared/backend/BackendChatClient.swift"
     "${CMAKE_CURRENT_SOURCE_DIR}/shared/backend/BackendSnapshotClient.swift"
     "${CMAKE_CURRENT_SOURCE_DIR}/shared/backend/BackendCommunityResourceClient.swift"
     "${METASEQUOIA_MACOS_ROOT}/src/BackendFileTransfer.swift"
@@ -25,7 +26,8 @@ set(MSIME_ACCOUNT_SOURCES
     "${METASEQUOIA_MACOS_ROOT}/src/BackendDictionaryView.swift"
     "${METASEQUOIA_MACOS_ROOT}/src/BackendSettingsView.swift"
     "${METASEQUOIA_MACOS_ROOT}/src/BackendClipboardView.swift"
-    "${METASEQUOIA_MACOS_ROOT}/src/BackendAccountWindow.swift")
+    "${METASEQUOIA_MACOS_ROOT}/src/BackendAccountWindow.swift"
+    "${METASEQUOIA_MACOS_ROOT}/src/CandidateTranslationBridge.swift")
 set(MSIME_ACCOUNT_ARCHIVES)
 foreach(architecture IN LISTS CMAKE_OSX_ARCHITECTURES)
     set(archive "${CMAKE_CURRENT_BINARY_DIR}/backend-account/${architecture}/libMSIMEBackendAccount.a")

--- a/platforms/macos/src/CandidateTranslationBridge.swift
+++ b/platforms/macos/src/CandidateTranslationBridge.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+// Glosses candidates through the account's own model, so nobody has to hold a translation vendor's
+// keys to see what a candidate means. The words go out as one request and come back as one object,
+// which is both cheaper than a call per candidate and what lets the model keep a page consistent.
+//
+// The controller drives this from Objective-C, so the entry point is a C function and the answer
+// comes back as a notification rather than a block: a @_cdecl function cannot take an Objective-C
+// block, and the controller already listens for the preference notifications next to this one.
+enum CandidateTranslationBridge {
+  static let notification = Notification.Name("MetasequoiaCandidateTranslationsDidArrive")
+
+  private static let session = BackendAccountSession()
+  private static let client = BackendAccountClient()
+  // Resolved once per launch: the catalogue rarely changes and a model lookup per keystroke would
+  // cost more than the translation it precedes.
+  private static var cachedModel: String?
+
+  static func translate(words: [String], languageName: String, generation: UInt64) {
+    guard !words.isEmpty, !languageName.isEmpty else { return }
+    Task {
+      do {
+        let token = try await session.accessToken()
+        let model = try await resolveModel(token: token)
+        let reply = try await client.chat(messages: prompt(words: words, languageName: languageName),
+                                          model: model, token: token)
+        let translations = parse(reply: reply, words: words)
+        guard !translations.isEmpty else { return }
+        await MainActor.run {
+          NotificationCenter.default.post(name: notification, object: nil,
+                                          userInfo: ["generation": generation, "translations": translations])
+        }
+      } catch {
+        // Signed out, offline, or a model that would not answer in the shape asked for. The strip
+        // simply stays as it is; a candidate window is the wrong place to report a failed request.
+      }
+    }
+  }
+
+  private static func resolveModel(token: String) async throws -> String {
+    if let cachedModel { return cachedModel }
+    let catalog = try await client.chatModels(token: token)
+    cachedModel = catalog.default_model
+    return catalog.default_model
+  }
+
+  // The model is asked for an object keyed by the words themselves, so a reply that drops or
+  // reorders an entry still lands against the right candidate instead of shifting the whole page.
+  private static func prompt(words: [String], languageName: String) -> [BackendAccountClient.ChatMessage] {
+    let instruction = """
+      Translate each Chinese word into \(languageName). Reply with nothing but a JSON object whose \
+      keys are exactly the input words and whose values are the translations. Keep each translation \
+      under four words, with no pronunciation, no notes and no punctuation at the end.
+      """
+    let payload = (try? JSONEncoder().encode(words)).flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+    return [.init(role: "system", content: instruction), .init(role: "user", content: payload)]
+  }
+
+  private static func parse(reply: String, words: [String]) -> [String: String] {
+    // Models fence JSON in code blocks often enough that the object is taken from the first brace
+    // to the last rather than from the reply as a whole.
+    guard let start = reply.firstIndex(of: "{"), let end = reply.lastIndex(of: "}"), start < end,
+          let data = String(reply[start...end]).data(using: .utf8),
+          let decoded = try? JSONDecoder().decode([String: String].self, from: data)
+    else { return [:] }
+    let asked = Set(words)
+    var translations: [String: String] = [:]
+    for (word, translation) in decoded {
+      let trimmed = translation.trimmingCharacters(in: .whitespacesAndNewlines)
+      // A word that was not asked about, an empty answer, or one long enough to be an explanation
+      // rather than a gloss, is dropped: the strip has room for a few words beside a candidate.
+      guard asked.contains(word), !trimmed.isEmpty, trimmed.count <= 40 else { continue }
+      translations[word] = trimmed
+    }
+    return translations
+  }
+}
+
+@_cdecl("MSIMETranslateCandidates")
+func translateCandidates(_ wordsJSON: UnsafePointer<CChar>, _ languageName: UnsafePointer<CChar>,
+                         _ generation: UInt64) {
+  let payload = String(cString: wordsJSON)
+  guard let data = payload.data(using: .utf8),
+        let words = try? JSONDecoder().decode([String].self, from: data)
+  else { return }
+  CandidateTranslationBridge.translate(words: words, languageName: String(cString: languageName),
+                                       generation: generation)
+}

--- a/platforms/macos/src/CandidateTranslationLanguage.h
+++ b/platforms/macos/src/CandidateTranslationLanguage.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+
+namespace metasequoia::mac
+{
+// The languages a candidate can be glossed into. `code` is what the phrase-based services take;
+// `name` is what the model is asked for, since a model reads "Spanish" and not "ES". The machine
+// translation providers accept every code here, so one list serves all three.
+struct CandidateTranslationLanguage
+{
+    const char *title;
+    const char *code;
+    const char *name;
+};
+
+inline constexpr CandidateTranslationLanguage kCandidateTranslationLanguages[] = {
+    {"英语", "EN", "English"},     {"日语", "JA", "Japanese"}, {"韩语", "KO", "Korean"},
+    {"西班牙语", "ES", "Spanish"}, {"法语", "FR", "French"},   {"德语", "DE", "German"},
+};
+
+inline constexpr std::size_t kCandidateTranslationLanguageCount =
+    sizeof(kCandidateTranslationLanguages) / sizeof(kCandidateTranslationLanguages[0]);
+
+// A stored index out of range answers with the first language rather than reading past the table.
+// The list has grown once and will again; a preference written by a later build must not decide
+// what an earlier one indexes into.
+inline const CandidateTranslationLanguage &CandidateTranslationLanguageAt(std::size_t index)
+{
+    return kCandidateTranslationLanguages[index < kCandidateTranslationLanguageCount ? index : 0];
+}
+
+// The providers a translation can come from. The account's model is the one that needs no keys of
+// the user's own, so it leads.
+enum class CandidateTranslationProvider
+{
+    AccountModel,
+    TencentMachineTranslation,
+    DeepLX,
+};
+
+inline CandidateTranslationProvider CandidateTranslationProviderAt(std::size_t index)
+{
+    switch (index)
+    {
+    case 1:
+        return CandidateTranslationProvider::TencentMachineTranslation;
+    case 2:
+        return CandidateTranslationProvider::DeepLX;
+    default:
+        return CandidateTranslationProvider::AccountModel;
+    }
+}
+} // namespace metasequoia::mac

--- a/platforms/macos/src/MetasequoiaInputController.mm
+++ b/platforms/macos/src/MetasequoiaInputController.mm
@@ -1,5 +1,9 @@
 #import "MetasequoiaInputController.h"
 
+// Implemented in CandidateTranslationBridge.swift.
+extern "C" void MSIMETranslateCandidates(const char *wordsJSON, const char *languageName,
+                                         unsigned long long generation);
+
 #import "DictionaryInstaller.h"
 #include "DictionaryRuntime.h"
 #include "../../../shared/apple-bridge/DictionarySessionLease.h"
@@ -28,6 +32,7 @@
 #include "CandidateSelectionState.h"
 #include "InputControllerKeyRouting.h"
 #include "InputBehaviorPreferences.h"
+#include "CandidateTranslationLanguage.h"
 #include <metasequoia/session.h>
 #include "contracts/punctuation/policy.h"
 #include "quanpin/quanpin_utils.h"
@@ -236,6 +241,10 @@ static NSHashTable *LiveDictionaryControllers()
                                                  selector:@selector(wubiCodeHintPreferenceDidChange:)
                                                      name:@"MetasequoiaWubiCodeHintDidChangeNotification"
                                                    object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(candidateTranslationsDidArrive:)
+                                                     name:@"MetasequoiaCandidateTranslationsDidArrive"
+                                                   object:nil];
     }
     return self;
 }
@@ -285,6 +294,29 @@ static NSHashTable *LiveDictionaryControllers()
     {
         [self refreshCandidatePanelPreservingSelection];
     }
+}
+
+// The account model answers for a whole page at once, so one reply fills several cache entries. A
+// reply for a composition that has already moved on is dropped rather than drawn over the new one.
+- (void)candidateTranslationsDidArrive:(NSNotification *)notification
+{
+    NSDictionary *info = notification.userInfo;
+    NSDictionary<NSString *, NSString *> *translations = info[@"translations"];
+    if (![translations isKindOfClass:[NSDictionary class]] ||
+        [info[@"generation"] unsignedLongLongValue] != _translationGeneration || _session == nullptr)
+        return;
+    const auto &languageEntry =
+        metasequoia::mac::CandidateTranslationLanguageAt(static_cast<std::size_t>(MetasequoiaInputInteger(
+            @"translationLanguage", 0, 0, metasequoia::mac::kCandidateTranslationLanguageCount - 1)));
+    NSString *language = @(languageEntry.code);
+    for (NSString *word in translations)
+    {
+        NSString *translation = translations[word];
+        if ([word isKindOfClass:[NSString class]] && [translation isKindOfClass:[NSString class]] && translation.length)
+            _translationCache[[NSString stringWithFormat:@"%@|%@", language, word]] = translation;
+    }
+    if (!_sessionSnapshot.preedit.empty())
+        [self rebuildCandidatePanelPreservingSelection:YES];
 }
 
 - (void)prepareForLearnedDataReset:(NSNotification *)notification
@@ -1017,7 +1049,11 @@ static NSHashTable *LiveDictionaryControllers()
         NSString *convertedDisplay = MetasequoiaChineseOutputString(display, traditionalOutput);
         if (MetasequoiaInputFlag(@"candidateTranslation"))
         {
-            NSString *language = @[ @"EN", @"JA", @"KO" ][MetasequoiaInputInteger(@"translationLanguage", 0, 0, 2)];
+            NSString *language =
+                @(metasequoia::mac::CandidateTranslationLanguageAt(
+                      static_cast<std::size_t>(MetasequoiaInputInteger(
+                          @"translationLanguage", 0, 0, metasequoia::mac::kCandidateTranslationLanguageCount - 1)))
+                      .code);
             NSString *translation = _translationCache[
                 [NSString stringWithFormat:@"%@|%@", language, MetasequoiaStringFromUtf8(candidate.word)]];
             if (translation.length)
@@ -1061,14 +1097,41 @@ static NSHashTable *LiveDictionaryControllers()
     if (!MetasequoiaInputFlag(@"candidateTranslation") || !snapshot.preedit.size())
         return;
     NSString *endpoint = [NSUserDefaults.standardUserDefaults stringForKey:@"translationEndpoint"];
-    const NSInteger provider = MetasequoiaInputInteger(@"translationProvider", 0, 0, 1);
+    const NSInteger providerIndex = MetasequoiaInputInteger(@"translationProvider", 0, 0, 2);
+    const auto provider = metasequoia::mac::CandidateTranslationProviderAt(static_cast<std::size_t>(providerIndex));
     NSString *secretId = [NSUserDefaults.standardUserDefaults stringForKey:@"translationSecretId"];
     NSString *secretKey = [NSUserDefaults.standardUserDefaults stringForKey:@"translationSecretKey"];
-    if ((provider == 1 && endpoint.length == 0) || (provider == 0 && (!secretId.length || !secretKey.length)))
+    if ((provider == metasequoia::mac::CandidateTranslationProvider::DeepLX && endpoint.length == 0) ||
+        (provider == metasequoia::mac::CandidateTranslationProvider::TencentMachineTranslation &&
+         (!secretId.length || !secretKey.length)))
         return;
     const NSUInteger generation = _translationGeneration;
-    NSString *language = @[ @"EN", @"JA", @"KO" ][MetasequoiaInputInteger(@"translationLanguage", 0, 0, 2)];
+    const auto &languageEntry =
+        metasequoia::mac::CandidateTranslationLanguageAt(static_cast<std::size_t>(MetasequoiaInputInteger(
+            @"translationLanguage", 0, 0, metasequoia::mac::kCandidateTranslationLanguageCount - 1)));
+    NSString *language = @(languageEntry.code);
     const NSUInteger limit = MIN((NSUInteger)5, snapshot.candidates.size());
+    if (provider == metasequoia::mac::CandidateTranslationProvider::AccountModel)
+    {
+        // One request for the whole page: a model keeps a page consistent when it sees it at once,
+        // and the account pays per call rather than per word.
+        NSMutableArray<NSString *> *pending = [NSMutableArray arrayWithCapacity:limit];
+        for (NSUInteger i = 0; i < limit; ++i)
+        {
+            NSString *word = MetasequoiaStringFromUtf8(snapshot.candidates[i].word);
+            if (_translationCache[[NSString stringWithFormat:@"%@|%@", language, word]] == nil)
+                [pending addObject:word];
+        }
+        if (pending.count == 0)
+            return;
+        NSData *payload = [NSJSONSerialization dataWithJSONObject:pending options:0 error:nil];
+        NSString *wordsJSON =
+            payload != nil ? [[NSString alloc] initWithData:payload encoding:NSUTF8StringEncoding] : nil;
+        if (wordsJSON.length)
+            MSIMETranslateCandidates(wordsJSON.UTF8String, languageEntry.name,
+                                     static_cast<unsigned long long>(generation));
+        return;
+    }
     for (NSUInteger i = 0; i < limit; ++i)
     {
         NSString *word = MetasequoiaStringFromUtf8(snapshot.candidates[i].word);
@@ -1076,7 +1139,8 @@ static NSHashTable *LiveDictionaryControllers()
         if (_translationCache[key] != nil)
             continue;
         __weak MetasequoiaInputController *weakSelf = self;
-        id client = provider == 1 ? (id)[MetasequoiaDeepLXClient new] : (id)[MetasequoiaTencentTmtClient new];
+        const bool viaDeepLX = provider == metasequoia::mac::CandidateTranslationProvider::DeepLX;
+        id client = viaDeepLX ? (id)[MetasequoiaDeepLXClient new] : (id)[MetasequoiaTencentTmtClient new];
         void (^completion)(NSString *, NSError *) = ^(NSString *text, NSError *error) {
           dispatch_async(dispatch_get_main_queue(), ^{
             MetasequoiaInputController *strongSelf = weakSelf;
@@ -1087,7 +1151,7 @@ static NSHashTable *LiveDictionaryControllers()
             [strongSelf rebuildCandidatePanelPreservingSelection:YES];
           });
         };
-        if (provider == 1)
+        if (viaDeepLX)
             [(MetasequoiaDeepLXClient *)client translateText:word
                                               targetLanguage:language
                                                     endpoint:endpoint

--- a/platforms/macos/src/PreferencesWindowController.mm
+++ b/platforms/macos/src/PreferencesWindowController.mm
@@ -1346,12 +1346,14 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
                                                   action:@selector(inputBehaviorChanged:)];
     _cloudCandidatesButton.identifier = @"cloudCandidates";
     _translationProviderButton = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
-    [_translationProviderButton addItemsWithTitles:@[ @"腾讯云", @"DeepLX（自部署）" ]];
+    [_translationProviderButton addItemsWithTitles:@[ @"水杉账号 AI", @"腾讯云", @"DeepLX（自部署）" ]];
+    _translationProviderButton.accessibilityLabel = @"候选翻译在线服务";
     _translationProviderButton.identifier = @"translationProvider";
     _translationProviderButton.target = self;
     _translationProviderButton.action = @selector(translationProviderChanged:);
     _translationLanguageButton = [[NSPopUpButton alloc] initWithFrame:NSZeroRect pullsDown:NO];
-    [_translationLanguageButton addItemsWithTitles:@[ @"英语", @"日语", @"韩语" ]];
+    [_translationLanguageButton addItemsWithTitles:@[ @"英语", @"日语", @"韩语", @"西班牙语", @"法语", @"德语" ]];
+    _translationLanguageButton.accessibilityLabel = @"候选翻译目标语言";
     _translationLanguageButton.identifier = @"translationLanguage";
     _translationLanguageButton.target = self;
     _translationLanguageButton.action = @selector(inputBehaviorChanged:);

--- a/platforms/macos/tests/InputControllerKeyRoutingTests.mm
+++ b/platforms/macos/tests/InputControllerKeyRoutingTests.mm
@@ -8,6 +8,7 @@
 #include "../src/FullWidthInput.h"
 #include "../src/HelpcodeSchemaPreference.h"
 #include "../src/InputSchemePreference.h"
+#include "../src/CandidateTranslationLanguage.h"
 #include "../src/WubiCommitPolicy.h"
 #include "../../../vendor/MetasequoiaImeEngine/contracts/punctuation/policy.h"
 
@@ -20,6 +21,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <initializer_list>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -217,6 +219,41 @@ int main()
             "A candidate keyed outside the typed code was annotated as though it extended it.");
     require(WubiCodeHint(WordItem{"wqb", "爷", 1}, "wq") == "b" && WubiCodeHint(WordItem{"wqb", "爷", 1}, "").empty(),
             "The wubi hint did not report the keys that are left to press.");
+
+    // A stored language or provider index is written by whichever build the user last ran; a later
+    // one that grew the list must not send an earlier one reading past it.
+    {
+        using metasequoia::mac::CandidateTranslationLanguageAt;
+        using metasequoia::mac::CandidateTranslationProvider;
+        using metasequoia::mac::CandidateTranslationProviderAt;
+        using metasequoia::mac::kCandidateTranslationLanguageCount;
+
+        require(std::string(CandidateTranslationLanguageAt(0).code) == "EN" &&
+                    std::string(CandidateTranslationLanguageAt(0).name) == "English",
+                "The first translation language was not English.");
+        require(std::string(CandidateTranslationLanguageAt(3).code) == "ES" &&
+                    std::string(CandidateTranslationLanguageAt(3).name) == "Spanish",
+                "Spanish was not reachable among the translation languages.");
+        require(std::string(CandidateTranslationLanguageAt(kCandidateTranslationLanguageCount).code) == "EN" &&
+                    std::string(CandidateTranslationLanguageAt(999).code) == "EN",
+                "An out-of-range language index was not clamped to the first language.");
+        // Every entry carries both a service code and a name a model can read.
+        for (std::size_t i = 0; i < kCandidateTranslationLanguageCount; ++i)
+        {
+            const auto &entry = CandidateTranslationLanguageAt(i);
+            require(entry.title != nullptr && entry.code != nullptr && entry.name != nullptr &&
+                        std::strlen(entry.code) == 2 && std::strlen(entry.name) > 2,
+                    "A translation language was missing its title, service code or model name.");
+        }
+
+        require(CandidateTranslationProviderAt(0) == CandidateTranslationProvider::AccountModel,
+                "The account model was not the default translation provider.");
+        require(CandidateTranslationProviderAt(1) == CandidateTranslationProvider::TencentMachineTranslation &&
+                    CandidateTranslationProviderAt(2) == CandidateTranslationProvider::DeepLX,
+                "The phrase-based providers moved out from under their stored indexes.");
+        require(CandidateTranslationProviderAt(99) == CandidateTranslationProvider::AccountModel,
+                "An unknown provider index did not fall back to the account model.");
+    }
 
     const auto dictionarySuffix = std::to_string(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     const std::filesystem::path dictionaryDirectory =

--- a/platforms/macos/tests/PreferencesWindowTests.mm
+++ b/platforms/macos/tests/PreferencesWindowTests.mm
@@ -727,6 +727,20 @@ int main()
                     shuangpinHelpcodeSchemaButton.enabled,
                 "The helpcode controls did not reflect the stored schemes and enabled state.");
 
+        // The account's own model leads the providers, since it is the one needing no keys of the
+        // user's own, and the language list reaches past the three the phrase services shipped with.
+        NSView *translationProviderView =
+            FindViewWithAccessibilityLabel(controller.window.contentView, @"候选翻译在线服务");
+        NSView *translationLanguageView =
+            FindViewWithAccessibilityLabel(controller.window.contentView, @"候选翻译目标语言");
+        require([translationProviderView isKindOfClass:[NSPopUpButton class]] &&
+                    [translationLanguageView isKindOfClass:[NSPopUpButton class]],
+                "The settings window did not expose the candidate translation controls.");
+        require([((NSPopUpButton *)translationProviderView).itemTitles.firstObject isEqualToString:@"水杉账号 AI"],
+                "The account model was not offered first among the translation providers.");
+        require([((NSPopUpButton *)translationLanguageView).itemTitles containsObject:@"西班牙语"],
+                "The translation languages did not reach past the three the services shipped with.");
+
         NSView *hudView = FindViewWithAccessibilityLabel(controller.window.contentView, @"切换中英文时显示提示");
         require([hudView isKindOfClass:[NSButton class]] && ((NSButton *)hudView).state == NSControlStateValueOn,
                 "The settings window did not reflect the stored input-mode badge preference.");


### PR DESCRIPTION
## Why

Candidate translation only worked through a service the user holds keys for — a Tencent secret pair, or a self-hosted DeepLX endpoint. That is a lot of setup for a gloss beside a candidate, and it is why the feature shipped switched off and stayed that way.

The backend already speaks an OpenAI-compatible `/v1/chat/completions`, and the account already holds a token for it. `BackendChatClient.swift` was simply never in `MSIME_ACCOUNT_SOURCES`, so the macOS target never compiled it.

## What

- `水杉账号 AI` leads the provider list. It needs no keys: signed in is enough.
- The page goes out as **one** request rather than a call per word. A model keeps a page consistent when it sees it at once, and the account pays per call rather than per candidate.
- The reply is asked for as a JSON object keyed by the words themselves, so a model that drops or reorders an entry still lands each translation against the right candidate instead of shifting the whole page. Entries that were not asked about, are empty, or run long enough to be an explanation rather than a gloss are dropped on the way in.
- A `@_cdecl` entry point cannot take an Objective-C block, so the answer returns as a notification — the controller already listens for several — carrying the generation it was asked under. A reply for a composition that has already moved on is dropped rather than drawn over the new one.
- Signed out, offline, or an unparseable reply leaves the strip exactly as it is. A candidate window is the wrong place to report a failed request.
- Languages reach past the three the phrase services shipped with: Spanish, French and German join English, Japanese and Korean. Each entry carries both a service code (`ES`) and the name a model reads (`Spanish`).
- The stored language and provider indexes are clamped rather than indexed into. The list has grown once and will again; a preference written by a later build must not send an earlier one reading past the table.

The Tencent and DeepLX paths are untouched and still selectable.

## Verification

- `ctest --test-dir build --output-on-failure` — 53/53
- New assertions cover the language table (English first, Spanish reachable, every entry carrying both a two-letter code and a model-readable name, out-of-range indexes clamped), the provider mapping including its fallback, and that the settings window offers the account model first and a language list that reaches past the original three
- Built and installed to `~/Library/Input Methods/`
