### PR TITLE
style: run clang-format over the bridge snapshot

### DIFF
--- a/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
+++ b/shared/apple-bridge/MetasequoiaInputSessionBridge.mm
@@ -608,8 +608,7 @@ metasequoia::apple::DictionaryInstallation ConfigureDataDirectory(bool refresh =
         [candidateCodes addObject:StringFromUTF8(code)];
     }
 
-    NSMutableArray<NSString *> *candidateGlosses =
-        [NSMutableArray arrayWithCapacity:snapshot.candidate_glosses.size()];
+    NSMutableArray<NSString *> *candidateGlosses = [NSMutableArray arrayWithCapacity:snapshot.candidate_glosses.size()];
     for (const auto &gloss : snapshot.candidate_glosses)
     {
         [candidateGlosses addObject:StringFromUTF8(gloss)];


### PR DESCRIPTION
## Summary

develop is failing `macOS 15 arm64` on a clang-format violation, and this is the one line.

It was fixed on the branch and never reached develop: #430 had already merged by the time the fix was pushed, so the merge took the commit before it. The later `gh pr merge` reported the PR as already merged rather than picking the new commit up, and I read that as success.

No behaviour change.
