### PR TITLE
fix(ios): record the engine's handwriting as deliberately unbuilt

### DIFF
--- a/platforms/ios/tests/ProjectConfigurationTests.py
+++ b/platforms/ios/tests/ProjectConfigurationTests.py
@@ -800,7 +800,11 @@ sys.exit(int(os.environ["UPLOAD_STATUS"]))
             self.skipTest("engine submodule is not checked out")
 
         project = (IOS_ROOT / "project.yml").read_text()
-        not_built = {"tests"}
+        # handwriting 是引擎自带的 zinnia 识别器,iOS 走的是 MLKit Digital Ink。
+        # Compiling it here would put a second recogniser, its third-party sources and its model
+        # data into a keyboard extension that never calls any of it. macOS takes it through
+        # add_subdirectory because that is where it is used.
+        not_built = {"tests", "handwriting"}
         missing = []
         for directory in sorted(engine_root.iterdir()):
             if not directory.is_dir() or directory.name.startswith("."):


### PR DESCRIPTION
## Summary

develop is failing the iOS Simulator job on `test_bridge_compiles_every_engine_source_directory`: `Lists differ: ['handwriting'] != []`.

Bumping the engine submodule in #432 brought a `handwriting` directory with it. The contract holds that every engine source directory is enumerated in the bridge target, because that target lists them by hand and a directory added upstream otherwise drops out silently — which is how `local_modes` once broke the extension.

This one should stay out. It is the engine's own zinnia recogniser, with third-party sources and model data beside it, and iOS recognises handwriting through MLKit Digital Ink. Compiling it would put a second recogniser into a keyboard extension that calls neither half. macOS picks it up through `add_subdirectory`, which is where it is actually used.

The contract already carries a set for directories that are deliberately not built. `handwriting` joins `tests` in it, with the reason written down.

## Verification

49 contract cases pass.
