### PR TITLE
feat(ios): let the keyboard produce English, and give nine-key its own digits

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -54,6 +54,15 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var handwritingActionHeight: NSLayoutConstraint?
   private var layoutPicker: KeyboardLayoutPickerView?
   private var candidatePanel: KeyboardCandidatePanelView?
+  private var nineKeyHoldPopup: UIView?
+  // 九键网格的按键。按 123 时同一批键改显数字,而不是换成 26 键那排符号。
+  private struct NineKeyGridKey {
+    let button: UIButton
+    let digit: Int
+    let letters: String?
+    let numberHint: UILabel?
+  }
+  private var nineKeyGridKeys: [NineKeyGridKey] = []
   private var moreMenu: UIMenu?
   private let dismissShortcut = UIButton()
   private var letterButtons: [(button: UIButton, lowercase: String, hint: UILabel)] = []
@@ -371,17 +380,23 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     nineKeyGrid.spacing = 7
     nineKeyGrid.distribution = .fillEqually
     nineKeyContainer.addArrangedSubview(nineKeyGrid)
-    let groups = [["1", "ABC", "DEF"], ["GHI", "JKL", "MNO"], ["PQRS", "TUV", "WXYZ"]]
-    for (rowIndex, lettersInRow) in groups.enumerated() {
+    // Keys 2-9 read their letters from nineKeyLetters, which the hold gesture below also reads, so
+    // the printed legend and what a hold offers cannot drift apart. Key 1 carries no letters.
+    for rowIndex in 0..<3 {
       let row = makeRow()
-      for (column, letters) in lettersInRow.enumerated() {
+      for column in 0..<3 {
         let digit = rowIndex * 3 + column + 1
+        let letters = Self.nineKeyLetters[digit]
         let button = makeKey(
-          title: digit == 1 ? "分词" : letters,
-          accessibilityLabel: digit == 1 ? "拼音分词" : "\(digit) \(letters)"
+          title: letters ?? "分词",
+          accessibilityLabel: letters.map { "\(digit) \($0)" } ?? "拼音分词"
         ) { [weak self] in
-          if digit == 1 { self?.handleCharacter("'") }
-          else { self?.handleCharacter(String(digit)) }
+          guard let self else { return }
+          // While the digit layer is up these keys are a numeric keypad, so they output the digit
+          // instead of feeding it to the pinyin session.
+          if showsSymbols { handleSymbol(String(digit)) }
+          else if letters == nil { handleCharacter("'") }
+          else { handleCharacter(String(digit)) }
         }
         button.accessibilityIdentifier = "nineKey\(digit)"
         if var configuration = button.configuration {
@@ -396,8 +411,10 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
         }
         button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.titleLabel?.minimumScaleFactor = 0.7
-        if digit != 1 {
+        var numberHint: UILabel?
+        if let letters {
           let number = UILabel()
+          numberHint = number
           number.text = String(digit)
           number.font = .systemFont(ofSize: 10)
           number.textColor = KeyboardSkinPreference.selected.accent
@@ -409,7 +426,16 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
             number.topAnchor.constraint(equalTo: button.topAnchor, constant: 3),
             number.centerXAnchor.constraint(equalTo: button.centerXAnchor),
           ])
+          // 长按取这个键上印着的数字和字母。九键把 2-9 当拼音输入,单个字母和数字本身没有入口,
+          // 长按是它们唯一的来路。
+          button.tag = digit
+          let hold = UILongPressGestureRecognizer(target: self, action: #selector(handleNineKeyHold(_:)))
+          hold.minimumPressDuration = 0.3
+          button.addGestureRecognizer(hold)
+          button.accessibilityHint = "长按输入 \(digit) 或 \(letters)"
         }
+        nineKeyGridKeys.append(
+          NineKeyGridKey(button: button, digit: digit, letters: letters, numberHint: numberHint))
         row.addArrangedSubview(button)
       }
       nineKeyGrid.addArrangedSubview(row)
@@ -438,6 +464,109 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     nineKeyContainer.addArrangedSubview(controls)
     controls.widthAnchor.constraint(equalTo: sidebar.widthAnchor).isActive = true
     return nineKeyContainer
+  }
+
+  /// 九键网格在拼音键面与数字键面之间切换。
+  ///
+  /// The same buttons carry both layers: the grid geometry a nine-key user picked is what the digit
+  /// layer should keep, and rebuilding a second grid would leave two sources for the key legends.
+  private func applyNineKeyDigitLayer(_ digits: Bool) {
+    for key in nineKeyGridKeys {
+      key.button.configuration?.title = digits ? String(key.digit) : (key.letters ?? "分词")
+      key.button.accessibilityLabel =
+        digits
+        ? "数字 \(key.digit)"
+        : (key.letters.map { "\(key.digit) \($0)" } ?? "拼音分词")
+      // The corner hint names the digit a letter key also types; on the digit layer the face is
+      // already the digit, so it would just print it twice.
+      key.numberHint?.isHidden = digits
+      key.button.accessibilityHint = digits ? nil : key.letters.map { "长按输入 \(key.digit) 或 \($0)" }
+    }
+  }
+
+  private static let nineKeyLetters: [Int: String] = [
+    2: "ABC", 3: "DEF", 4: "GHI", 5: "JKL", 6: "MNO", 7: "PQRS", 8: "TUV", 9: "WXYZ",
+  ]
+
+  @objc private func handleNineKeyHold(_ gesture: UILongPressGestureRecognizer) {
+    guard gesture.state == .began, let key = gesture.view as? UIButton,
+      let letters = Self.nineKeyLetters[key.tag]
+    else { return }
+    showNineKeyHoldOptions(from: key, digit: key.tag, letters: letters)
+  }
+
+  private func showNineKeyHoldOptions(from key: UIButton, digit: Int, letters: String) {
+    dismissNineKeyHoldOptions()
+    playInputClick()
+    let skin = KeyboardSkinPreference.selected
+    // A full-surface backdrop so a tap anywhere else dismisses the row instead of typing.
+    let backdrop = UIView()
+    backdrop.accessibilityIdentifier = "nineKeyHoldBackdrop"
+    backdrop.backgroundColor = .clear
+    backdrop.translatesAutoresizingMaskIntoConstraints = false
+    backdrop.addGestureRecognizer(
+      UITapGestureRecognizer(target: self, action: #selector(dismissNineKeyHoldOptionsGesture)))
+
+    let options = UIStackView()
+    options.axis = .horizontal
+    options.spacing = 4
+    options.distribution = .fillEqually
+    options.accessibilityIdentifier = "nineKeyHoldOptions"
+    options.backgroundColor = skin.background
+    options.layer.cornerRadius = 10
+    options.layer.borderWidth = 1
+    options.layer.borderColor = skin.accent.withAlphaComponent(0.3).cgColor
+    options.isLayoutMarginsRelativeArrangement = true
+    options.layoutMargins = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
+    options.translatesAutoresizingMaskIntoConstraints = false
+
+    for option in [String(digit)] + letters.lowercased().map(String.init) {
+      let item = makeKey(title: option, accessibilityLabel: "输入 \(option)") { [weak self] in
+        self?.commitNineKeyHoldOption(option)
+      }
+      item.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+      item.accessibilityIdentifier = "nineKeyHoldOption-\(option)"
+      item.widthAnchor.constraint(equalToConstant: 36).isActive = true
+      item.heightAnchor.constraint(equalToConstant: 38).isActive = true
+      options.addArrangedSubview(item)
+    }
+
+    view.addSubview(backdrop)
+    backdrop.addSubview(options)
+    // Centring on the key yields to the edge insets, so the row stays inside the keyboard when the
+    // held key is in the first or last column.
+    let centred = options.centerXAnchor.constraint(equalTo: key.centerXAnchor)
+    centred.priority = .defaultHigh
+    NSLayoutConstraint.activate([
+      backdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      backdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      backdrop.topAnchor.constraint(equalTo: view.topAnchor),
+      backdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+      options.bottomAnchor.constraint(equalTo: key.topAnchor, constant: -6),
+      centred,
+      options.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 6),
+      options.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -6),
+    ])
+    nineKeyHoldPopup = backdrop
+    UIAccessibility.post(notification: .layoutChanged, argument: options)
+  }
+
+  private func commitNineKeyHoldOption(_ text: String) {
+    playInputClick()
+    // The letter or digit is output, not pinyin input, so an open composition is committed first
+    // rather than having the character appended to it.
+    render(session.finishComposition())
+    insertOwnText(text)
+    dismissNineKeyHoldOptions()
+  }
+
+  @objc private func dismissNineKeyHoldOptionsGesture() {
+    dismissNineKeyHoldOptions()
+  }
+
+  private func dismissNineKeyHoldOptions() {
+    nineKeyHoldPopup?.removeFromSuperview()
+    nineKeyHoldPopup = nil
   }
 
   private func makeCandidateStrip() -> UIView {
@@ -809,10 +938,16 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private func makeSymbolRow(_ symbols: [String]) -> UIStackView {
     let row = makeRow()
     for symbol in symbols {
-      row.addArrangedSubview(
-        makeKey(title: symbol, accessibilityLabel: "符号 \(symbol)") { [weak self] in
-          self?.handleSymbol(symbol)
-        })
+      let key = makeKey(title: symbol, accessibilityLabel: "符号 \(symbol)") { [weak self] in
+        self?.handleSymbol(symbol)
+      }
+      // Ten keys to a row leave about 32pt each, and the plain configuration's default 12pt on each
+      // side leaves 8pt for a glyph that needs 12. The title line break mode is byClipping, so the
+      // shortfall took the right-hand third off every digit rather than shrinking it. The letter
+      // rows already zero this; the symbol rows never did. Row spacing is fillEqually, so the keys
+      // keep their size and only the glyph gains the room.
+      key.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+      row.addArrangedSubview(key)
     }
     return row
   }
@@ -1225,6 +1360,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     _ = session.setLearningEnabled(DictionaryLearningPreference.enabled)
     _ = session.setFuzzyPinyinRules(FuzzyPinyinPreference.activeRules)
     session.setWubiMixedPinyin(WubiMixedPinyinPreference.isEnabled)
+    _ = session.setEnglishMixedCandidates(EnglishMixedCandidatesPreference.isEnabled)
   }
 
   private func applyInputScheme() -> MetasequoiaInputSnapshot {
@@ -1667,13 +1803,19 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     if writes { handwriting.activate() }
     handwritingActionHeight?.isActive = writes
     letterRowViews.forEach { $0.isHidden = showsSymbols || nineKey || writes || kana }
-    nineKeyContainer.isHidden = showsSymbols || !nineKey
-    nineKeyRows.forEach { $0.isHidden = showsSymbols || !nineKey }
+    // Nine-key keeps its own grid for the digit layer rather than handing over to the 26-key symbol
+    // rows, which would put a ten-across keypad under a keyboard the user chose for three columns.
+    let nineKeyDigits = nineKey && showsSymbols
+    nineKeyContainer.isHidden = !nineKey
+    nineKeyRows.forEach { $0.isHidden = !nineKey }
+    applyNineKeyDigitLayer(nineKeyDigits)
     let hasSpellings = !session.nineKeySpellings().isEmpty
     spellingScrollView.isHidden = !hasSpellings
     punctuationStack.isHidden = hasSpellings
     if actionRow != nil {
-      let usesNineKeyLayout = nineKey && !showsSymbols
+      // The digit layer keeps the same grid, so the action row keeps its nine-key arrangement and
+      // the grid keeps its height; only the key legends change.
+      let usesNineKeyLayout = nineKey
       nineKeyHeight.isActive = usesNineKeyLayout
       let globeIndex = usesNineKeyLayout ? 5 : 2
       if actionRow.arrangedSubviews.firstIndex(of: actionGlobeButton) != globeIndex {
@@ -1707,7 +1849,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       symbolDeleteWidth?.isActive = showsSymbols
       NSLayoutConstraint.activate(usesNineKeyLayout ? nineKeyActionWidths : standardActionWidths)
     }
-    symbolRowViews.forEach { $0.isHidden = !showsSymbols }
+    symbolRowViews.forEach { $0.isHidden = !showsSymbols || (isChineseMode && inputScheme == .nineKey && !session.isInLocalMode) }
     for (row, height) in standardRowHeights { height.isActive = !row.isHidden }
     if var configuration = layoutToggleButton?.configuration {
       configuration.title = showsSymbols ? (kana ? "あいう" : (nineKey ? "九键" : "ABC")) : "123"
@@ -2267,6 +2409,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   }
 
   private func closeKeyboardPicker() {
+    dismissNineKeyHoldOptions()
     if let panel = candidatePanel {
       panel.removeFromSuperview()
       candidatePanel = nil

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -403,6 +403,61 @@ final class NineKeyKeyboardTests: XCTestCase {
     }
   }
 
+  func testNineKeysCarryTheirLettersAndAHoldGesture() throws {
+    let previousScheme = InputSchemePreference.scheme
+    defer { InputSchemePreference.scheme = previousScheme }
+    InputSchemePreference.scheme = .nineKey
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 390, height: 292)
+
+    // Nine-key treats 2-9 as pinyin, so a bare letter or digit has no other way in than a hold.
+    let expected = [2: "ABC", 3: "DEF", 4: "GHI", 5: "JKL", 6: "MNO", 7: "PQRS", 8: "TUV", 9: "WXYZ"]
+    for (digit, letters) in expected {
+      let key = try button("nineKey\(digit)", in: controller)
+      XCTAssertEqual(key.configuration?.title, letters, "九键 \(digit) 的键面字母")
+      XCTAssertEqual(key.tag, digit, "长按要靠 tag 认出是哪个键")
+      let holds = (key.gestureRecognizers ?? []).compactMap { $0 as? UILongPressGestureRecognizer }
+      XCTAssertEqual(holds.count, 1, "九键 \(digit) 需要且只需要一个长按手势")
+    }
+
+    // The word-split key carries no letters, so it offers nothing to hold for.
+    let split = try button("nineKey1", in: controller)
+    XCTAssertEqual(split.configuration?.title, "分词")
+    XCTAssertTrue(
+      (split.gestureRecognizers ?? []).compactMap { $0 as? UILongPressGestureRecognizer }.isEmpty,
+      "分词键不该有长按手势")
+  }
+
+  func testNineKeyDigitLayerKeepsTheGridInsteadOfTheTwentySixKeyRows() throws {
+    let previousScheme = InputSchemePreference.scheme
+    defer { InputSchemePreference.scheme = previousScheme }
+    InputSchemePreference.scheme = .nineKey
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 390, height: 292)
+
+    XCTAssertEqual(try button("nineKey2", in: controller).configuration?.title, "ABC")
+    try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
+    controller.view.layoutIfNeeded()
+
+    // The grid stays and re-labels itself; handing over to the ten-across symbol rows is what this
+    // guards against, because a nine-key user chose three columns.
+    XCTAssertFalse(controller.view.subviews.isEmpty)
+    for digit in 1...9 {
+      XCTAssertEqual(try button("nineKey\(digit)", in: controller).configuration?.title, String(digit),
+                     "数字键面上九键 \(digit) 应显示数字")
+    }
+    let symbolDigits = descendants(controller.view).filter {
+      $0.accessibilityLabel == "符号 1" && !($0.superview?.isHidden ?? true)
+    }
+    XCTAssertTrue(symbolDigits.isEmpty, "九键的数字键面不应显示 26 键那排符号")
+
+    try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
+    controller.view.layoutIfNeeded()
+    XCTAssertEqual(try button("nineKey2", in: controller).configuration?.title, "ABC", "退出数字键面要恢复字母")
+  }
+
   func testKeyboardSettingsReplaceLayoutCardsAndVoiceIsIndependent() throws {
     let previousScheme = InputSchemePreference.scheme
     defer { InputSchemePreference.scheme = previousScheme }

--- a/platforms/ios/SharedUI/EnglishMixedCandidatesPreference.swift
+++ b/platforms/ios/SharedUI/EnglishMixedCandidatesPreference.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// 中文输入时是否把英文词混进候选。
+///
+/// On by default: typing latin letters on the Chinese keyboard and getting only Chinese back reads
+/// as the keyboard being unable to produce English at all. The Engine keeps the cost low on its own
+/// -- it only consults the English dictionary for an all-lowercase prefix of at least two letters,
+/// under Quanpin or Shuangpin -- so a Chinese composition that happens to be spelled in letters is
+/// unaffected unless the dictionary actually holds the word.
+enum EnglishMixedCandidatesPreference {
+  static let enabledKey = "english.mixedCandidates"
+  static var defaults: UserDefaults {
+    UserDefaults(suiteName: InputSchemePreference.appGroupIdentifier) ?? .standard
+  }
+
+  static var isEnabled: Bool {
+    get { defaults.object(forKey: enabledKey) as? Bool ?? true }
+    set { defaults.set(newValue, forKey: enabledKey) }
+  }
+}

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -1110,6 +1110,27 @@ final class OnboardingUITests: XCTestCase {
   }
 
   @MainActor
+  func testNineKeySchemeSurvivesRelaunch() {
+    let app = XCUIApplication()
+    app.launchArguments = ["-hasCompletedOnboarding", "YES"]
+    app.launch()
+    defer { restoreSchemeVisibility(in: app) }
+    app.buttons["inputSettingsLink"].tap()
+    let nine = app.switches["enabledInputScheme_nineKey"]
+    XCTAssertTrue(nine.waitForExistence(timeout: 5))
+    if nine.value as? String == "0" { nine.tap() }
+    XCTAssertTrue(wait(nine, until: "value == '1'"))
+    app.buttons["inputScheme_nineKey"].tap()
+    XCTAssertEqual(app.buttons["inputScheme_nineKey"].value as? String, "已选择")
+    app.terminate()
+    app.launch()
+    app.buttons["inputSettingsLink"].tap()
+    XCTAssertTrue(app.buttons["inputScheme_nineKey"].waitForExistence(timeout: 5))
+    XCTAssertEqual(app.buttons["inputScheme_nineKey"].value as? String, "已选择",
+                   "九键在重新启动后必须仍是选中的方案")
+  }
+
+  @MainActor
   func testInputSchemeVisibilityPersistsAndFallsBack() {
     let app = XCUIApplication()
     app.launchArguments = ["-hasCompletedOnboarding", "YES"]

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -12,14 +12,16 @@ class InputSessionAdapter::Impl
   public:
     explicit Impl(const RuntimePaths &runtime_paths, SchemeType scheme = SchemeType::Quanpin,
                   std::string profile = "xiaohe", bool learning = false, std::uint32_t fuzzy = 0,
-                  FrequencyAdjustmentOptions frequency = {FrequencyAdjustmentMode::Promote, 1, 1})
-        : paths{runtime_paths}, session{MakeOptions(paths, scheme, profile, learning, fuzzy, frequency)},
+                  FrequencyAdjustmentOptions frequency = {FrequencyAdjustmentMode::Promote, 1, 1},
+                  bool english_mixed = false)
+        : paths{runtime_paths}, session{MakeOptions(paths, scheme, profile, learning, fuzzy, frequency, english_mixed)},
           profile_name{std::move(profile)}
     {
     }
 
     static SessionOptions MakeOptions(const RuntimePaths &paths, SchemeType scheme, const std::string &profile,
-                                      bool learning, std::uint32_t fuzzy, FrequencyAdjustmentOptions frequency)
+                                      bool learning, std::uint32_t fuzzy, FrequencyAdjustmentOptions frequency,
+                                      bool english_mixed)
     {
         SessionOptions session_options;
         session_options.paths = paths;
@@ -33,6 +35,9 @@ class InputSessionAdapter::Impl
         session_options.learning = learning;
         session_options.fuzzy_pinyin.rules = fuzzy;
         session_options.frequency = learning ? frequency : FrequencyAdjustmentOptions{};
+        // Mixes English words into the Chinese candidates. The Engine keeps its own guards: Quanpin
+        // and Shuangpin only, an all-lowercase prefix, and at least english.minimum_prefix letters.
+        session_options.english.mixed_candidates = english_mixed;
         // The iOS product ships the locked main, English and expressive databases.
         LocalModeOptions options;
         options.unicode = true;
@@ -80,14 +85,14 @@ InputSessionAdapter::InputSessionAdapter() : InputSessionAdapter(RuntimePaths::l
 
 InputSessionAdapter::InputSessionAdapter(const RuntimePaths &paths)
     : impl_(std::make_unique<Impl>(paths, SchemeType::Quanpin, "xiaohe", learning_enabled_, fuzzy_pinyin_rules_,
-                                   frequency_))
+                                   frequency_, english_mixed_candidates_))
 {
 }
 
 void InputSessionAdapter::replace_session(SchemeType scheme, std::string profile, bool nine_key)
 {
     impl_ = std::make_unique<Impl>(impl_->paths, scheme, std::move(profile), learning_enabled_, fuzzy_pinyin_rules_,
-                                   frequency_);
+                                   frequency_, english_mixed_candidates_);
     impl_->nine_key = nine_key;
     impl_->session.set_nine_key_enabled(nine_key);
     impl_->session.set_wubi_mixed_pinyin(wubi_mixed_pinyin_);
@@ -188,6 +193,24 @@ void InputSessionAdapter::set_wubi_mixed_pinyin(bool enabled)
         return;
     wubi_mixed_pinyin_ = enabled;
     impl_->session.set_wubi_mixed_pinyin(enabled);
+}
+
+bool InputSessionAdapter::set_english_mixed_candidates(bool enabled)
+{
+    if (enabled == english_mixed_candidates_)
+        return true;
+    // The Engine takes this through SessionOptions, so the session is rebuilt rather than retuned.
+    const auto current = impl_->session.snapshot();
+    if (!current.preedit.empty() || current.local_mode != LocalInputMode::None)
+        return false;
+    english_mixed_candidates_ = enabled;
+    replace_session(current.scheme, impl_->profile_name, impl_->nine_key);
+    return true;
+}
+
+bool InputSessionAdapter::english_mixed_candidates() const
+{
+    return english_mixed_candidates_;
 }
 
 bool InputSessionAdapter::set_fuzzy_pinyin_rules(std::uint32_t rules)

--- a/shared/apple-bridge/InputSessionAdapter.h
+++ b/shared/apple-bridge/InputSessionAdapter.h
@@ -76,6 +76,12 @@ class InputSessionAdapter
     bool set_frequency_adjustment(FrequencyAdjustmentOptions options);
     FrequencyAdjustmentOptions frequency_adjustment() const;
     void set_wubi_mixed_pinyin(bool enabled);
+    // Offers words from the packaged English dictionary alongside the Chinese candidates, so a latin
+    // word can be committed without leaving the Chinese keyboard. The Engine applies this to Quanpin
+    // and Shuangpin only, and only to an all-lowercase prefix. Returns false during composition,
+    // like the other options the Engine reads from SessionOptions.
+    bool set_english_mixed_candidates(bool enabled);
+    bool english_mixed_candidates() const;
     RuntimePaths runtime_paths() const;
     bool idle() const;
     PersonalDictionaryEditResult edit_personal_word(const std::optional<PersonalDictionaryEntry> &previous,
@@ -105,6 +111,7 @@ class InputSessionAdapter
     std::uint32_t fuzzy_pinyin_rules_ = 0;
     FrequencyAdjustmentOptions frequency_{FrequencyAdjustmentMode::Promote, 1, 1};
     bool wubi_mixed_pinyin_ = false;
+    bool english_mixed_candidates_ = false;
     std::unique_ptr<Impl> impl_;
 };
 } // namespace metasequoia::apple

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.h
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.h
@@ -55,6 +55,7 @@ typedef NS_ENUM(NSInteger, MetasequoiaFrequencyAdjustmentMode) {
                       triggerCount:(NSInteger)triggerCount
                         linearStep:(NSInteger)linearStep;
 - (void)setWubiMixedPinyin:(BOOL)enabled;
+- (BOOL)setEnglishMixedCandidates:(BOOL)enabled;
 - (BOOL)suspendDictionarySession;
 - (BOOL)resumeDictionarySessionWithError:(NSError **)error NS_SWIFT_NAME(resumeDictionarySession());
 // Call on the session-owning thread. This token describes the current logical

--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -429,6 +429,11 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
     _adapter->set_wubi_mixed_pinyin(enabled);
 }
 
+- (BOOL)setEnglishMixedCandidates:(BOOL)enabled
+{
+    return _adapter->set_english_mixed_candidates(enabled);
+}
+
 - (BOOL)setLearningEnabled:(BOOL)enabled
 {
     _requestedLearning = enabled;


### PR DESCRIPTION
## Summary

Four things the Chinese keyboard could not do, all reported against a simulator build.

- **English words now appear among the Chinese candidates.** Typing `ios` returned only Chinese. The Engine has carried this the whole time as `EnglishInputOptions::mixed_candidates`, and `set_english_input_options` had never been called anywhere under `platforms/` or `shared/` **on either platform**, leaving it at its default of `false`. It reaches the Engine through `SessionOptions` rather than a setter, so the adapter rebuilds its session the way it already does for the fuzzy pinyin rules and reports `false` while a composition is open. On by default.
- **Holding a nine-key types a letter or a digit.** Nine-key treats 2-9 as pinyin, so the letters printed on those keys had no way in. A 0.3s hold raises the row the key is printed with; picking one commits any open composition first, because this is output rather than pinyin input.
- **The digit layer keeps the nine-key grid.** Pressing `123` hid the grid and handed the surface to the 26-key symbol rows, putting a ten-across keypad under a keyboard chosen for three columns. The grid now relabels itself to 1-9 and a tap outputs the digit.
- **The digit and symbol keys get their glyphs back.** Their titles ran through the plain configuration's default 12pt side insets, leaving about 8pt of a 32pt key for a glyph needing 12. With `titleLineBreakMode = .byClipping` every digit lost the right third of its shape instead of shrinking, so `0` read as `(` and `@` as a bare left arc.

## Notes

The Engine guards the English candidates on its own once the option is on: Quanpin and Shuangpin only, an all-lowercase prefix, at least `minimum_prefix` letters, and five words from the packaged English dictionary with the first placed second in the list. A composition spelled in letters is untouched unless the dictionary holds the word.

The key legends and the hold gesture now read from one `nineKeyLetters` table. They were separate literals, which would have let the printed face and what a hold offers drift apart.

The symbol-key inset fix is deliberately scoped to `makeSymbolRow`. Row distribution is `fillEqually`, so zeroing the horizontal insets changes no key's size; the action row uses `.fill` and is left alone.

**macOS is unchanged.** `InputSessionAdapter` is shared, and macOS has the same never-enabled English candidates, but turning it on there is a separate product call.

## Verification

- `scripts/format.sh --check` clean; simulator build succeeds
- `ReleaseConfigurationTests.py` and `ProjectConfigurationTests.py` pass
- New `testNineKeySchemeSurvivesRelaunch` passes, covering a separate report that nine-key reverts to 26-key across a relaunch. That turned out **not** to be a code defect: an unsigned simulator install gets no App Group provisioning, so the host app and the keyboard each keep their own `group.app.msime.ios` preferences — the app container held `nineKey` while the keyboard container held `ziranma`. `platforms/ios/README.md` documents this. Verified against an ad-hoc signed install carrying the App Group entitlement.
- New `KeyboardTests` cases cover the hold gesture and the digit layer. **These were not run locally**: the keyboard test host fails to launch under the Xcode 27 SDK with `UIScene life cycle is required`, and `project.yml` declares no `UIApplicationSceneManifest`. CI is what exercises them.
- The hold popup's placement and the digit layer's feel were **not** verified interactively. Xcode 27 ships no Simulator GUI app, so the device can be screenshotted but not driven from this machine.
