### PR TITLE
feat(ios): type a helpcode with shift while composing

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -81,6 +81,14 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   private var inputContext = KeyboardInputContext()
   private var inputScheme: ChineseInputScheme = .quanpin
   private var usesShuangpin: Bool { inputScheme.shuangpinProfile != nil }
+  /// 组合进行中按下 shift 的字母作为辅码送给引擎。
+  ///
+  /// The engine takes helpcode for Quanpin and Shuangpin, and only inside a composition, so this
+  /// asks the same questions. A local utility mode spells its own input and is left alone.
+  private var entersHelpcode: Bool {
+    letterCaseState != .lowercase && !visiblePreedit.isEmpty && !session.isInLocalMode
+      && (inputScheme == .quanpin || usesShuangpin)
+  }
   private var supportsLocalTools: Bool { isChineseMode && inputScheme != .wubi && !inputScheme.isJapanese }
   private var nineKeyRows: [UIView] = []
   private var actionRow: UIStackView!
@@ -1103,6 +1111,14 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
         && !("2"..."9").contains(character) && character != "'" {
         return
       }
+      // Shift does nothing to a letter while composing Chinese, and the engine reads a capital
+      // there as helpcode -- the extra key that narrows the candidates down. That is the one thing
+      // it can usefully mean here, so it is what it does.
+      if entersHelpcode, let letter = character.first, letter.isLetter {
+        render(session.handleCharacter(character.uppercased()))
+        if letterCaseState == .shifted { letterCaseState = .lowercase; updateLetterCaseControls() }
+        return
+      }
       render(session.handleCharacter(character))
     } else {
       let output = letterCaseState == .lowercase ? character : character.uppercased()
@@ -1255,7 +1271,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
   }
 
   private func updateLetterCaseControls() {
-    let usesUppercase = !isChineseMode && letterCaseState != .lowercase
+    // Chinese mode shows capitals too once shift means helpcode, so the shift key reads as having
+    // done something rather than looking stuck.
+    let usesUppercase = letterCaseState != .lowercase && (!isChineseMode || entersHelpcode)
     for (button, lowercase, hintLabel) in letterButtons {
       // A hint only means something while the key feeds a double-pinyin composition, so English
       // mode drops it even though the scheme underneath is unchanged.

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -429,6 +429,37 @@ final class NineKeyKeyboardTests: XCTestCase {
       "分词键不该有长按手势")
   }
 
+  func testShiftEntersHelpcodeWhileComposingShuangpin() throws {
+    let previousScheme = InputSchemePreference.scheme
+    defer { InputSchemePreference.scheme = previousScheme }
+    InputSchemePreference.scheme = .shuangpin
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 390, height: 292)
+
+    func letterKey(_ letter: String) throws -> UIButton {
+      try XCTUnwrap(descendants(controller.view).first {
+        $0.accessibilityLabel == "字母 \(letter)" || $0.accessibilityLabel == "大写 \(letter)"
+      } as? UIButton)
+    }
+
+    // Shift before a composition still means capitals for the host, so the letters stay lowercase
+    // faces and nothing is sent to the engine as helpcode.
+    try button("shiftButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(try letterKey("N").configuration?.title, "n", "组合开始前 shift 不该改中文键面")
+
+    // Start a composition, then shift: the faces go uppercase because the next letter is helpcode.
+    try button("shiftButton", in: controller).sendActions(for: .primaryActionTriggered)
+    try letterKey("N").sendActions(for: .primaryActionTriggered)
+    XCTAssertFalse(try button("preeditButton", in: controller).configuration?.title?.isEmpty ?? true)
+    try button("shiftButton", in: controller).sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(try letterKey("N").configuration?.title, "N", "组合中 shift 应显示大写,表示下一个字母是辅码")
+
+    // Taking it drops shift, the way a one-shot capital does.
+    try letterKey("N").sendActions(for: .primaryActionTriggered)
+    XCTAssertEqual(try letterKey("N").configuration?.title, "n", "辅码输入后 shift 应复位")
+  }
+
   func testNineKeyDigitLayerKeepsTheGridInsteadOfTheTwentySixKeyRows() throws {
     let previousScheme = InputSchemePreference.scheme
     defer { InputSchemePreference.scheme = previousScheme }

--- a/platforms/ios/tests/InputSessionAdapterTests.cpp
+++ b/platforms/ios/tests/InputSessionAdapterTests.cpp
@@ -288,17 +288,15 @@ int RunTest()
         Require(!adapter.handle_backspace().handled, "Idle Backspace was swallowed by the engine adapter.");
         Require(!adapter.handle_character('N').handled, "Unsupported uppercase input was swallowed by the adapter.");
 
-        // The engine treats A-Z during a composition as helpcode input, so testing uppercase with no
-        // composition proves nothing any more: that path was always unhandled. Pin the state that
-        // actually changed, and pin that the composition survives untouched.
+        // A-Z during a composition is helpcode, which the engine narrows the candidates down with.
+        // Outside one it is a capital the user is typing and stays unhandled, so the keyboard can
+        // hand it to the client itself.
         Require(adapter.handle_character('n').handled && adapter.handle_character('i').handled,
-                "The uppercase fixture did not start a composition.");
-        const auto uppercaseDuringComposition = adapter.handle_character('H');
-        Require(!uppercaseDuringComposition.handled,
-                "Uppercase input during a composition was swallowed instead of passed to the client.");
-        Require(uppercaseDuringComposition.preedit == "ni",
-                "Uppercase input during a composition altered the preedit.");
-        Require(adapter.cancel().handled, "The uppercase fixture did not clear its composition.");
+                "The helpcode fixture did not start a composition.");
+        const auto helpcode = adapter.handle_character('H');
+        Require(helpcode.handled, "Uppercase input during a composition was not offered to the engine as helpcode.");
+        Require(helpcode.preedit == "ni", "Helpcode input replaced the composition instead of narrowing it.");
+        Require(adapter.cancel().handled, "The helpcode fixture did not clear its composition.");
 
         const auto punctuation = adapter.handle_punctuation('.');
         Require(punctuation.handled && punctuation.commit.has_value() && *punctuation.commit == "。",

--- a/shared/apple-bridge/InputSessionAdapter.cpp
+++ b/shared/apple-bridge/InputSessionAdapter.cpp
@@ -102,10 +102,11 @@ InputSessionAdapter::~InputSessionAdapter() = default;
 
 InputSnapshot InputSessionAdapter::handle_character(char character)
 {
-    // The engine accepts A-Z during a composition as helpcode input, which this keyboard does not offer.
-    // Reject it here so an uppercase letter stays unhandled and the frontend passes it to the client,
-    // preserving the keyboard's existing uppercase passthrough behavior.
-    if (character >= 'A' && character <= 'Z')
+    // A-Z during a composition is helpcode, which the engine narrows down candidates with. Outside
+    // one it is a capital the user is typing, and the keyboard hands those to the client itself, so
+    // it stays unhandled here. The engine applies its own rules to the helpcode -- Quanpin and
+    // Shuangpin only, and only while the scheme has it switched on.
+    if (character >= 'A' && character <= 'Z' && impl_->session.snapshot().preedit.empty())
     {
         return MakeSnapshot(impl_->session, KeyResult{});
     }


### PR DESCRIPTION
## Summary

> 作者优化还要继续，比如双拼增加辅码

The engine has taken helpcode the whole time — a capital inside a composition narrows the candidates down, for Quanpin and Shuangpin, `SessionOptions::helpcode` on by default. The adapter turned **every** capital away before it could reach the engine, because the keyboard had no way to type one during a composition:

```cpp
// before: A-Z is rejected outright
if (character >= 'A' && character <= 'Z')
// after: only outside a composition, where it really is a capital the user is typing
if (character >= 'A' && character <= 'Z' && impl_->session.snapshot().preedit.empty())
```

**Shift is the way in.** It already does nothing to a letter while composing Chinese, so it has no meaning to lose, and narrowing the candidates is the one useful thing it can mean there. The letter faces show capitals while it is armed, so the key reads as having done something instead of looking stuck, and taking the helpcode drops shift the way a one-shot capital does.

Outside a composition a capital is still a capital and still reaches the client untouched. The rest is left to the engine, which applies helpcode to Quanpin and Shuangpin only and only where the scheme has it switched on. A local utility mode spells its own input, so it is excluded.

## Scope

`InputSessionAdapter` is iOS-only — macOS drives the session directly and already passes shift through `character(c, true)` — so this does not change macOS behaviour.

`InputSessionAdapterTests` pinned the old contract (*"Uppercase input during a composition was swallowed instead of passed to the client"*) and now pins the new one.

## Verification

- New `KeyboardTests` case: shift before a composition leaves the Chinese faces lowercase; shift during one turns them uppercase; taking the helpcode resets shift
- Simulator test build succeeds, `scripts/format.sh --check` clean
- `InputSessionAdapter.cpp` passes a syntax check with the engine headers

**Not run locally:** the `MetasequoiaAppleInputSessionAdapterTests` C++ target, which is where the rewritten adapter assertions live — configuring the CMake build needs OpenMP, which is not installed on this machine. CI covers it.
