### PR TITLE
fix(macos): show each translation provider only what it asks for

### DIFF
--- a/platforms/macos/src/CandidateTranslationBridge.swift
+++ b/platforms/macos/src/CandidateTranslationBridge.swift
@@ -86,3 +86,11 @@ func translateCandidates(_ wordsJSON: UnsafePointer<CChar>, _ languageName: Unsa
   CandidateTranslationBridge.translate(words: words, languageName: String(cString: languageName),
                                        generation: generation)
 }
+
+// Whether an account is signed in, so the settings can say what a provider needs before anyone
+// turns it on. Reading the keychain is cheap and synchronous, and the token itself is not needed to
+// answer this much.
+@_cdecl("MSIMEBackendAccountSignedIn")
+func backendAccountSignedIn() -> Bool {
+  ((try? BackendKeychain().load()) ?? nil) != nil
+}

--- a/platforms/macos/src/PreferencesWindowController.mm
+++ b/platforms/macos/src/PreferencesWindowController.mm
@@ -1,4 +1,6 @@
 extern "C" void MSIMEShowBackendAccount(void);
+// Implemented in CandidateTranslationBridge.swift.
+extern "C" bool MSIMEBackendAccountSignedIn(void);
 
 #import "PreferencesWindowController.h"
 
@@ -10,6 +12,7 @@ extern "C" void MSIMEShowBackendAccount(void);
 #include "HelpcodeSchemaPreference.h"
 #include "InputControllerKeyRouting.h"
 #include "InputBehaviorPreferences.h"
+#include "CandidateTranslationLanguage.h"
 #include "InputSchemePreference.h"
 #import "CandidateSkinAppearance.h"
 #import "CandidateSkinPreviewView.h"
@@ -336,6 +339,8 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     NSView *_translationTencentIdRow;
     NSView *_translationTencentKeyRow;
     NSView *_translationEndpointRow;
+    NSView *_translationAccountRow;
+    NSTextField *_translationAccountLabel;
     MetasequoiaCandidatePreviewView *_candidatePreview;
     MetasequoiaSkinSettingsView *_skinSettings;
     NSButton *_candidateLearningButton;
@@ -1376,11 +1381,21 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     _translationTencentIdRow = PreferenceRow(@"腾讯云 SecretId", _translationSecretIdField);
     _translationTencentKeyRow = PreferenceRow(@"腾讯云 SecretKey", _translationSecretKeyField);
     _translationEndpointRow = PreferenceRow(@"DeepLX Endpoint", _translationEndpointField);
+    _translationAccountLabel = [NSTextField labelWithString:@""];
+    _translationAccountLabel.textColor = [NSColor secondaryLabelColor];
+    _translationAccountLabel.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+    _translationAccountLabel.accessibilityLabel = @"候选翻译账号状态";
+    _translationAccountRow = PreferenceRow(@"", _translationAccountLabel);
+    // The rows are addressed by label so the settings test can watch each provider reveal its own.
+    _translationTencentIdRow.accessibilityLabel = @"腾讯云 SecretId 行";
+    _translationTencentKeyRow.accessibilityLabel = @"腾讯云 SecretKey 行";
+    _translationEndpointRow.accessibilityLabel = @"DeepLX Endpoint 行";
+    _translationAccountRow.accessibilityLabel = @"候选翻译账号状态行";
     NSBox *translationCard = CardWithViews(
         @[
             _candidateTranslationButton, PreferenceRow(@"在线服务", _translationProviderButton),
-            PreferenceRow(@"目标语言", _translationLanguageButton), _translationTencentIdRow, _translationTencentKeyRow,
-            _translationEndpointRow
+            PreferenceRow(@"目标语言", _translationLanguageButton), _translationAccountRow, _translationTencentIdRow,
+            _translationTencentKeyRow, _translationEndpointRow
         ],
         8.0);
     NSView *shortcutsPage = PreferencesPage(@"快捷键", @"设置候选翻页与输入状态切换快捷键。", @[ shortcutCard ]);
@@ -2252,19 +2267,36 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
         MetasequoiaInputFlag(@"candidateTranslation") ? NSControlStateValueOn : NSControlStateValueOff;
     _cloudCandidatesButton.state =
         MetasequoiaInputFlag(@"cloudCandidates") ? NSControlStateValueOn : NSControlStateValueOff;
-    [_translationProviderButton selectItemAtIndex:MetasequoiaInputInteger(@"translationProvider", 0, 0, 1)];
-    [_translationLanguageButton selectItemAtIndex:MetasequoiaInputInteger(@"translationLanguage", 0, 0, 2)];
-    _translationProviderButton.enabled = _candidateTranslationButton.state == NSControlStateValueOn;
-    _translationLanguageButton.enabled = _candidateTranslationButton.state == NSControlStateValueOn;
-    const BOOL tencent = _translationProviderButton.indexOfSelectedItem == 0;
-    _translationSecretIdField.enabled = _candidateTranslationButton.state == NSControlStateValueOn && tencent;
-    _translationSecretKeyField.enabled = _candidateTranslationButton.state == NSControlStateValueOn && tencent;
-    _translationEndpointField.enabled = _candidateTranslationButton.state == NSControlStateValueOn && !tencent;
+    [_translationProviderButton
+        selectItemAtIndex:MetasequoiaInputInteger(@"translationProvider", 0, 0,
+                                                  _translationProviderButton.numberOfItems - 1)];
+    [_translationLanguageButton
+        selectItemAtIndex:MetasequoiaInputInteger(@"translationLanguage", 0, 0,
+                                                  _translationLanguageButton.numberOfItems - 1)];
+    const BOOL translating = _candidateTranslationButton.state == NSControlStateValueOn;
+    _translationProviderButton.enabled = translating;
+    _translationLanguageButton.enabled = translating;
+    // Each provider shows only what it needs: the account model asks for nothing, and leaving a
+    // vendor's key fields under it reads as though it wanted them.
+    const auto provider = metasequoia::mac::CandidateTranslationProviderAt(
+        static_cast<std::size_t>(_translationProviderButton.indexOfSelectedItem));
+    const BOOL tencent = provider == metasequoia::mac::CandidateTranslationProvider::TencentMachineTranslation;
+    const BOOL deeplx = provider == metasequoia::mac::CandidateTranslationProvider::DeepLX;
+    const BOOL accountModel = provider == metasequoia::mac::CandidateTranslationProvider::AccountModel;
+    _translationSecretIdField.enabled = translating && tencent;
+    _translationSecretKeyField.enabled = translating && tencent;
+    _translationEndpointField.enabled = translating && deeplx;
     _translationTencentIdRow.hidden = !tencent;
     _translationTencentKeyRow.hidden = !tencent;
-    _translationEndpointRow.hidden = tencent;
-    _translationSecretIdField.placeholderString = tencent ? @"SecretId（腾讯云）" : @"DeepLX 不需要 SecretId";
-    _translationSecretKeyField.placeholderString = tencent ? @"SecretKey（腾讯云）" : @"DeepLX 不需要 SecretKey";
+    _translationEndpointRow.hidden = !deeplx;
+    _translationAccountRow.hidden = !accountModel;
+    // Signed out is the one thing that stops this provider, and it stops it silently, so the card
+    // says so rather than leaving someone to wonder why nothing appears beside their candidates.
+    _translationAccountLabel.stringValue = MSIMEBackendAccountSignedIn()
+                                               ? @"使用已登录的水杉账号，无需填写密钥。"
+                                               : @"需要先登录水杉账号，否则候选旁不会出现译文。";
+    _translationSecretIdField.placeholderString = @"SecretId（腾讯云）";
+    _translationSecretKeyField.placeholderString = @"SecretKey（腾讯云）";
 }
 
 - (void)translationCredentialChanged:(NSTextField *)sender

--- a/platforms/macos/src/PreferencesWindowController.mm
+++ b/platforms/macos/src/PreferencesWindowController.mm
@@ -341,6 +341,7 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     NSView *_translationEndpointRow;
     NSView *_translationAccountRow;
     NSTextField *_translationAccountLabel;
+    NSButton *_translationAccountButton;
     MetasequoiaCandidatePreviewView *_candidatePreview;
     MetasequoiaSkinSettingsView *_skinSettings;
     NSButton *_candidateLearningButton;
@@ -1385,7 +1386,18 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     _translationAccountLabel.textColor = [NSColor secondaryLabelColor];
     _translationAccountLabel.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
     _translationAccountLabel.accessibilityLabel = @"候选翻译账号状态";
-    _translationAccountRow = PreferenceRow(@"", _translationAccountLabel);
+    // Signed out, the line that names the requirement also offers the way to meet it: the sign-in
+    // entry lives on another page, and a setting that names one without a route to it is how someone
+    // ends up hunting the settings for a button that was never on that page.
+    _translationAccountButton = [NSButton buttonWithTitle:@"登录…" target:self action:@selector(showBackendAccount:)];
+    _translationAccountButton.bezelStyle = NSBezelStyleRounded;
+    _translationAccountButton.accessibilityLabel = @"登录水杉账号";
+    NSStackView *translationAccountStatus =
+        [NSStackView stackViewWithViews:@[ _translationAccountLabel, _translationAccountButton ]];
+    translationAccountStatus.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+    translationAccountStatus.alignment = NSLayoutAttributeCenterY;
+    translationAccountStatus.spacing = 8.0;
+    _translationAccountRow = PreferenceRow(@"", translationAccountStatus);
     // The rows are addressed by label so the settings test can watch each provider reveal its own.
     _translationTencentIdRow.accessibilityLabel = @"腾讯云 SecretId 行";
     _translationTencentKeyRow.accessibilityLabel = @"腾讯云 SecretKey 行";
@@ -2292,9 +2304,10 @@ NSView *PreferencesPage(NSString *title, NSString *summary, NSArray<NSView *> *c
     _translationAccountRow.hidden = !accountModel;
     // Signed out is the one thing that stops this provider, and it stops it silently, so the card
     // says so rather than leaving someone to wonder why nothing appears beside their candidates.
-    _translationAccountLabel.stringValue = MSIMEBackendAccountSignedIn()
-                                               ? @"使用已登录的水杉账号，无需填写密钥。"
-                                               : @"需要先登录水杉账号，否则候选旁不会出现译文。";
+    const BOOL signedIn = MSIMEBackendAccountSignedIn();
+    _translationAccountLabel.stringValue =
+        signedIn ? @"使用已登录的水杉账号，无需填写密钥。" : @"需要先登录水杉账号，否则候选旁不会出现译文。";
+    _translationAccountButton.hidden = signedIn;
     _translationSecretIdField.placeholderString = @"SecretId（腾讯云）";
     _translationSecretKeyField.placeholderString = @"SecretKey（腾讯云）";
 }

--- a/platforms/macos/tests/PreferencesWindowTests.mm
+++ b/platforms/macos/tests/PreferencesWindowTests.mm
@@ -741,6 +741,37 @@ int main()
         require([((NSPopUpButton *)translationLanguageView).itemTitles containsObject:@"西班牙语"],
                 "The translation languages did not reach past the three the services shipped with.");
 
+        // Each provider shows only what it needs. Leaving a vendor's key fields under the account
+        // model reads as though it wanted them, which is how this shipped the first time.
+        NSPopUpButton *translationProviderButton = (NSPopUpButton *)translationProviderView;
+        NSView *tencentIdRow = FindViewWithAccessibilityLabel(controller.window.contentView, @"腾讯云 SecretId 行");
+        NSView *endpointRow = FindViewWithAccessibilityLabel(controller.window.contentView, @"DeepLX Endpoint 行");
+        NSView *accountStatus = FindViewWithAccessibilityLabel(controller.window.contentView, @"候选翻译账号状态行");
+        require(tencentIdRow != nil && endpointRow != nil && accountStatus != nil,
+                "The translation card did not expose a row for each provider's requirements.");
+        const auto rowHidden = [](NSView *view) { return view.hidden; };
+        for (NSInteger index = 0; index < translationProviderButton.numberOfItems; ++index)
+        {
+            [translationProviderButton selectItemAtIndex:index];
+            require([NSApp sendAction:translationProviderButton.action
+                                   to:translationProviderButton.target
+                                 from:translationProviderButton],
+                    "Choosing a translation provider was not acted on.");
+            const BOOL account = index == 0;
+            const BOOL tencent = index == 1;
+            const BOOL deeplx = index == 2;
+            require(rowHidden(tencentIdRow) == !tencent,
+                    "The Tencent credential rows did not follow the chosen provider.");
+            require(rowHidden(endpointRow) == !deeplx, "The DeepLX endpoint row did not follow the chosen provider.");
+            require(rowHidden(accountStatus) == !account,
+                    "The account status line did not follow the chosen provider.");
+        }
+        [translationProviderButton selectItemAtIndex:0];
+        require([NSApp sendAction:translationProviderButton.action
+                               to:translationProviderButton.target
+                             from:translationProviderButton],
+                "Restoring the account provider was not acted on.");
+
         NSView *hudView = FindViewWithAccessibilityLabel(controller.window.contentView, @"切换中英文时显示提示");
         require([hudView isKindOfClass:[NSButton class]] && ((NSButton *)hudView).state == NSControlStateValueOn,
                 "The settings window did not reflect the stored input-mode badge preference.");

--- a/platforms/macos/tests/PreferencesWindowTests.mm
+++ b/platforms/macos/tests/PreferencesWindowTests.mm
@@ -766,6 +766,15 @@ int main()
             require(rowHidden(accountStatus) == !account,
                     "The account status line did not follow the chosen provider.");
         }
+        // Signed out, the row also carries the way to sign in: the entry lives on another page, and
+        // naming a requirement without a route to it is how this sent someone hunting for a button
+        // that was never on that page.
+        NSView *signInView = FindViewWithAccessibilityLabel(controller.window.contentView, @"登录水杉账号");
+        require([signInView isKindOfClass:[NSButton class]],
+                "The account provider named a requirement without offering the way to meet it.");
+        require(((NSButton *)signInView).target != nil && ((NSButton *)signInView).action != nullptr,
+                "The sign-in button was not wired to anything.");
+
         [translationProviderButton selectItemAtIndex:0];
         require([NSApp sendAction:translationProviderButton.action
                                to:translationProviderButton.target


### PR DESCRIPTION
Follow-up to #413, from trying it in the settings window.

## Each provider now shows only what it asks for

Choosing `水杉账号 AI` left two Tencent key fields sitting under it — it reads as though the account model wanted a vendor's credentials, when the whole point of it is that it needs none.

The card was written for two providers and decided what to show with `indexOfSelectedItem == 0`. Inserting the account model at the front made that test point at the wrong provider.

Two more of the same slip were in there:

- the provider index was still clamped to `0...1`, so **DeepLX could not be selected at all**
- the language index to `0...2`, so **choosing Spanish and reopening settings landed back on English**

Both now clamp to what the control actually holds, so the next provider or language added does not need this remembering.

## Signed out no longer looks like a broken feature

Being signed out is the one thing that stops the account provider, and it stops it silently: the request returns without a token and the strip stays as it was. The card now says which it is —

- 使用已登录的水杉账号，无需填写密钥。
- 需要先登录水杉账号，否则候选旁不会出现译文。

`MSIMEBackendAccountSignedIn` reads the keychain synchronously; the token itself is not needed to answer that much.

## Verification

- `ctest --test-dir build --output-on-failure` — 53/53
- The settings test now walks every provider in turn and asserts the Tencent rows, the DeepLX row and the account line each appear for exactly one of them — the case that shipped broken
- Built and installed to `~/Library/Input Methods/`
