### PR TITLE
ci: stop installing zsh in the contracts job, and unbreak the iOS suite

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -2,7 +2,7 @@ name: Repository contracts
 
 # ReleaseConfigurationTests almost entirely reads files in the tree and asserts on their text: README.md against the features it promises, the Info.plist keys, the release workflow's steps and ordering, the packaging scripts. None of that needs Apple tooling, yet ctest only reaches it after the macOS build, so a README claim that no longer matches the code was reported around forty minutes into a pull request and cost a macOS runner to say so.
 #
-# Called by both ci.yml and ci-docs.yml so it runs on every pull request, and so a change to the documents it asserts on can skip the matrix without losing the assertions. The cases that genuinely need tiffutil, sips or zsh carry a @requires guard and stay covered by the macOS job.
+# Called by both ci.yml and ci-docs.yml so it runs on every pull request, and so a change to the documents it asserts on can skip the matrix without losing the assertions. Three cases genuinely need tiffutil, sips or zsh; a @requires guard skips those here and the macOS job keeps running them.
 
 on:
   workflow_call:
@@ -16,15 +16,13 @@ jobs:
   contracts:
     name: Repository contracts
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Not recursive: two cases read the Engine's punctuation contract and quanpin header, and the Engine's own submodules are hundreds of megabytes of audio dependencies that nothing here asserts on.
           submodules: true
           persist-credentials: false
-      - name: Install zsh
-        # test_release_scripts_have_valid_zsh_syntax and the packaging refusal case shell out to it. The runner image usually ships it; installing keeps the @requires guard from quietly skipping both on Linux.
-        run: command -v zsh >/dev/null || { sudo apt-get update && sudo apt-get install -y zsh; }
+      # zsh is deliberately not installed. ubuntu-24.04 ships without it, and apt-get update on a runner spent 10m22s refreshing indexes for a step whose tests then ran in 0.042s -- more than this whole job is meant to cost. The two cases that shell out to zsh check macOS release scripts with a #!/bin/zsh shebang, so the macOS job is the honest place for them; the @requires guard skips them here.
       - name: Check the repository contracts
         run: python3 platforms/macos/tests/ReleaseConfigurationTests.py

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -1192,10 +1192,16 @@ final class NineKeyKeyboardTests: XCTestCase {
     attachment.lifetime = .keepAlways
     add(attachment)
 
-    try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
-    XCTAssertTrue(try XCTUnwrap(nine.superview).isHidden)
+    // The digit layer keeps this grid rather than swapping in the 26-key rows, so the container stays
+    // visible and only the faces change. testNineKeyDigitLayerKeepsTheGridInsteadOfTheTwentySixKeyRows
+    // owns that contract; this case asserted the container hid, which was true before the digit layer
+    // shared the grid and has contradicted the other case since.
     try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
     XCTAssertFalse(try XCTUnwrap(nine.superview).isHidden)
+    XCTAssertEqual(nine.configuration?.title, "6")
+    try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertFalse(try XCTUnwrap(nine.superview).isHidden)
+    XCTAssertEqual(nine.configuration?.title, "MNO")
     try button("bottomLanguageKey", in: controller).sendActions(for: .primaryActionTriggered)
     XCTAssertTrue(try XCTUnwrap(nine.superview).isHidden)
     try button("bottomLanguageKey", in: controller).sendActions(for: .primaryActionTriggered)

--- a/platforms/ios/UITests/OnboardingUITests.swift
+++ b/platforms/ios/UITests/OnboardingUITests.swift
@@ -1165,7 +1165,11 @@ final class OnboardingUITests: XCTestCase {
     // Same two steps as the hide above: the switch commits first and the scheme list is rebuilt
     // from it, so waiting on the button alone races a rebuild that has not been asked for yet.
     // Toggling back also follows a screenshot, which leaves the app busy for a moment longer.
-    XCTAssertTrue(wait(nine, until: "value == '1'"))
+    // The switch itself needs the same budget as the rebuild that follows it, not the default 5s. The
+    // case passed in 59.9s on develop and failed here at 94.274s on a contended Intel runner, on this
+    // line: the tap lands, the screenshot above is still settling, and 5s runs out before SwiftUI
+    // reports the new value.
+    XCTAssertTrue(wait(nine, until: "value == '1'", timeout: 15))
     XCTAssertTrue(wait(app.buttons["inputScheme_nineKey"], until: "isEnabled == true", timeout: 15))
   }
 


### PR DESCRIPTION
## What

Removes the `Install zsh` step that #414 merged with. Measured on that pull request's own run:

| step | duration |
|---|---|
| `actions/checkout` incl. submodule | 20s |
| **`Install zsh`** | **10m22s** |
| test step | 0.042s |

`ubuntu-24.04` ships without `zsh`, so the step fell through to `apt-get update`, which spent ten minutes refreshing package indexes. The job exists to answer in seconds ahead of the macOS build; as merged it costs more than the thing it front-runs, on every pull request.

## Why skipping those cases is the right answer

`test_release_scripts_have_valid_zsh_syntax` and `test_package_script_refuses_ambiguously_named_unsigned_assets` shell out to `zsh` because the scripts they check carry a `#!/bin/zsh` shebang — macOS release tooling. The macOS job runs both through `ctest` regardless, so the `@requires("zsh")` guard skipping them on Linux loses no coverage; it just stops Linux from pretending to be the place that verifies macOS shell scripts. They now skip alongside the menu icon case, which needs `tiffutil` and `sips`.

The job timeout drops from 15 to 10 minutes, since nothing left in it should approach either number.

## Verification

`actionlint` clean at CI's `--severity=warning`. The previous run already proved the suite itself passes on Linux: `Ran 22 tests` → `OK (skipped=1)`; this change makes that `skipped=3`, and the three are exactly the guarded cases.


## Also here: the red iOS suite on develop

`develop` has been failing `iOS Simulator` since #416 merged, and this branch inherited it, so it could not go green on its own.

`NineKeyKeyboardTests.swift:1196` asserts the nine-key container hides when the layout toggle switches to digits. #416 changed that rule deliberately — the digit layer now keeps the same grid and only re-labels the faces (`nineKeyContainer.isHidden = !nineKey`, down from `showsSymbols || !nineKey`) — and added `testNineKeyDigitLayerKeepsTheGridInsteadOfTheTwentySixKeyRows` asserting exactly that. The two cases have contradicted each other ever since. #416's own `iOS Simulator` check failed on the same line and the pull request was merged anyway, which is how develop went red.

The new contract is the authoritative one, so the stale assertion is what changes: the container stays visible and `nineKey6` goes from `MNO` to `6` and back.

It rides along here rather than in its own pull request because this branch is blocked by that red, and one iOS Simulator run is forty minutes of the runner time this pull request exists to stop wasting.


## And one flake, with evidence

`OnboardingUITests.testInputSchemeVisibilityPersistsAndFallsBack` then failed at line 1168 on this branch — a wait on the nine-key switch reporting its new value, using the helper's default 5s. The line immediately after it already allows 15s for the scheme list that is rebuilt from that value, and the comment above both explains why the region is slow: the tap follows a screenshot.

The same case passed on `develop` in 59.890s and failed here at 94.274s on a contended Intel runner, so the condition is right and only the budget was short. It now gets the 15s its neighbour has. The other four default-timeout waits in that file follow neither a screenshot nor a relaunch and have no failure behind them, so they keep the default — raising every timeout would hide a hang instead of fixing a race.

Separately, `macOS 15 x86_64` failed once in `Check out source` with `Recv failure: Operation timed out` then `Could not resolve host: github.com` while fetching the nested `googlepinyinime-rev` submodule. Pure network; the push above re-runs it.
