### PR TITLE
ci: run the text contracts on Linux and skip the matrix for prose

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,6 +1,6 @@
 name: CI (documentation)
 
-# The other half of ci.yml's paths-ignore. GitHub leaves a required status check that never reports in "Expected" and refuses the merge exactly as if it had failed -- the same trap quality.yml documents for a required job that skips -- so a workflow skipped by path filtering cannot satisfy main and develop's protection on its own. This workflow reports the same check names for the paths ci.yml ignores: the quality checks run for real because they are cheap and run on Linux, and the three macOS and iOS checks answer without taking a runner.
+# The other half of ci.yml's paths-ignore. GitHub leaves a required status check that never reports in "Expected" and refuses the merge exactly as if it had failed -- the same trap quality.yml documents for a required job that skips -- so a workflow skipped by path filtering cannot satisfy main and develop's protection on its own. This workflow reports the same check names for the paths ci.yml ignores: the quality and contract checks run for real because they are cheap and run on Linux, and the three macOS and iOS checks answer without taking a runner.
 #
 # The two path lists have to stay identical. GitHub Actions does not support YAML anchors, so ReleaseConfigurationTests compares them instead; a path ignored here but not there silently blocks every documentation pull request.
 
@@ -8,7 +8,10 @@ on:
   pull_request:
     paths:
       - CHANGELOG.md
+      - PRIVACY.md
       - README.en.md
+      - README.md
+      - docs/apple-platform-architecture.md
       - docs/backend-integration.md
       - docs/ios-distribution.md
       - docs/plans/**
@@ -18,7 +21,10 @@ on:
       - main
     paths:
       - CHANGELOG.md
+      - PRIVACY.md
       - README.en.md
+      - README.md
+      - docs/apple-platform-architecture.md
       - docs/backend-integration.md
       - docs/ios-distribution.md
       - docs/plans/**
@@ -35,6 +41,10 @@ permissions:
 jobs:
   quality:
     uses: ./.github/workflows/quality.yml
+
+  # The reason README.md and PRIVACY.md can be on the ignored list at all: this is the suite that asserts on them, and it needs neither a build nor a Mac.
+  contracts:
+    uses: ./.github/workflows/contracts.yml
 
   macos:
     # Same name as ci.yml's matrix leg, because the name is what branch protection requires.

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,57 @@
+name: CI (documentation)
+
+# The other half of ci.yml's paths-ignore. GitHub leaves a required status check that never reports in "Expected" and refuses the merge exactly as if it had failed -- the same trap quality.yml documents for a required job that skips -- so a workflow skipped by path filtering cannot satisfy main and develop's protection on its own. This workflow reports the same check names for the paths ci.yml ignores: the quality checks run for real because they are cheap and run on Linux, and the three macOS and iOS checks answer without taking a runner.
+#
+# The two path lists have to stay identical. GitHub Actions does not support YAML anchors, so ReleaseConfigurationTests compares them instead; a path ignored here but not there silently blocks every documentation pull request.
+
+on:
+  pull_request:
+    paths:
+      - CHANGELOG.md
+      - README.en.md
+      - docs/backend-integration.md
+      - docs/ios-distribution.md
+      - docs/plans/**
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - CHANGELOG.md
+      - README.en.md
+      - docs/backend-integration.md
+      - docs/ios-distribution.md
+      - docs/plans/**
+
+# merge_group is absent on purpose: ci.yml takes that event with no path filter at all, so the merge queue always gets the real matrix and never two workflows reporting one check name.
+
+concurrency:
+  group: ci-docs-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    uses: ./.github/workflows/quality.yml
+
+  macos:
+    # Same name as ci.yml's matrix leg, because the name is what branch protection requires.
+    name: macOS 15 ${{ matrix.architecture }}
+    strategy:
+      matrix:
+        architecture: [arm64, x86_64]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Report the macOS check for a documentation-only change
+        run: echo "No macOS source, build input or asserted document changed; ci.yml owns this check for every other path."
+
+  ios:
+    name: iOS Simulator
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Report the iOS check for a documentation-only change
+        run: echo "No iOS source, build input or asserted document changed; ci.yml owns this check for every other path."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,25 @@ on:
     branches:
       - develop
       - main
-    # Documentation no build step reads and no suite asserts on. A change confined to these paths held a macOS 15 x86_64 runner for the full iOS interface suite to prove nothing, and the release build on main queued behind it. ci-docs.yml answers for the required checks on exactly this list, so those pull requests stay mergeable.
+    # Prose that no build step compiles. A change confined to these paths held a macOS 15 x86_64 runner for the full iOS interface suite to prove nothing, and the release build on main queued behind it. ci-docs.yml answers for the required checks on exactly this list, so those pull requests stay mergeable, and it calls contracts.yml as well -- README.md, PRIVACY.md and the architecture document are asserted on by ReleaseConfigurationTests, and that suite runs on Linux, so ignoring them here keeps the assertions and drops only the matrix.
     #
-    # What is deliberately absent matters more than what is here: ReleaseConfigurationTests greps README.md, PRIVACY.md, LICENSE, THIRD_PARTY_NOTICES.txt and docs/apple-platform-architecture.md, and those assertions only run inside the macOS job's ctest. Editing one of them has to run the matrix that checks it. A new documentation file is not ignored until it is added here, which fails toward running CI.
+    # LICENSE and THIRD_PARTY_NOTICES.txt stay off the list on purpose: CMake installs them into the bundle, so they are build inputs rather than prose. A new documentation file is not ignored until someone adds it here, which fails toward running CI.
     paths-ignore:
       - CHANGELOG.md
+      - PRIVACY.md
       - README.en.md
+      - README.md
+      - docs/apple-platform-architecture.md
       - docs/backend-integration.md
       - docs/ios-distribution.md
       - docs/plans/**
   pull_request:
     paths-ignore:
       - CHANGELOG.md
+      - PRIVACY.md
       - README.en.md
+      - README.md
+      - docs/apple-platform-architecture.md
       - docs/backend-integration.md
       - docs/ios-distribution.md
       - docs/plans/**
@@ -42,6 +48,10 @@ permissions:
 jobs:
   quality:
     uses: ./.github/workflows/quality.yml
+
+  # Minutes into the run rather than after the macOS build that ctest waits for. The macOS job still runs the same suite through ctest, including the cases this one skips for want of Apple tooling.
+  contracts:
+    uses: ./.github/workflows/contracts.yml
 
   macos:
     name: macOS 15 ${{ matrix.architecture }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,22 @@ on:
     branches:
       - develop
       - main
+    # Documentation no build step reads and no suite asserts on. A change confined to these paths held a macOS 15 x86_64 runner for the full iOS interface suite to prove nothing, and the release build on main queued behind it. ci-docs.yml answers for the required checks on exactly this list, so those pull requests stay mergeable.
+    #
+    # What is deliberately absent matters more than what is here: ReleaseConfigurationTests greps README.md, PRIVACY.md, LICENSE, THIRD_PARTY_NOTICES.txt and docs/apple-platform-architecture.md, and those assertions only run inside the macOS job's ctest. Editing one of them has to run the matrix that checks it. A new documentation file is not ignored until it is added here, which fails toward running CI.
+    paths-ignore:
+      - CHANGELOG.md
+      - README.en.md
+      - docs/backend-integration.md
+      - docs/ios-distribution.md
+      - docs/plans/**
   pull_request:
+    paths-ignore:
+      - CHANGELOG.md
+      - README.en.md
+      - docs/backend-integration.md
+      - docs/ios-distribution.md
+      - docs/plans/**
   workflow_dispatch:
     inputs:
       mac_only:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,30 @@
+name: Repository contracts
+
+# ReleaseConfigurationTests almost entirely reads files in the tree and asserts on their text: README.md against the features it promises, the Info.plist keys, the release workflow's steps and ordering, the packaging scripts. None of that needs Apple tooling, yet ctest only reaches it after the macOS build, so a README claim that no longer matches the code was reported around forty minutes into a pull request and cost a macOS runner to say so.
+#
+# Called by both ci.yml and ci-docs.yml so it runs on every pull request, and so a change to the documents it asserts on can skip the matrix without losing the assertions. The cases that genuinely need tiffutil, sips or zsh carry a @requires guard and stay covered by the macOS job.
+
+on:
+  workflow_call:
+  # Lets the text contracts be re-run on their own, without dispatching the full matrix.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    name: Repository contracts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Not recursive: two cases read the Engine's punctuation contract and quanpin header, and the Engine's own submodules are hundreds of megabytes of audio dependencies that nothing here asserts on.
+          submodules: true
+          persist-credentials: false
+      - name: Install zsh
+        # test_release_scripts_have_valid_zsh_syntax and the packaging refusal case shell out to it. The runner image usually ships it; installing keeps the @requires guard from quietly skipping both on Linux.
+        run: command -v zsh >/dev/null || { sudo apt-get update && sudo apt-get install -y zsh; }
+      - name: Check the repository contracts
+        run: python3 platforms/macos/tests/ReleaseConfigurationTests.py

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -2,6 +2,7 @@ import json
 import os
 import plistlib
 import re
+import shutil
 import subprocess
 import unittest
 from pathlib import Path
@@ -9,6 +10,20 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 MACOS_ROOT = PROJECT_ROOT / "platforms" / "macos"
+
+
+def requires(*tools):
+    """Skip a case that shells out to tooling only macOS has.
+
+    Almost everything in this file reads a file in the tree and asserts on its text, which needs no
+    Apple tooling and no build. contracts.yml therefore runs the whole file on Linux, minutes into a
+    pull request instead of after the macOS build that ctest waits for. The handful of cases below
+    genuinely need tiffutil, sips or zsh, and the macOS job is where they still run -- this skip
+    narrows the Linux run, it does not move coverage off macOS.
+    """
+
+    missing = [tool for tool in tools if shutil.which(tool) is None]
+    return unittest.skipIf(missing, f"{', '.join(missing)} unavailable; the macOS job runs this case")
 
 
 class ReleaseConfigurationTests(unittest.TestCase):
@@ -78,9 +93,18 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual(ignored[0], ignored[1])
         self.assertEqual(answered, ignored, "ci-docs.yml must answer for exactly the paths ci.yml ignores")
 
-        # These are asserted on by this very file, and only the macOS job runs it. Ignoring one would let a documentation edit break a test that nothing re-runs until the next source change.
-        for asserted_document in ("README.md", "PRIVACY.md", "LICENSE", "THIRD_PARTY_NOTICES.txt", "docs/apple-platform-architecture.md"):
-            self.assertNotIn(asserted_document, ignored[0])
+        # README.md, PRIVACY.md and the architecture document are asserted on by this very file, so they can only be ignored while something that is not the macOS job still runs it. That something is contracts.yml, and both workflows have to call it: ci-docs.yml for the ignored paths, ci.yml for everything else.
+        contracts = (PROJECT_ROOT / ".github/workflows/contracts.yml").read_text()
+        self.assertIn("uses: ./.github/workflows/contracts.yml", ci)
+        self.assertIn("uses: ./.github/workflows/contracts.yml", docs)
+        self.assertIn("python3 platforms/macos/tests/ReleaseConfigurationTests.py", contracts)
+        self.assertIn("runs-on: ubuntu-24.04", contracts)
+        for asserted_document in ("README.md", "PRIVACY.md", "docs/apple-platform-architecture.md"):
+            self.assertIn(asserted_document, ignored[0])
+
+        # Build inputs, not prose: CMake installs both into the bundle.
+        for build_input in ("LICENSE", "THIRD_PARTY_NOTICES.txt"):
+            self.assertNotIn(build_input, ignored[0])
 
         # Branch protection requires check names, so the substitutes have to be named identically and must not spend a macOS runner to say nothing happened.
         for required_check in ("name: macOS 15 ${{ matrix.architecture }}", "name: iOS Simulator"):
@@ -114,6 +138,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
             f"{canonical_repository}/releases/latest/download/appcast.xml",
         )
 
+    @requires("tiffutil", "sips")
     def test_input_source_uses_a_dedicated_menu_icon(self):
         with (MACOS_ROOT / "resources/Info.plist").open("rb") as info_file:
             info = plistlib.load(info_file)
@@ -448,7 +473,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 action_reference = uses_line.removeprefix("uses:").strip().split()[0]
                 if action_reference.startswith("./"):
                     # Local reusable workflows are pinned by the caller's own commit.
-                    self.assertEqual(action_reference, "./.github/workflows/quality.yml")
+                    self.assertIn(action_reference, {"./.github/workflows/quality.yml", "./.github/workflows/contracts.yml"})
                     self.assertTrue((PROJECT_ROOT / action_reference).is_file())
                     continue
                 action, separator, revision = action_reference.partition("@")
@@ -944,6 +969,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("vendor/MetasequoiaImeEngine/helpcode/helpcodes", cmake)
         self.assertIn("Resources/helpcodes", cmake)
 
+    @requires("zsh")
     def test_release_scripts_have_valid_zsh_syntax(self):
         for relative_path in (
             "scripts/install-release.sh",
@@ -961,6 +987,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
 
+    @requires("zsh")
     def test_package_script_refuses_ambiguously_named_unsigned_assets(self):
         environment = os.environ.copy()
         for variable in (

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -53,7 +53,42 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertIn("cancel-in-progress: true", workflow)
         # merge-release-pr.sh dispatches ci.yml and waits on that run with --exit-status, so a pull_request run on the same branch must land in a different concurrency group or it cancels the release.
         self.assertIn("${{ github.event_name }}", workflow.split("concurrency:", 1)[1].split("permissions:", 1)[0])
-        self.assertIn("on:\n  push:\n    branches:\n      - develop\n      - main\n  pull_request:\n", workflow)
+        self.assertIn("on:\n  push:\n    branches:\n      - develop\n      - main\n", workflow)
+        self.assertIn("\n  pull_request:\n", workflow)
+
+    def test_documentation_paths_are_skipped_by_a_workflow_that_reports_the_same_checks(self):
+        ci = (PROJECT_ROOT / ".github/workflows/ci.yml").read_text()
+        docs = (PROJECT_ROOT / ".github/workflows/ci-docs.yml").read_text()
+
+        def path_lists(workflow, key):
+            lists = []
+            for block in workflow.split(f"{key}:\n")[1:]:
+                entries = []
+                for line in block.splitlines():
+                    if not line.startswith("      - "):
+                        break
+                    entries.append(line.removeprefix("      - "))
+                lists.append(entries)
+            return lists
+
+        ignored = path_lists(ci, "paths-ignore")
+        answered = path_lists(docs, "paths")
+        # push and pull_request each carry the list; GitHub Actions has no YAML anchors to share one.
+        self.assertEqual(len(ignored), 2)
+        self.assertEqual(ignored[0], ignored[1])
+        self.assertEqual(answered, ignored, "ci-docs.yml must answer for exactly the paths ci.yml ignores")
+
+        # These are asserted on by this very file, and only the macOS job runs it. Ignoring one would let a documentation edit break a test that nothing re-runs until the next source change.
+        for asserted_document in ("README.md", "PRIVACY.md", "LICENSE", "THIRD_PARTY_NOTICES.txt", "docs/apple-platform-architecture.md"):
+            self.assertNotIn(asserted_document, ignored[0])
+
+        # Branch protection requires check names, so the substitutes have to be named identically and must not spend a macOS runner to say nothing happened.
+        for required_check in ("name: macOS 15 ${{ matrix.architecture }}", "name: iOS Simulator"):
+            self.assertIn(required_check, ci)
+            self.assertIn(required_check, docs)
+        self.assertIn("architecture: [arm64, x86_64]", docs)
+        self.assertIn("uses: ./.github/workflows/quality.yml", docs)
+        self.assertNotIn("runs-on: macos", docs)
 
     def test_current_repository_links_use_the_canonical_apple_repository(self):
         canonical_repository = "https://github.com/metasequoiaime/MSIME-Apple"


### PR DESCRIPTION
## The problem

A pull request touching only prose holds a `macOS 15 x86_64` runner for the full iOS interface suite to prove nothing. This morning there were eight runs queued in this repository and none running, with the release build for `main` behind exactly that.

Underneath it is a second, larger waste that applies to every pull request: `ReleaseConfigurationTests` is almost entirely file reads and text assertions — `README.md` against the features it promises, the `Info.plist` keys, `release.yml`'s step order, the packaging scripts — and `ctest` only reaches it after the macOS build. A README claim that no longer matches the code was reported around forty minutes in, on a macOS runner, having waited for a compile it never needed.

## What changes

**`contracts.yml`** — the text contracts on `ubuntu-24.04`, called by both `ci.yml` and `ci-docs.yml`, so every pull request gets that answer in minutes. The macOS job still runs the same suite through `ctest`; nothing moved off macOS. Three cases genuinely need Apple tooling (`tiffutil` and `sips` for the menu icon's two pages, `zsh` for the release script syntax and the packaging refusal) and a `@requires` guard skips exactly those on Linux. Installing `zsh` there was tried and reverted: `apt-get update` on the runner spent 10m22s for a test step that ran in 0.042s, and the scripts those cases check carry a `#!/bin/zsh` shebang, so the macOS job is the honest place for them.

**`ci.yml`** — `paths-ignore` for prose no build step compiles: `CHANGELOG.md`, `PRIVACY.md`, `README.md`, `README.en.md`, `docs/apple-platform-architecture.md`, `docs/backend-integration.md`, `docs/ios-distribution.md`, `docs/plans/**`. `README.md` and friends can be on that list precisely because `contracts.yml` still asserts on them. `LICENSE` and `THIRD_PARTY_NOTICES.txt` stay off it: CMake installs them into the bundle, so they are build inputs rather than prose.

**`ci-docs.yml`** — the other half. The `main and develop protection` ruleset requires `macOS 15 arm64`, `macOS 15 x86_64`, `iOS Simulator`, `quality / Workflow validation` and `quality / Dependency review`. A required check that never reports stays in `Expected` and blocks the merge exactly as a failure would — the behaviour `quality.yml` already documents for a required job that skips — so path-filtering `ci.yml` alone would make every documentation pull request permanently unmergeable. This workflow answers with the same check names: `quality` and `contracts` run for real, the two macOS names and the iOS name report from `ubuntu-24.04`. `merge_group` is deliberately absent, since `ci.yml` takes that event with no path filter and the merge queue must always get the real matrix.

`release.yml` is untouched: `ReleaseAutomationTests.py:130` pins a documentation-only push to `main` to build both platforms, which is a separate decision from this one.

## Drift guard

GitHub Actions has no YAML anchors, so the path list exists in three copies. A new test compares them and asserts both workflows call `contracts.yml`, because a path ignored in `ci.yml` but missing from `ci-docs.yml` would silently block every documentation pull request, and an ignored document whose assertions no longer run anywhere would silently lose coverage.

## Verification

- All 22 cases in `ReleaseConfigurationTests` pass locally on macOS with the Engine submodule linked in, including the three guarded ones.
- `actionlint` clean on `ci.yml`, `ci-docs.yml` and `contracts.yml` at CI's `--severity=warning`.
- The drift guard was mutation-checked: adding `README.md` to `ci-docs.yml` alone makes it fail.
- The Linux run itself is verified by this pull request — it edits `.github/**`, so `ci.yml` runs in full and `contracts / Repository contracts` reports here.

## Not in this pull request

`contracts / Repository contracts` is not a required check. Adding it to the ruleset is a branch-protection change and yours to make; without it a red contract run does not block a merge.

