### PR TITLE
feat(ios): label the symbol keys with the punctuation they insert

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -69,6 +69,8 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var microsoftFinalKey: UIButton?
   private var letterRowViews: [UIView] = []
   private var symbolRowViews: [UIView] = []
+  // 有中文对应标点的符号键,随中英模式换脸。
+  private var symbolKeyFaces: [(key: UIButton, ascii: String, chinese: String)] = []
   private var layoutToggleButton: UIButton?
   private weak var shiftButton: UIButton?
   private weak var enterButton: UIButton?
@@ -157,6 +159,20 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     Array("1234567890").map(String.init),
     [",", ".", "?", "!", ";", ":", "'", "\"", "@", "/"],
     ["(", ")", "[", "]", "<", ">", "\\", "-", "_", "="],
+  ]
+
+  /// 中文输入时这些键实际送出的标点,取自 Engine 的标点契约。
+  ///
+  /// The keys are labelled with the ASCII that produces them, so nothing on the keyboard says that
+  /// a backslash is how you type a 、 -- which is what people ask. Showing what the key will
+  /// actually produce answers it without spending a second key on it. Pairs show their opening
+  /// half; the engine alternates on its own. Characters the contract leaves out, @ / - =, keep
+  /// their own face because that is what they insert.
+  /// ReleaseConfigurationTests holds this to the contract these values were read from.
+  static let chineseSymbolFaces: [String: String] = [
+    ",": "，", ".": "。", "?": "？", "!": "！", ";": "；", ":": "：",
+    "(": "（", ")": "）", "[": "【", "]": "】", "\\": "、",
+    "<": "《", ">": "》", "'": "‘", "\"": "“", "_": "——",
   ]
 
   override func loadView() {
@@ -947,6 +963,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     for symbol in symbols {
       let key = makeKey(title: symbol, accessibilityLabel: "符号 \(symbol)") { [weak self] in
         self?.handleSymbol(symbol)
+      }
+      if let chinese = Self.chineseSymbolFaces[symbol] {
+        symbolKeyFaces.append((key, symbol, chinese))
       }
       // Ten keys to a row leave about 32pt each, and the plain configuration's default 12pt on each
       // side leaves 8pt for a glyph that needs 12. The title line break mode is byClipping, so the
@@ -1857,6 +1876,15 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       NSLayoutConstraint.activate(usesNineKeyLayout ? nineKeyActionWidths : standardActionWidths)
     }
     symbolRowViews.forEach { $0.isHidden = !showsSymbols || (isChineseMode && inputScheme == .nineKey && !session.isInLocalMode) }
+    // Chinese punctuation only comes out in Chinese mode, and a local utility mode takes the plain
+    // character, so the face follows what the key is actually going to insert right now.
+    let sendsChinesePunctuation = isChineseMode && !session.isInLocalMode
+    for face in symbolKeyFaces {
+      let title = sendsChinesePunctuation ? face.chinese : face.ascii
+      guard face.key.configuration?.title != title else { continue }
+      face.key.configuration?.title = title
+      face.key.accessibilityLabel = "符号 \(title)"
+    }
     for (row, height) in standardRowHeights { height.isActive = !row.isHidden }
     if var configuration = layoutToggleButton?.configuration {
       configuration.title = showsSymbols ? (kana ? "あいう" : (nineKey ? "九键" : "ABC")) : "123"

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -429,6 +429,33 @@ final class NineKeyKeyboardTests: XCTestCase {
       "分词键不该有长按手势")
   }
 
+  func testSymbolKeysShowThePunctuationTheyInsert() throws {
+    let previousScheme = InputSchemePreference.scheme
+    defer { InputSchemePreference.scheme = previousScheme }
+    InputSchemePreference.scheme = .quanpin
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 390, height: 292)
+    try button("layoutToggleButton", in: controller).sendActions(for: .primaryActionTriggered)
+    controller.view.layoutIfNeeded()
+
+    func face(_ label: String) -> UIButton? {
+      descendants(controller.view).first { $0.accessibilityLabel == "符号 \(label)" } as? UIButton
+    }
+
+    // Nothing on the keyboard said that a backslash is how you reach 、, which is what people ask.
+    for (ascii, chinese) in [("\\", "、"), (",", "，"), ("[", "【"), ("<", "《")] {
+      XCTAssertNotNil(face(chinese), "中文模式下应显示 \(chinese)")
+      XCTAssertNil(face(ascii), "中文模式下不该再显示 \(ascii)")
+    }
+
+    // English mode inserts the plain character, so that is what it has to show.
+    try button("bottomLanguageKey", in: controller).sendActions(for: .primaryActionTriggered)
+    controller.view.layoutIfNeeded()
+    XCTAssertNotNil(face("\\"), "英文模式下应显示反斜杠本身")
+    XCTAssertNil(face("、"))
+  }
+
   func testNineKeyDigitLayerKeepsTheGridInsteadOfTheTwentySixKeyRows() throws {
     let previousScheme = InputSchemePreference.scheme
     defer { InputSchemePreference.scheme = previousScheme }

--- a/platforms/macos/tests/ReleaseConfigurationTests.py
+++ b/platforms/macos/tests/ReleaseConfigurationTests.py
@@ -349,6 +349,40 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual((PROJECT_ROOT / "version.txt").read_text().strip(), match.group(1))
         self.assertIn("x-release-please-version", project_line)
 
+    def test_ios_symbol_faces_show_what_the_contract_will_insert(self):
+        # The iOS keys carry the Chinese punctuation they produce rather than the ASCII that
+        # produces it, so nobody has to guess that 、 is on the backslash. The faces are a literal
+        # copied out of the contract, and a contract edit that leaves it behind puts a wrong
+        # character on a key, so they are held together here.
+        policy = json.loads(
+            (PROJECT_ROOT / "vendor/MetasequoiaImeEngine/contracts/punctuation/policy.json").read_text()
+        )
+        expected = {entry["input"]: entry["output"] for entry in policy["simple"]}
+        expected.update({entry["input"]: entry["opening"] for entry in policy["alternating"]})
+        expected[policy["nested"]["openingInput"]] = policy["nested"]["opening"]
+        expected[policy["nested"]["closingInput"]] = policy["nested"]["closing"]
+
+        controller = (
+            PROJECT_ROOT / "platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift"
+        ).read_text()
+        # Take whole lines rather than splitting on a bracket: "[" is one of the keys, so a bracket
+        # scan stops halfway through the table and silently checks only what came before it.
+        body = controller.split("static let chineseSymbolFaces", 1)[1].split("= [", 1)[1]
+        table = "".join(
+            line for line in body.splitlines(keepends=True)[: body.count("\n")]
+            if not line.lstrip().startswith("]")
+        ).split("\n  ]")[0]
+        # Anchor each pair on what precedes it, or the match slides across the ", " between entries
+        # and invents a key out of the separator.
+        faces = dict(re.findall(r'(?:^|[\[,]\s*)"((?:[^"\\]|\\.)+)":\s*"([^"]+)"', table, re.MULTILINE))
+        faces = {key.replace('\\\\', '\\').replace('\\"', '"'): value for key, value in faces.items()}
+        self.assertTrue(faces, "the iOS keyboard must declare the punctuation faces")
+
+        for ascii_input, face in faces.items():
+            self.assertEqual(
+                face, expected.get(ascii_input),
+                f"the {ascii_input!r} key shows {face!r}, contract inserts {expected.get(ascii_input)!r}")
+
     def test_punctuation_dispatch_matches_the_pinned_engine_table(self):
         controller = (MACOS_ROOT / "src/MetasequoiaInputController.mm").read_text()
         # Read the contract itself. punctuation_policy.cpp only forwards to it through simple_output


### PR DESCRIPTION
## Summary

A user asked in the group chat how to type 、 on this keyboard, saying they press `/` for it in Sogou.

It is on the **backslash**, and has been all along — the Engine's punctuation contract maps `'\\' -> 、`. Nothing on the keyboard says so, because the keys carry the ASCII that produces the punctuation rather than the punctuation itself. The same gap covers the whole row: `,` inserts ，, `[` inserts 【, `<` inserts 《. So the fix is not a second key for 、, and not taking `/` away from the user — it is keys that say what they do.

In Chinese mode the faces now show the contract's own output. In English mode, and in a local utility mode, they show the plain character, because that is what gets inserted there. Pairs show their opening half and the engine alternates on its own. `@ / - =` are not in the contract and keep their own face.

**`/` is deliberately left alone.** Mapping it to 、 would match Sogou, but `/` is wanted as itself in Chinese text — dates, paths, fractions — and the contract is shared with macOS, so a keyboard-side override would put the two platforms out of step.

## Verification

- New `KeyboardTests` case asserts Chinese mode shows 、，【《 and English mode shows the plain characters
- `ReleaseConfigurationTests` now holds the iOS face table to the Engine contract it was copied from
- `ProjectConfigurationTests` passes, `scripts/format.sh --check` clean, simulator build and test build succeed

The contract test took two attempts to actually check anything, which is worth recording: `[` is one of the keys, so splitting the Swift literal on a bracket stopped halfway through the table and silently validated only the entries before it; and the regex then matched across the `", "` between entries and invented a key out of the separator. Both are fixed, and the test was confirmed to fail — `the '\\' key shows '·', contract inserts '、'` — when a face is deliberately corrupted.
