### PR TITLE
feat(ios): let the keyboard height be adjusted

### DIFF
--- a/platforms/ios/App/Sources/KeyboardLayoutSettingsView.swift
+++ b/platforms/ios/App/Sources/KeyboardLayoutSettingsView.swift
@@ -4,8 +4,19 @@ struct KeyboardLayoutSettingsView: View {
   @State private var keySpacing = KeyboardLayoutPreference.keySpacing
   @State private var rowSpacing = KeyboardLayoutPreference.rowSpacing
   @State private var voice = KeyboardLayoutPreference.voiceShortcutEnabled
+  @State private var height = KeyboardLayoutPreference.heightAdjustment
   var body: some View {
     Form {
+      Section {
+        spacingRow("键盘高度", value: $height, range: -12...48, identifier: "appKeyboardHeightSlider",
+                   format: { $0 > 0 ? "+\(Int($0))" : "\(Int($0))" }) {
+          KeyboardLayoutPreference.heightAdjustment = $0
+        }
+      } header: {
+        Text("键盘高度")
+      } footer: {
+        Text("在系统键盘高度的基础上增减，按键会跟着变高。调整后重新唤出键盘生效。")
+      }
       Section {
         spacingRow("按键间距", value: $keySpacing, range: 3...6, identifier: "appKeySpacingSlider") {
           KeyboardLayoutPreference.keySpacing = $0
@@ -34,6 +45,7 @@ struct KeyboardLayoutSettingsView: View {
       keySpacing = KeyboardLayoutPreference.keySpacing
       rowSpacing = KeyboardLayoutPreference.rowSpacing
       voice = KeyboardLayoutPreference.voiceShortcutEnabled
+      height = KeyboardLayoutPreference.heightAdjustment
     }
   }
 
@@ -42,13 +54,14 @@ struct KeyboardLayoutSettingsView: View {
     value: Binding<Double>,
     range: ClosedRange<Double>,
     identifier: String,
+    format: @escaping (Double) -> String = { String(format: "%.1f", $0) },
     store: @escaping (Double) -> Void
   ) -> some View {
     VStack(alignment: .leading, spacing: 4) {
       HStack {
         Text(title)
         Spacer()
-        Text(String(format: "%.1f", value.wrappedValue)).font(.callout).monospacedDigit()
+        Text(format(value.wrappedValue)).font(.callout).monospacedDigit()
           .foregroundStyle(.secondary)
       }
       Slider(

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardLayoutPickerView.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardLayoutPickerView.swift
@@ -6,9 +6,10 @@ import UIKit
 /// presets survive only as upgrade defaults for the spacing values -- so picking one changed
 /// nothing the user could see. The spacing the geometry actually reads is editable here instead.
 final class KeyboardLayoutPickerView: UIView {
-  init(keySpacing: Double, rowSpacing: Double, voiceEnabled: Bool,
+  init(keySpacing: Double, rowSpacing: Double, height: Double, voiceEnabled: Bool,
        onKeySpacing: @escaping (Double) -> Void,
        onRowSpacing: @escaping (Double) -> Void,
+       onHeight: @escaping (Double) -> Void,
        onVoice: @escaping (Bool) -> Void,
        onClose: @escaping () -> Void) {
     super.init(frame: .zero); accessibilityIdentifier = "keyboardLayoutPicker"
@@ -20,6 +21,11 @@ final class KeyboardLayoutPickerView: UIView {
                                range: 3...6, skin: skin, onChange: onKeySpacing)
     let rows = Self.spacingRow(title: "行间距", identifier: "rowSpacingSlider", value: rowSpacing,
                                range: 4...10, skin: skin, onChange: onRowSpacing)
+    // Height belongs next to spacing: both answer "the keys are hard to hit", and sending someone
+    // to the host app for one of them while the other is here would be arbitrary.
+    let tall = Self.spacingRow(title: "键盘高度", identifier: "keyboardHeightSlider", value: height,
+                               range: -12...48, skin: skin,
+                               format: { $0 > 0 ? "+\(Int($0))" : "\(Int($0))" }, onChange: onHeight)
 
     let voiceLabel = UILabel(); voiceLabel.text = "顶部语音入口"; voiceLabel.font = .systemFont(ofSize: 14, weight: .medium); voiceLabel.textColor = skin.keyForeground
     let voiceSwitch = UISwitch(); voiceSwitch.isOn = voiceEnabled; voiceSwitch.onTintColor = skin.accent; voiceSwitch.accessibilityIdentifier = "voiceShortcutSwitch"; voiceSwitch.accessibilityLabel = "顶部语音入口"
@@ -29,7 +35,7 @@ final class KeyboardLayoutPickerView: UIView {
     }, for: .valueChanged)
     let voice = UIStackView(arrangedSubviews: [voiceLabel, UIView(), voiceSwitch]); voice.alignment = .center; voice.spacing = 8
 
-    let stack = UIStackView(arrangedSubviews: [keys, rows, voice]); stack.axis = .vertical; stack.spacing = 16
+    let stack = UIStackView(arrangedSubviews: [keys, rows, tall, voice]); stack.axis = .vertical; stack.spacing = 16
     for item in [title, close, stack] { item.translatesAutoresizingMaskIntoConstraints = false; addSubview(item) }
     NSLayoutConstraint.activate([
       close.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
@@ -49,16 +55,17 @@ final class KeyboardLayoutPickerView: UIView {
 
   private static func spacingRow(title: String, identifier: String, value: Double,
                                  range: ClosedRange<Double>, skin: KeyboardSkin,
+                                 format: @escaping (Double) -> String = { String(format: "%.1f", $0) },
                                  onChange: @escaping (Double) -> Void) -> UIStackView {
     let caption = UILabel(); caption.text = title; caption.font = .systemFont(ofSize: 14, weight: .medium); caption.textColor = skin.keyForeground
     let amount = UILabel(); amount.font = .monospacedDigitSystemFont(ofSize: 14, weight: .regular); amount.textColor = skin.keyForeground.withAlphaComponent(0.7)
-    amount.text = String(format: "%.1f", value)
+    amount.text = format(value)
     let header = UIStackView(arrangedSubviews: [caption, UIView(), amount]); header.alignment = .firstBaseline; header.spacing = 8
     let slider = UISlider(); slider.minimumValue = Float(range.lowerBound); slider.maximumValue = Float(range.upperBound)
     slider.value = Float(value); slider.minimumTrackTintColor = skin.accent; slider.accessibilityIdentifier = identifier; slider.accessibilityLabel = title
     slider.addAction(UIAction { action in
       guard let slider = action.sender as? UISlider else { return }
-      amount.text = String(format: "%.1f", Double(slider.value))
+      amount.text = format(Double(slider.value))
       onChange(Double(slider.value))
     }, for: .valueChanged)
     let row = UIStackView(arrangedSubviews: [header, slider]); row.axis = .vertical; row.spacing = 4

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -179,7 +179,11 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       skinBackdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
     ])
     installKeyboard()
-    let height = view.heightAnchor.constraint(equalToConstant: 260 + Self.compositionRowHeight)
+    // Start at the height the setting asks for. updatePreferredKeyboardHeight settles it once the
+    // orientation is known; starting at the stock value would show one height and then jump.
+    let height = view.heightAnchor.constraint(
+      equalToConstant: 260 + Self.compositionRowHeight
+        + CGFloat(KeyboardLayoutPreference.heightAdjustment))
     height.priority = .init(999)
     height.identifier = "keyboardHeight"
     height.isActive = true
@@ -2272,9 +2276,12 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     // The composition line added a row to the candidate strip; the keyboard grew by it rather than
     // taking the space out of the keys.
     let extra = Self.compositionRowHeight
-    let height: CGFloat = handwriting.isHidden
+    let base: CGFloat = handwriting.isHidden
       ? (landscape ? 216 + extra : 260 + extra)
       : (landscape ? 260 + extra : 360 + extra)
+    // The rows divide whatever height the keyboard claims, so this reaches the key faces too --
+    // which is the point, since a key too small to hit is what this setting answers.
+    let height = base + CGFloat(KeyboardLayoutPreference.heightAdjustment)
     if keyboardHeightConstraint?.constant != height { keyboardHeightConstraint?.constant = height }
   }
 
@@ -2310,6 +2317,7 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     let picker = KeyboardLayoutPickerView(
       keySpacing: KeyboardLayoutPreference.keySpacing,
       rowSpacing: KeyboardLayoutPreference.rowSpacing,
+      height: KeyboardLayoutPreference.heightAdjustment,
       voiceEnabled: KeyboardLayoutPreference.voiceShortcutEnabled,
       onKeySpacing: { [weak self] spacing in
         KeyboardLayoutPreference.keySpacing = spacing
@@ -2318,6 +2326,12 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
       onRowSpacing: { [weak self] spacing in
         KeyboardLayoutPreference.rowSpacing = spacing
         self?.applyLayoutPreferences()
+      },
+      // Applied live so the panel is being resized under the finger that is dragging the slider,
+      // which is the only way to judge the height being picked.
+      onHeight: { [weak self] adjustment in
+        KeyboardLayoutPreference.heightAdjustment = adjustment
+        self?.updatePreferredKeyboardHeight()
       },
       // Only the shortcut bar changes shape with this setting, so it is refreshed on its own. Going
       // through updateKeyboardLayout would rebuild the keys and drop a composition in progress.

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -429,6 +429,33 @@ final class NineKeyKeyboardTests: XCTestCase {
       "分词键不该有长按手势")
   }
 
+  func testKeyboardHeightFollowsTheSetting() throws {
+    let previous = KeyboardLayoutPreference.heightAdjustment
+    defer { KeyboardLayoutPreference.heightAdjustment = previous }
+
+    func height(for adjustment: Double) -> CGFloat {
+      KeyboardLayoutPreference.heightAdjustment = adjustment
+      let controller = KeyboardViewController()
+      controller.loadViewIfNeeded()
+      controller.view.frame = CGRect(x: 0, y: 0, width: 390, height: 292)
+      controller.view.layoutIfNeeded()
+      return controller.view.constraints.first { $0.identifier == "keyboardHeight" }?.constant ?? 0
+    }
+
+    let standard = height(for: 0)
+    XCTAssertGreaterThan(standard, 0)
+    // The keys divide whatever the keyboard claims, so a taller keyboard is what makes them easier
+    // to hit -- the setting exists for that, not for the strip.
+    XCTAssertEqual(height(for: 24), standard + 24, accuracy: 0.5)
+    XCTAssertEqual(height(for: -12), standard - 12, accuracy: 0.5)
+
+    // Out-of-range values are clamped by the preference rather than reaching the constraint.
+    KeyboardLayoutPreference.heightAdjustment = 500
+    XCTAssertEqual(KeyboardLayoutPreference.heightAdjustment, 48)
+    KeyboardLayoutPreference.heightAdjustment = -500
+    XCTAssertEqual(KeyboardLayoutPreference.heightAdjustment, -12)
+  }
+
   func testNineKeyDigitLayerKeepsTheGridInsteadOfTheTwentySixKeyRows() throws {
     let previousScheme = InputSchemePreference.scheme
     defer { InputSchemePreference.scheme = previousScheme }

--- a/platforms/ios/SharedUI/KeyboardLayoutPreference.swift
+++ b/platforms/ios/SharedUI/KeyboardLayoutPreference.swift
@@ -34,6 +34,7 @@ enum KeyboardLayoutPreference {
   static let keySpacingKey = "keyboard.spacing.keys"
   static let rowSpacingKey = "keyboard.spacing.rows"
   static let voiceShortcutKey = "keyboard.shortcut.voice"
+  static let heightAdjustmentKey = "keyboard.height.adjustment"
   // Old presets supply upgrade defaults only. Key placement no longer depends on them.
   static var keySpacing: Double {
     get { spacing(key: keySpacingKey, fallback: selected.keySpacing, range: 3...6) }
@@ -42,6 +43,16 @@ enum KeyboardLayoutPreference {
   static var rowSpacing: Double {
     get { spacing(key: rowSpacingKey, fallback: selected.rowSpacing, range: 4...10) }
     set { defaults.set(min(10, max(4, newValue)), forKey: rowSpacingKey) }
+  }
+  /// 键盘整体高度相对默认值的增减,单位 pt。
+  ///
+  /// A keyboard extension states its own height, and the built-in one is the only reference a typist
+  /// has for what is comfortable, so the useful range is around that rather than a free-for-all: too
+  /// short leaves nothing to aim at, too tall eats the conversation above it. The value is added to
+  /// whichever height the current orientation and panel already asked for.
+  static var heightAdjustment: Double {
+    get { spacing(key: heightAdjustmentKey, fallback: 0, range: -12...48) }
+    set { defaults.set(min(48, max(-12, newValue)), forKey: heightAdjustmentKey) }
   }
   static var voiceShortcutEnabled: Bool {
     get { defaults.object(forKey: voiceShortcutKey) == nil ? selected == .doubao : defaults.bool(forKey: voiceShortcutKey) }


### PR DESCRIPTION
## Summary

> 感觉键盘的高度能在调高点就好了，按键太小了不好打字

The height was fixed at whatever the orientation and the handwriting panel implied, with nothing to tune. It is now adjustable by **-12 to +48pt** around that, from either the in-keyboard settings panel or the app's key settings.

The setting **adds to** the computed height rather than replacing it, so the orientation and panel rules still choose the starting point. The rows divide whatever the keyboard claims, so this reaches the key faces — which is the point, since the complaint was about the keys being too small, not about the strip.

## Notes

**Why that range.** A keyboard extension states its own height, and the system keyboard is the only reference a typist has for what is comfortable, so the useful range sits around it: much shorter leaves nothing to aim at, much taller eats the conversation above.

**Why both places.** The slider sits with the spacing sliders in the in-keyboard panel *and* in the app, because all three answer the same complaint — sending someone to the host app for one and not the others would be arbitrary.

**Live resize.** Dragging the slider in the keyboard resizes the panel under the finger. That is the only way to judge the height being chosen; a value that only takes effect later would be guesswork.

**No jump on open.** The initial constraint reads the setting too, so a keyboard configured tall does not appear at the stock height and then snap.

## Verification

- New `KeyboardTests` case asserts the constraint tracks the setting (+24 and -12 against the standard height) and that out-of-range values are clamped to the -12/+48 bounds by the preference
- Existing `testKeyboardSpacingSettingsPersist` still passes, so the settings screen is intact
- `ProjectConfigurationTests` and `ReleaseConfigurationTests` pass, `scripts/format.sh --check` clean, simulator test build succeeds
