### PR TITLE
chore(ios): move Digital Ink to 8.0.0 and the deployment target to 15.5

### DIFF
--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,14 +1,15 @@
 source 'https://cdn.cocoapods.org/'
-platform :ios, '15.0'
+platform :ios, '15.5'
 build_root = ENV.fetch('MSIME_IOS_BUILD_ROOT', File.expand_path('../../build/ios', __dir__))
 project File.join(build_root, 'MetasequoiaImeIOS.xcodeproj')
 workspace File.join(build_root, 'MetasequoiaImeIOS.xcworkspace')
 use_frameworks! :linkage => :static
 
-# 4.x is the last Digital Ink SDK supporting the product's iOS 15.0 deployment target.
-# Language models are managed independently by ML Kit.
+# Digital Ink 8.x asks for iOS 15.5, which is what sets this product's deployment target. Language
+# models are managed independently by ML Kit. Note that 8.x still ships a fat framework whose arm64
+# slice targets devices, so it has no arm64 simulator slice -- the same as 4.x did.
 abstract_target 'HandwritingSDK' do
-  pod 'MLKitDigitalInkRecognition', '4.0.0'
+  pod 'MLKitDigitalInkRecognition', '8.0.0'
   target 'MetasequoiaKeyboard'
   target 'MetasequoiaKeyboardTests'
 end
@@ -22,7 +23,7 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.5'
     end
   end
 end

--- a/platforms/ios/Podfile.lock
+++ b/platforms/ios/Podfile.lock
@@ -1,64 +1,51 @@
 PODS:
-  - GoogleDataTransport (9.4.1):
-    - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleToolboxForMac/DebugUtils (2.3.2):
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-  - GoogleToolboxForMac/Defines (2.3.2)
-  - GoogleToolboxForMac/Logger (2.3.2):
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-  - "GoogleToolboxForMac/NSData+zlib (2.3.2)":
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.3.2)":
-    - GoogleToolboxForMac/DebugUtils (= 2.3.2)
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-    - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.2)"
-  - "GoogleToolboxForMac/NSString+URLArguments (2.3.2)"
-  - GoogleUtilities/Environment (7.13.3):
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleToolboxForMac/Defines (4.2.1)
+  - GoogleToolboxForMac/Logger (4.2.1):
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - GoogleUtilities/Environment (8.1.0):
     - GoogleUtilities/Privacy
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.3):
+  - GoogleUtilities/Logger (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.3)
-  - GoogleUtilities/UserDefaults (7.13.3):
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilitiesComponents (1.1.0):
-    - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (3.5.0)
-  - MLKitCommon (10.0.0):
-    - GoogleDataTransport (~> 9.0)
-    - GoogleToolboxForMac/Logger (~> 2.1)
-    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
-    - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
-    - GoogleUtilities/UserDefaults (~> 7.0)
-    - GoogleUtilitiesComponents (~> 1.0)
-    - GTMSessionFetcher/Core (< 4.0, >= 1.1)
-  - MLKitDigitalInkRecognition (4.0.0):
-    - MLKitCommon (~> 10.0)
-    - MLKitMDD (~> 6.0)
-    - SSZipArchive (< 3.0, >= 2.2.3)
-  - MLKitMDD (6.0.0):
-    - MLKitCommon (~> 10.0)
-  - nanopb (2.30910.0):
-    - nanopb/decode (= 2.30910.0)
-    - nanopb/encode (= 2.30910.0)
-  - nanopb/decode (2.30910.0)
-  - nanopb/encode (2.30910.0)
+  - MLKitCommon (14.0.0):
+    - GoogleDataTransport (~> 10.0)
+    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
+    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
+    - GoogleUtilities/Logger (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
+  - MLKitDigitalInkRecognition (8.0.0):
+    - MLKitCommon (~> 14.0)
+    - MLKitMDD (~> 10.0)
+    - SSZipArchive (< 3.0, >= 2.5.5)
+  - MLKitMDD (10.0.0):
+    - MLKitCommon (~> 14.0)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - PromisesObjC (2.4.0)
-  - SSZipArchive (2.4.3)
+  - SSZipArchive (2.6.0)
 
 DEPENDENCIES:
-  - MLKitDigitalInkRecognition (= 4.0.0)
+  - MLKitDigitalInkRecognition (= 8.0.0)
 
 SPEC REPOS:
   trunk:
     - GoogleDataTransport
     - GoogleToolboxForMac
     - GoogleUtilities
-    - GoogleUtilitiesComponents
     - GTMSessionFetcher
     - MLKitCommon
     - MLKitDigitalInkRecognition
@@ -68,18 +55,17 @@ SPEC REPOS:
     - SSZipArchive
 
 SPEC CHECKSUMS:
-  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
-  GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
-  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
-  GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  MLKitCommon: afcd11b6c0735066a0dde8b4bf2331f6197cbca2
-  MLKitDigitalInkRecognition: 51411badefc7f60c5fc2f8606a4a4d9819752ffc
-  MLKitMDD: ad94b775d9497b32af2dba0e104dc5695b310921
-  nanopb: 438bc412db1928dac798aa6fd75726007be04262
+  MLKitCommon: 47d47b50a031d00db62f1b0efe5a1d8b09a3b2e6
+  MLKitDigitalInkRecognition: d352ba532b816e7a930b8fa2e180288352c4736c
+  MLKitMDD: 264ea38cb1eafc18ee1f37eb69e7f2596962df6c
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
+  SSZipArchive: 8a6ee5677c8e304bebc109e39cf0da91ccef22ea
 
-PODFILE CHECKSUM: 2417031a9e50699bfbfdd64bb978c5ee42ce0f68
+PODFILE CHECKSUM: 3e18a512d42a9afe18c0b40d40d035edc811c85e
 
 COCOAPODS: 1.17.0

--- a/platforms/ios/project.yml
+++ b/platforms/ios/project.yml
@@ -4,7 +4,7 @@ options:
   bundleIdPrefix: app.msime
   createIntermediateGroups: true
   deploymentTarget:
-    iOS: "15.0"
+    iOS: "15.5"
 
 settings:
   base:
@@ -16,9 +16,9 @@ settings:
     # Bumped by release-please alongside CMakeLists.txt. It used to be pinned at 0.1.0 while the
     # project shipped 0.45.x, so any iOS artifact would have carried a version that matched nothing.
     MARKETING_VERSION: 0.48.6 # x-release-please-version
-    # ML Kit Digital Ink 4.x provides x86_64 simulator binaries.
+    # ML Kit Digital Ink 8.x provides x86_64 simulator binaries, and asks for iOS 15.5.
     SWIFT_VERSION: 6.0
-    IPHONEOS_DEPLOYMENT_TARGET: 15.0
+    IPHONEOS_DEPLOYMENT_TARGET: 15.5
     # Xcode 26 no longer falls back to the target name when a target leaves PRODUCT_NAME unset, so a
     # target without it links as a bare `-l` and builds products named `.xctest` or `-Runner.app`.
     # Targets that publish a different product name still override this below.

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -270,7 +270,10 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
 
         self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: app.msime.ios\n", project)
         self.assertIn("PRODUCT_BUNDLE_IDENTIFIER: app.msime.ios.keyboard\n", project)
-        self.assertIn("deploymentTarget:\n    iOS: \"15.0\"", project)
+        self.assertIn("deploymentTarget:\n    iOS: \"15.5\"", project)
+        # The Podfile states the same floor, and the pods are compiled against whatever it says. The
+        # two drifting apart builds the dependencies for a different iOS than the app declares.
+        self.assertIn("platform :ios, '15.5'", (IOS_ROOT / "Podfile").read_text())
 
     def test_testflight_archive_uses_distribution_profiles(self):
         script = (IOS_ROOT / "scripts/package_ios_testflight.sh").read_text()


### PR DESCRIPTION
## Summary

Moves ML Kit Digital Ink from 4.0.0 to 8.0.0 and raises the iOS deployment target from 15.0 to 15.5.

The pin sat on 4.0.0 for one reason, recorded in the Podfile: it was the last release still accepting an iOS 15.0 floor. 8.x asks for 15.5, so taking the SDK four major versions forward costs iOS 15.0–15.4. `MLKitCommon` comes along from 10.0.0 to 14.0.0, and `GoogleUtilitiesComponents` drops out of the graph entirely.

**No source changes were needed.** `DigitalInkRecognitionModel`, `DigitalInkRecognizer`, `Ink`, `Stroke` and `StrokePoint` are all unchanged across the jump, so `HandwritingInputView` compiles untouched.

## This does not change the simulator situation

Worth stating plainly, since it is the obvious reason to reach for an upgrade: 8.x **still** ships a fat `.framework` rather than an `.xcframework`, and its arm64 slice is still built for devices:

```
$ lipo -info MLKitDigitalInkRecognition        # 8.0.0
Architectures in the fat file: x86_64 arm64
$ otool -l -arch arm64 ... | grep platform
 platform 2                                     # 2 = iOS, not 7 = iOS Simulator
```

Identical to 4.0.0. Google still publishes no arm64 simulator slice for Digital Ink, so simulator builds on Apple Silicon are unaffected by this change. CI is unaffected either way — it builds on an Intel runner, where the x86_64 slice links normally.

## Verification

- Device build succeeds (`platform=iOS`, physical iPhone 17)
- Simulator build succeeds
- `ProjectConfigurationTests.py` passes — 46 tests
- `scripts/format.sh --check` clean

The deployment target is declared in both `project.yml` and the `Podfile`, and the pods are compiled against whatever the latter says. The configuration test now asserts the two agree, instead of only checking `project.yml`, so they cannot drift into building the dependencies for a different iOS than the app declares.
