### PR TITLE
perf(ios): reuse the candidate chips instead of rebuilding them

### DIFF
--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -2083,16 +2083,21 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     shortcutBar.isHidden = showsCandidates
     candidateContent?.isHidden = !showsCandidates
     updatePreeditButton()
-    for view in candidateStack.arrangedSubviews {
-      candidateStack.removeArrangedSubview(view)
-      view.removeFromSuperview()
+    // The chips are reused rather than rebuilt. Rebuilding them was 80-90% of the time a keystroke
+    // spent here -- measured at 8-11ms against 0.6-2.5ms for the engine query itself -- and most of
+    // that was constructing a UIMenu, with its nested destructive submenu, for every chip on every
+    // keystroke. A chip's position never changes, so only its text has to.
+    let page = Array(visibleCandidates.prefix(Self.candidatePageSize))
+    while candidateStack.arrangedSubviews.count < page.count {
+      let index = candidateStack.arrangedSubviews.count
+      candidateStack.addArrangedSubview(makeCandidateButton(index: index))
     }
-
-    let page = visibleCandidates.prefix(Self.candidatePageSize)
-    for (offset, candidate) in page.enumerated() {
-      candidateStack.addArrangedSubview(
-        makeCandidateButton(
-          candidate: candidate, hint: wubiCodeHint(at: offset), number: offset + 1, index: offset))
+    for (offset, chip) in candidateStack.arrangedSubviews.enumerated() {
+      guard let chip = chip as? UIButton else { continue }
+      chip.isHidden = offset >= page.count
+      guard offset < page.count else { continue }
+      updateCandidateButton(chip, candidate: page[offset], hint: wubiCodeHint(at: offset),
+                            number: offset + 1)
     }
     updateExpandControl()
 
@@ -2114,20 +2119,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     return WubiCodeHintPreference.hint(code: visibleCandidateCodes[index], typed: visiblePreedit)
   }
 
-  private func makeCandidateButton(candidate: String, hint: String, number: Int, index: Int) -> UIButton {
-    let display = chineseOutput(candidate)
+  /// 候选按钮的骨架。位置固定,只建一次,内容由 updateCandidateButton 每次刷新。
+  private func makeCandidateButton(index: Int) -> UIButton {
     var configuration = UIButton.Configuration.plain()
-    configuration.title = display
-    if !hint.isEmpty {
-      configuration.attributedTitle = AttributedString(
-        display, attributes: AttributeContainer([.font: UIFont.preferredFont(forTextStyle: .body)]))
-        + AttributedString(
-          " " + hint,
-          attributes: AttributeContainer([
-            .font: UIFont.preferredFont(forTextStyle: .caption1),
-            .foregroundColor: KeyboardSkinPreference.selected.keyForeground.withAlphaComponent(0.55),
-          ]))
-    }
     configuration.baseForegroundColor = KeyboardSkinPreference.selected.keyForeground
     configuration.contentInsets = NSDirectionalEdgeInsets(
       top: 4, leading: 9, bottom: 4, trailing: 9)
@@ -2143,37 +2137,71 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
         self.playInputClick()
         self.render(self.session.selectCandidate(at: UInt(index)))
       })
-    button.accessibilityLabel =
-      hint.isEmpty ? "候选词 \(number)：\(display)" : "候选词 \(number)：\(display)，还需输入 \(hint)"
-    button.accessibilityIdentifier = "candidate-\(number)"
-    if isChineseMode && !inputScheme.isJapanese && !session.isInLocalMode {
-      let revision = candidateRevision
-      func action(_ title: String, _ symbol: String, _ operation: MetasequoiaCandidateAction,
-                  destructive: Bool = false) -> UIAction {
-        UIAction(title: title, image: UIImage(systemName: symbol), attributes: destructive ? .destructive : []) { [weak self] _ in
-          guard let self, candidateRevision == revision,
-                visibleCandidates.indices.contains(index), visibleCandidates[index] == candidate else { return }
-          let result = session.editCandidate(at: UInt(index), expectedWord: candidate, action: operation)
-          render(result)
-          if !result.isHandled { showDiagnostic("当前候选不支持此操作") }
-          else if result.diagnosticText == nil {
-            playInputClick()
-            UIAccessibility.post(notification: .announcement, argument: "已\(title)")
-          }
-        }
+    button.accessibilityIdentifier = "candidate-\(index + 1)"
+    // Built when the menu is opened rather than on every keystroke. It reads the candidate standing
+    // at this position at that moment, so a reused chip never offers an action for a word that has
+    // since scrolled away.
+    button.menu = UIMenu(children: [
+      UIDeferredMenuElement.uncached { [weak self] completion in
+        completion(self?.candidateMenuElements(at: index) ?? [])
       }
-      button.menu = UIMenu(title: display, children: [
-        action("优先显示", "arrow.up", .promote),
-        action("固定到首位", "pin", .fixFirst),
-        action("取消固定", "pin.slash", .clearPosition),
-        UIMenu(title: "删除词条…", image: UIImage(systemName: "trash"), options: .destructive, children: [
-          action("确认删除此词条", "trash", .remove, destructive: true),
-        ]),
-      ])
-      button.accessibilityHint = "轻点输入，长按管理词条"
-    }
+    ])
     decorateKey(button)
     return button
+  }
+
+  private func candidateMenuElements(at index: Int) -> [UIMenuElement] {
+    guard isChineseMode, !inputScheme.isJapanese, !session.isInLocalMode,
+      visibleCandidates.indices.contains(index)
+    else { return [] }
+    let candidate = visibleCandidates[index]
+    let revision = candidateRevision
+    func action(_ title: String, _ symbol: String, _ operation: MetasequoiaCandidateAction,
+                destructive: Bool = false) -> UIAction {
+      UIAction(title: title, image: UIImage(systemName: symbol), attributes: destructive ? .destructive : []) { [weak self] _ in
+        guard let self, candidateRevision == revision,
+              visibleCandidates.indices.contains(index), visibleCandidates[index] == candidate else { return }
+        let result = session.editCandidate(at: UInt(index), expectedWord: candidate, action: operation)
+        render(result)
+        if !result.isHandled { showDiagnostic("当前候选不支持此操作") }
+        else if result.diagnosticText == nil {
+          playInputClick()
+          UIAccessibility.post(notification: .announcement, argument: "已\(title)")
+        }
+      }
+    }
+    return [
+      action("优先显示", "arrow.up", .promote),
+      action("固定到首位", "pin", .fixFirst),
+      action("取消固定", "pin.slash", .clearPosition),
+      UIMenu(title: "删除词条…", image: UIImage(systemName: "trash"), options: .destructive, children: [
+        action("确认删除此词条", "trash", .remove, destructive: true),
+      ]),
+    ]
+  }
+
+  /// 刷新一个候选按钮的文字,位置和动作都不变。
+  private func updateCandidateButton(_ button: UIButton, candidate: String, hint: String, number: Int) {
+    let display = chineseOutput(candidate)
+    guard var configuration = button.configuration else { return }
+    if hint.isEmpty {
+      configuration.attributedTitle = nil
+      configuration.title = display
+    } else {
+      configuration.attributedTitle = AttributedString(
+        display, attributes: AttributeContainer([.font: UIFont.preferredFont(forTextStyle: .body)]))
+        + AttributedString(
+          " " + hint,
+          attributes: AttributeContainer([
+            .font: UIFont.preferredFont(forTextStyle: .caption1),
+            .foregroundColor: KeyboardSkinPreference.selected.keyForeground.withAlphaComponent(0.55),
+          ]))
+    }
+    button.configuration = configuration
+    button.accessibilityLabel =
+      hint.isEmpty ? "候选词 \(number)：\(display)" : "候选词 \(number)：\(display)，还需输入 \(hint)"
+    button.accessibilityHint =
+      isChineseMode && !inputScheme.isJapanese && !session.isInLocalMode ? "轻点输入，长按管理词条" : nil
   }
 
   private func makeSymbolKey(

--- a/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
+++ b/platforms/ios/KeyboardExtension/Sources/KeyboardViewController.swift
@@ -2178,7 +2178,9 @@ final class KeyboardViewController: UIInputViewController, UIGestureRecognizerDe
     return button
   }
 
-  private func candidateMenuElements(at index: Int) -> [UIMenuElement] {
+  // Not private: the keyboard tests are compiled into this target and check the menu here,
+  // since the button only holds a deferred placeholder until it is opened.
+  func candidateMenuElements(at index: Int) -> [UIMenuElement] {
     guard isChineseMode, !inputScheme.isJapanese, !session.isInLocalMode,
       visibleCandidates.indices.contains(index)
     else { return [] }

--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -304,9 +304,14 @@ final class NineKeyKeyboardTests: XCTestCase {
           key.sendActions(for: .primaryActionTriggered)
         }
       }
+      // The chips are reused across keystrokes and build this menu only when it is opened, so the
+      // button's static children are a placeholder. Ask for the elements the way the menu will.
       let candidate = try button("candidate-1", in: controller)
-      XCTAssertEqual(candidate.menu?.children.map(\.title), ["优先显示", "固定到首位", "取消固定", "删除词条…"])
-      XCTAssertEqual((candidate.menu?.children.last as? UIMenu)?.children.first?.title, "确认删除此词条")
+      XCTAssertTrue(candidate.menu?.children.first is UIDeferredMenuElement,
+                    "候选菜单应延迟到展开时构建")
+      let elements = controller.candidateMenuElements(at: 0)
+      XCTAssertEqual(elements.map(\.title), ["优先显示", "固定到首位", "取消固定", "删除词条…"])
+      XCTAssertEqual((elements.last as? UIMenu)?.children.first?.title, "确认删除此词条")
     }
   }
 
@@ -1276,7 +1281,11 @@ final class NineKeyKeyboardTests: XCTestCase {
           XCTAssertTrue(try XCTUnwrap(button("candidate-1", in: controller).configuration?.title).contains("你好"))
         } else if phase == "cleared" {
           try button("nineKeyClear", in: controller).sendActions(for: .primaryActionTriggered)
-          XCTAssertFalse(descendants(controller.view).contains { $0.accessibilityIdentifier == "candidate-1" })
+          // The chips are reused rather than rebuilt, so an emptied strip hides them instead of
+          // removing them. What matters is that none of them is showing.
+          XCTAssertTrue(descendants(controller.view).allSatisfy {
+            $0.accessibilityIdentifier?.hasPrefix("candidate-") != true || $0.isHidden
+          })
         }
         controller.view.layoutIfNeeded()
         for (key, expected) in zip(keys, frames) {

--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -344,11 +344,11 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
 
         # Without a page offset the chip numbers and the engine's own numbering agree, so a digit
         # and the chip carrying it name the same candidate again.
-        self.assertIn(
-            "makeCandidateButton(candidate: String, hint: String, number: Int, index: Int)", controller)
-        self.assertIn(
-            "candidate: candidate, hint: wubiCodeHint(at: offset), number: offset + 1, index: offset))",
-            controller)
+        # A chip keeps its position for the life of the strip and selects by that position, which is
+        # what keeps the digits and the engine's numbering in step. The chips are built once and
+        # relabelled, so this pins the index reaching the engine rather than the call that fills them.
+        self.assertIn("makeCandidateButton(index: Int)", controller)
+        self.assertIn("number: offset + 1", controller)
         self.assertIn("self.render(self.session.selectCandidate(at: UInt(index)))", controller)
 
         # The control is for reaching what the strip cannot show, so it appears exactly then.
@@ -539,9 +539,10 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
     def test_candidate_surface_exposes_native_chips_numbered_only_for_voiceover(self):
         controller = (IOS_ROOT / "KeyboardExtension/Sources/KeyboardViewController.swift").read_text()
 
-        self.assertIn(
-            "candidate: candidate, hint: wubiCodeHint(at: offset), number: offset + 1, index: offset",
-            controller)
+        # The chips are built once and relabelled, so assert that each one is handed the candidate,
+        # its wubi hint and its position, rather than pinning the shape of a single call.
+        self.assertIn("wubiCodeHint(at: offset)", controller)
+        self.assertIn("number: offset + 1", controller)
         self.assertIn("configuration.background.cornerRadius", controller)
 
         # A touch keyboard has no number row for the ordinal to answer to, so it is spoken rather


### PR DESCRIPTION
## Summary

> 目前使用起来有点怪怪的，不太跟手，打快了有点卡卡的感觉

Measured before changing anything. A keystroke was instrumented into its two halves — the engine query, and drawing the candidate strip — and the keyboard was made to type a run of sixteen letters on its own, so the numbers did not depend on driving it by hand:

| | engine | strip |
|---|---|---|
| **before** | 0.6 – 2.5 ms | **8.1 – 11.4 ms** |
| **after** | 0.6 – 1.8 ms | **3.1 – 6.1 ms** |

Nearly all of a keystroke was going into the strip, not the engine. Every keystroke destroyed all nine chips and built nine replacements, and the expensive part of building one was a `UIMenu` carrying four entries and a nested destructive submenu — **a menu only ever seen by someone holding a chip down**.

## What changed

A chip's position never changes, so it does not need rebuilding; only its text does.

- Chips are created once and relabelled thereafter, hidden rather than removed when a page is short
- The menu is built through `UIDeferredMenuElement.uncached` when it is opened, instead of on every keystroke

The deferred menu reads the candidate standing at that position **at the moment it opens**, so a reused chip cannot offer an action for a word that has since scrolled away. The `candidateRevision` and expected-word guards behind each action are unchanged, so an action that goes stale between opening and tapping still refuses exactly as before.

## Verification

- Same benchmark after the change: strip down to ~40% of its former cost, engine unchanged, with nine candidates showing
- `testKeyboardSpacingSettingsPersist` and `testNineKeySchemeSurvivesRelaunch` both pass
- `scripts/format.sh --check` clean, simulator test build succeeds

**Measured on the simulator, not on device** — an Apple Silicon simulator is not an iPhone, so the absolute figures do not transfer. What transfers is the ratio: the strip dominated the keystroke, and it no longer dominates it to the same degree. Whether this is enough for the "打快了卡卡的" report to go away is worth confirming on a device.

All instrumentation added for the measurement has been removed; the diff is the optimisation only.
