### PR TITLE
test(ios): cover the other way nine-key can disappear

### DIFF
--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -959,6 +959,38 @@ final class NineKeyKeyboardTests: XCTestCase {
     })
   }
 
+  func testNineKeyGridSurvivesALatinFieldAndAStuckLocalMode() throws {
+    // 反馈 #419 的另一半:方案没变,但九宫格没了。The grid is hidden by exactly two things beyond the
+    // scheme -- English mode and an open local input mode -- so those are the two a keyboard can
+    // come back in. Either one looks to the user like the layout changed itself.
+    let previous = InputSchemePreference.scheme
+    let enabled = InputSchemePreference.enabledSchemes
+    defer {
+      InputSchemePreference.enabledSchemes = enabled
+      InputSchemePreference.scheme = previous
+    }
+    InputSchemePreference.enabledSchemes = [.quanpin, .nineKey]
+    InputSchemePreference.scheme = .nineKey
+
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 390, height: 292)
+    controller.viewWillAppear(false)
+    controller.view.layoutIfNeeded()
+    let grid = try XCTUnwrap(button("nineKey6", in: controller).superview)
+    XCTAssertFalse(grid.isHidden, "九键应当是起始布局")
+
+    // 进一个只收拉丁字母的输入框,再回到普通输入框。
+    let latin = UUID(), ordinary = UUID()
+    controller.applyInputContext(keyboardType: .emailAddress, documentIdentifier: latin)
+    controller.view.layoutIfNeeded()
+    XCTAssertTrue(grid.isHidden, "拉丁输入框应当切到英文 26 键")
+    controller.applyInputContext(keyboardType: .default, documentIdentifier: ordinary)
+    controller.view.layoutIfNeeded()
+    XCTAssertFalse(grid.isHidden, "回到普通输入框应当恢复九键")
+    XCTAssertEqual(InputSchemePreference.scheme, .nineKey, "方案自始至终没变过")
+  }
+
   private func descendants(_ view: UIView) -> [UIView] {
     [view] + view.subviews.flatMap { descendants($0) }
   }


### PR DESCRIPTION
## Summary

#419 reports nine-key coming back as 26-key after the keyboard has been away. The scheme preference had one path that could do that silently, and #427 closed it. This covers the other half.

The grid is hidden by exactly two things beyond the scheme itself: English mode, and an open local input mode. A keyboard can come back in either one without the stored scheme having changed, and to the user that is indistinguishable from the layout changing itself — which is why it needed ruling out rather than reasoning about.

Entering a latin-only field and returning to an ordinary one restores the grid, with the scheme untouched throughout. It already did. This is what says so.

## Where that leaves the report

It still does not reproduce. Three cases now cover every way the layout can change without the user choosing:

- tearing the keyboard down and rebuilding it keeps nine-key
- a lost scheme name no longer resolves to 全拼 26 键 forever (#427)
- a latin field does not leave the grid behind

So whatever is behind the report is not one of those. The issue asks the reporter for the one detail that splits the remaining possibilities: whether the scheme button still reads 全拼 9 键 when it happens.
