### PR TITLE
feat(ios): take the engine that answers nine-key with English words

### DIFF
--- a/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
+++ b/platforms/ios/KeyboardTests/NineKeyKeyboardTests.swift
@@ -1038,6 +1038,31 @@ final class NineKeyKeyboardTests: XCTestCase {
     XCTAssertTrue(withGloss.lowercased().contains("hello"), "你好 的释义应当是 hello:\(withGloss)")
   }
 
+  func testNineKeyOffersEnglishForTheDigitsTyped() throws {
+    // 反馈:九键打 65 想要 ok,但候选里没有。
+    let previousScheme = InputSchemePreference.scheme
+    let enabled = InputSchemePreference.enabledSchemes
+    defer {
+      InputSchemePreference.enabledSchemes = enabled
+      InputSchemePreference.scheme = previousScheme
+    }
+    InputSchemePreference.enabledSchemes = [.quanpin, .nineKey]
+    InputSchemePreference.scheme = .nineKey
+    let controller = KeyboardViewController()
+    controller.loadViewIfNeeded()
+    controller.view.frame = CGRect(x: 0, y: 0, width: 390, height: 292)
+    controller.viewWillAppear(false)
+    for key in ["nineKey6", "nineKey5"] {
+      try button(key, in: controller).sendActions(for: .primaryActionTriggered)
+    }
+    let chips = descendants(controller.view).compactMap { $0 as? UIButton }
+      .filter { ($0.accessibilityIdentifier ?? "").hasPrefix("candidate-") && !$0.isHidden }
+      .compactMap { chip -> String? in
+        chip.configuration?.attributedTitle.map { String($0.characters) } ?? chip.configuration?.title
+      }
+    XCTAssertTrue(chips.contains { $0.hasPrefix("ok") }, "九键 65 应当给出 ok:\(chips)")
+  }
+
   private func descendants(_ view: UIView) -> [UIView] {
     [view] + view.subviews.flatMap { descendants($0) }
   }


### PR DESCRIPTION
## Summary

Reported from a phone: nine-key, typing 65 for "ok", no such candidate.

The fix is in the engine — MSIME-Engine#126, already on main. Nine-key sends digits, and the mixed English candidates quanpin and shuangpin get were gated on a lowercase prefix and on one of those two schemes, so they never applied. This bumps the submodule to it and adds the case that says so from the keyboard's side.

## The part that is not done yet

Ranking needs word frequencies, and `english_words` shipped with every one of its 148,049 weights at zero. The dictionary's prefix query already ordered by weight; with nothing to order by it fell through to alphabetical, so `ok` sat behind `ml`, `nj` and `oj`. The same engine PR fills the column from a frequency list that had been sitting unread in the tree, and it also applies to the 26-key mixed candidates, which have had the same problem all along.

**The built dictionary has to be regenerated before any of that reaches a keyboard.** A device build with the weights patched in locally gives 哦了 **ok** 哦 噢 喔 嚄 old older oklahoma oldest for 65; without them the English words still appear, just ordered alphabetically.

## Verification

- New case types 6 then 5 on a nine-key keyboard and asserts a candidate starting with `ok`. It passes against a locally reweighted dictionary and fails against the shipped one, which is the state of the world rather than a flaw in the case.
- Installed to a device.

One thing worth recording: patching the bundled `english.db` by hand is not enough on its own. The digest is recorded twice — `english.db.sha256` and `dictionary-manifest.json` — and leaving either stale makes the keyboard report 词库更新未完成. It caught the tampering, which is the integrity check working.
