### PR TITLE
fix(ios): stop the scroll edge effect from blurring the candidates

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardKeyButton.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardKeyButton.swift
@@ -50,11 +50,26 @@ final class CandidateScrollView: UIScrollView {
   override init(frame: CGRect) {
     super.init(frame: frame)
     delaysContentTouches = false
+    disableEdgeEffects()
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     delaysContentTouches = false
+    disableEdgeEffects()
+  }
+
+  /// 关闭 iOS 26 起默认开启的滚动边缘效果。
+  ///
+  /// The effect fades and blurs content towards a scroll view's edges. On a strip one row tall it
+  /// reaches the candidates themselves: the top of every chip was softened into a smudge while the
+  /// keys beside them, which are not inside a scroll view, stayed sharp. Sampling the pixels showed
+  /// it plainly -- the bottom of a chip held its exact fill colour, the top was blended with its
+  /// surroundings. The strip only ever scrolls sideways, so there is no vertical edge to hint at.
+  private func disableEdgeEffects() {
+    guard #available(iOS 26.0, *) else { return }
+    topEdgeEffect.isHidden = true
+    bottomEdgeEffect.isHidden = true
   }
 
   override func touchesShouldCancel(in view: UIView) -> Bool {

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -580,6 +580,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     let compositionRow = UIView()
     compositionRow.accessibilityIdentifier = "compositionRow"
     compositionRow.translatesAutoresizingMaskIntoConstraints = false
+    // The preedit button is centred here with no height of its own, so anything that makes it taller
+    // than this row lands on the candidates underneath. Keep whatever overflows inside the row.
+    compositionRow.clipsToBounds = true
     container.addSubview(compositionRow)
 
     var preeditConfiguration = UIButton.Configuration.plain()
@@ -592,7 +595,11 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     preeditConfiguration.titleTextAttributesTransformer =
       UIConfigurationTextAttributesTransformer { attributes in
         var attributes = attributes
-        attributes.font = .preferredFont(forTextStyle: .subheadline)
+        // Cap what Dynamic Type may do to this. The button is centred in a fixed-height row with no
+        // bound on its own height, so at the larger text sizes it outgrew the row and painted down
+        // over the candidates. 17pt plus the 8pt of insets stays inside compositionRowHeight.
+        attributes.font = UIFontMetrics(forTextStyle: .subheadline).scaledFont(
+          for: .systemFont(ofSize: 15), maximumPointSize: 17)
         return attributes
       }
     preeditButton.configuration = preeditConfiguration


### PR DESCRIPTION
## Summary

Every candidate had its top half softened into a smudge while the keys beside it stayed sharp.

iOS 26 gives `UIScrollView` a **scroll edge effect** that fades and blurs content towards its edges, on by default (`UIScrollEdgeEffect.hidden` defaults to `false`). The candidate strip is the only text in the keyboard that lives inside a scroll view, and at one row tall the effect reaches the candidates themselves. It only ever scrolls sideways, so the vertical edges have nothing to hint at — they are turned off, guarded by `#available(iOS 26.0, *)`.

**This surfaced now because the app was built against the iOS 26 SDK for the first time today**, not because of any change to the strip.

## How it was identified

Sampling the pixels of a candidate is what settled it, after several wrong guesses:

```
bottom: 255,255,255 | 247,206,70 | 247,206,70 ...   exact fill colours, clean boundaries
top:    229,221,180 | 223,207,140 | 224,208,138 ... every pixel a blend, no pure colour
```

An occluding view would have been a flat band of one colour. Only a gradient blur produces a row where nothing is its own colour. Layout was ruled out first: the chip measured `c28 l20 f17 s28 v28 y0.0` on device — label 20.3pt against ascender 16.2 + descender 4.1, centred with 4pt clear top and bottom, no transform, no fractional pixel offset.

## Also included

Two things found while tracking this down, both real and both separate from the blur:

- The preedit button is centred in a fixed-height row and has no height of its own, so Dynamic Type let it outgrow the row and paint down over the candidates. That is a plain occlusion, not the blur — it showed up as candidates being covered outright. Its font is now capped, and the row clips whatever still overflows.

## Verification

- `scripts/format.sh --check` clean
- `ProjectConfigurationTests.py` and `ReleaseConfigurationTests.py` pass
- Device and simulator builds both succeed
- **Confirmed fixed on a physical iPhone 17 (iOS 27)** by the reporter, after the blur had survived six other attempted fixes
