### PR TITLE
fix(mac): keep a long candidate gloss from overdrawing the candidate

### DIFF
--- a/platforms/macos/src/CandidateGlossLayout.h
+++ b/platforms/macos/src/CandidateGlossLayout.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <algorithm>
+
+#include <CoreGraphics/CoreGraphics.h>
+
+namespace metasequoia::mac
+{
+// A vertical candidate draws its English gloss right-aligned, with this much space on either side of it.
+constexpr CGFloat kCandidateGlossGap = 12.0;
+
+// The widest a gloss is ever drawn at. Anything longer is truncated rather than allowed to take the width the
+// candidate itself needs: english.db ships senses that measure close to 300pt at the default candidate size, and
+// 华中科技大学 -> "Huazhong University of Science and Technology" is one of them.
+constexpr CGFloat kCandidateGlossMaxWidth = 208.0;
+
+// Width a vertical candidate grows by to make room for a gloss that measures `measuredWidth`, gaps included.
+constexpr CGFloat CandidateGlossReservedWidth(CGFloat measuredWidth)
+{
+    return 2.0 * kCandidateGlossGap + std::min<CGFloat>(std::max<CGFloat>(measuredWidth, 0.0), kCandidateGlossMaxWidth);
+}
+
+// Width the gloss is drawn at inside a candidate that has `availableWidth` left over for it. Layout reserves
+// CandidateGlossReservedWidth for the same gloss, so drawing never claims more room than was set aside.
+constexpr CGFloat CandidateGlossDrawnWidth(CGFloat measuredWidth, CGFloat availableWidth)
+{
+    return std::max<CGFloat>(std::min<CGFloat>({measuredWidth, kCandidateGlossMaxWidth, availableWidth}), 0.0);
+}
+} // namespace metasequoia::mac

--- a/platforms/macos/src/CandidatePanel.mm
+++ b/platforms/macos/src/CandidatePanel.mm
@@ -1,6 +1,7 @@
 #import "CandidatePanel.h"
 #import "CandidateAppearancePreferences.h"
 #import "CandidateSkinAppearance.h"
+#include "CandidateGlossLayout.h"
 #include "StringConversion.h"
 
 #include <cmath>
@@ -84,9 +85,10 @@
             NSParagraphStyleAttributeName : paragraph,
         };
         const NSSize translationSize = [translation sizeWithAttributes:translationAttributes];
-        translationWidth = MIN(translationSize.width, MAX(0.0, self.bounds.size.width - textLeft - 8.0));
+        translationWidth =
+            metasequoia::mac::CandidateGlossDrawnWidth(translationSize.width, self.bounds.size.width - textLeft - 8.0);
     }
-    const CGFloat gap = translationWidth > 0.0 ? 12.0 : 0.0;
+    const CGFloat gap = translationWidth > 0.0 ? metasequoia::mac::kCandidateGlossGap : 0.0;
     const CGFloat rightPad = 8.0 + translationWidth + gap;
     if (split.location == NSNotFound)
     {
@@ -314,11 +316,8 @@
         CGFloat itemWidth = ceil(leftPad + [number sizeWithAttributes:measure].width + 6.0 +
                                  [word sizeWithAttributes:measure].width + 8.0);
         if (translation.length > 0)
-        {
-            const CGFloat translationWidth =
-                MIN(ceil([translation sizeWithAttributes:translationMeasure].width) + 12.0, 220.0);
-            itemWidth += 12.0 + translationWidth;
-        }
+            itemWidth = ceil(itemWidth + metasequoia::mac::CandidateGlossReservedWidth(
+                                             [translation sizeWithAttributes:translationMeasure].width));
         [titles addObject:title];
         [translations addObject:translation.length > 0 ? translation : @""];
         [widths addObject:@(itemWidth)];

--- a/platforms/macos/tests/CandidatePanelTests.mm
+++ b/platforms/macos/tests/CandidatePanelTests.mm
@@ -1,6 +1,7 @@
 #import "../src/CandidatePanel.h"
 #import "../src/CandidateSkinAppearance.h"
 #import "../src/CandidateAppearancePreferences.h"
+#include "../src/CandidateGlossLayout.h"
 #include "../src/StringConversion.h"
 #include <stdexcept>
 
@@ -8,6 +9,44 @@ static void Require(bool condition, const char *message)
 {
     if (!condition)
         throw std::runtime_error(message);
+}
+
+static NSButton *FirstCandidateButton(MetasequoiaCandidatePanel *panel)
+{
+    for (NSView *view in panel.window.contentView.subviews)
+        if ([view isKindOfClass:NSButton.class] && view.tag == 0)
+            return (NSButton *)view;
+    Require(false, "The candidate window did not render its first candidate.");
+    return nil;
+}
+
+static NSFont *CandidateButtonFont(MetasequoiaCandidatePanel *panel)
+{
+    return FirstCandidateButton(panel).font;
+}
+
+static NSBitmapImageRep *RenderCandidateButton(MetasequoiaCandidatePanel *panel)
+{
+    NSButton *button = FirstCandidateButton(panel);
+    NSBitmapImageRep *render = [button bitmapImageRepForCachingDisplayInRect:button.bounds];
+    [button cacheDisplayInRect:button.bounds toBitmapImageRep:render];
+    return render;
+}
+
+// Whether two candidate renders paint the leading `width` points, where the candidate text goes, identically.
+static bool CandidateRegionsMatch(NSBitmapImageRep *left, NSBitmapImageRep *right, CGFloat width)
+{
+    Require(left.size.width > 0.0 && right.size.width > 0.0, "A candidate render came back empty.");
+    const CGFloat scale = left.pixelsWide / left.size.width;
+    Require(fabs(right.pixelsWide / right.size.width - scale) < 0.01,
+            "The two candidate renders used different backing scales.");
+    const NSInteger columns = MIN(static_cast<NSInteger>(width * scale), MIN(left.pixelsWide, right.pixelsWide));
+    const NSInteger rows = MIN(left.pixelsHigh, right.pixelsHigh);
+    for (NSInteger y = 0; y < rows; ++y)
+        for (NSInteger x = 0; x < columns; ++x)
+            if (![[left colorAtX:x y:y] isEqual:[right colorAtX:x y:y]])
+                return false;
+    return true;
 }
 
 @interface CandidatePanelTestDelegate : NSObject <MetasequoiaCandidatePanelDelegate>
@@ -124,6 +163,30 @@ int main()
                 horizontalButton = (NSButton *)view;
         Require(horizontalButton != nil && ![horizontalButton.accessibilityLabel containsString:@"metasequoia"],
                 "A horizontal candidate window still presented the vertical-only gloss.");
+        for (const CGFloat measured : {0.0, 40.0, 208.0, 292.0, 1000.0})
+            Require(metasequoia::mac::CandidateGlossDrawnWidth(measured, 10000.0) +
+                            2.0 * metasequoia::mac::kCandidateGlossGap <=
+                        metasequoia::mac::CandidateGlossReservedWidth(measured) + 0.5,
+                    "A gloss drew wider than the room the candidate layout reserves for it.");
+        // english.db ships senses far wider than the room the layout sets aside for them, so what the button paints
+        // over the candidate itself has to stay the same whether or not a gloss follows it.
+        panel.panelType = kIMKSingleColumnScrollingCandidatePanel;
+        NSString *longGloss = @"Huazhong University of Science and Technology";
+        NSAttributedString *longWord = MetasequoiaIndexedCandidateString(@"华中科技大学", 0);
+        [panel setCandidateData:@[ MetasequoiaCandidateStringByAddingTranslation(longWord, @"HUST") ]];
+        NSFont *candidateFont = CandidateButtonFont(panel);
+        NSBitmapImageRep *withShortGloss = RenderCandidateButton(panel);
+        NSDictionary *glossMeasure =
+            @{NSFontAttributeName : [NSFont systemFontOfSize:MAX(12.0, candidateFont.pointSize - 3.0)]};
+        Require([longGloss sizeWithAttributes:glossMeasure].width > metasequoia::mac::kCandidateGlossMaxWidth,
+                "The long-gloss fixture no longer exceeds the width a gloss may be drawn at.");
+        [panel setCandidateData:@[ MetasequoiaCandidateStringByAddingTranslation(longWord, longGloss) ]];
+        NSBitmapImageRep *withLongGloss = RenderCandidateButton(panel);
+        const CGFloat textWidth =
+            8.0 + 6.0 + [@"1  华中科技大学" sizeWithAttributes:@{NSFontAttributeName : candidateFont}].width;
+        Require(CandidateRegionsMatch(withShortGloss, withLongGloss, textWidth),
+                "A gloss longer than the reserved width overdrew the candidate itself.");
+        panel.panelType = kIMKSingleRowSteppingCandidatePanel;
         [panel setCandidateData:[candidates subarrayWithRange:NSMakeRange(0, 5)]];
         for (NSScreen *screen in NSScreen.screens)
         {


### PR DESCRIPTION
Follow-up to #387. The vertical gloss it added measures its width twice, and the two measurements disagree.

`layoutCandidates` reserved at most 220pt for a gloss, while `drawRect` clamped the same gloss only against the button width and then subtracted that unclamped width from the room left for the candidate text. A gloss wider than the reservation therefore took the candidate's own space, and `NSLineBreakByTruncatingTail` cut the word down to whatever was left.

Measured with AppKit at the default candidate size (16pt candidate, 13pt gloss):

```
候选「华中科技大学」  gloss "Huazhong University of Science and Technology"
  gloss measures 292pt, layout reserves 220pt
  button is 363pt wide, drawRect still draws the gloss at 292pt
  the word needs 95pt and gets 23pt   -> renders as one character plus an ellipsis
```

This is not a synthetic value. Formatting every gloss in the shipped `english.db` the way `FormatCandidateGloss` does and measuring it: 16 of 31371 `zh_en_glosses` rows and 40 of 91057 `en_zh_glosses` rows exceed the reserved width, including everyday words such as `制度化`, `国际化`, `专业化`, `商业化` and `不相称`.

## What changed

`CandidateGlossLayout.h` holds the gap, the maximum drawn width and the two widths derived from them, and both the layout pass and `drawRect` now go through it. The width drawing claims is the width layout set aside, so a longer gloss truncates with the existing tail ellipsis instead of pushing into the candidate. Nothing changes for glosses under the cap: reserved width stays `gloss + 24pt`, same as before.

## Test plan

- [x] `candidate_panel`: renders the same candidate with a short gloss and with a 292pt one, and requires the two renders to paint the candidate region identically. Verified it fails on the pre-fix `drawRect` and passes after.
- [x] `ctest` on macOS 15 arm64: 54/54 pass
- [x] `scripts/format.sh --check`
- [x] Built and installed to `~/Library/Input Methods` from this branch, so the vertical candidate window can be checked by hand on `zhiduhua` / `huazhongkejidaxue`
