### PR TITLE
fix(release): restore the 1000 offset on automatic build numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,10 @@ jobs:
         env:
           REQUESTED_TAG: ${{ inputs.tag }}
         run: |
+          # Start above the legacy iOS commit-count builds (491 at migration) and the 1002.x builds already on TestFlight and Sparkle; #405 dropped this offset from a stale checkout and shipped 3.64.1.
           # Three numeric components; retries receive a distinct build, up to 99 attempts.
           test "$GITHUB_RUN_ATTEMPT" -lt 100
-          build="$((1 + GITHUB_RUN_NUMBER / 100)).$((GITHUB_RUN_NUMBER % 100)).$GITHUB_RUN_ATTEMPT"
+          build="$((1000 + GITHUB_RUN_NUMBER / 100)).$((GITHUB_RUN_NUMBER % 100)).$GITHUB_RUN_ATTEMPT"
           if [[ "$REQUESTED_TAG" == *-build.* ]]; then
             build="${REQUESTED_TAG##*-build.}"
           fi

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -48,7 +48,8 @@ class BuildNumberTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             builds.append(tuple(map(int, output.strip().split("=")[1].split("."))))
         self.assertEqual(builds, sorted(set(builds)))
-        self.assertGreater(builds[0], (0, 48, 6))
+        # The offset keeps every build above the legacy commit-count builds (491): #405 dropped it from a stale checkout and shipped 3.64.1, a CFBundleVersion below the 1002.x line TestFlight and Sparkle already carry.
+        self.assertGreater(builds[0], (1000, 0, 0))
 
     def test_manual_build_draft_preserves_its_build(self):
         result, output = self.run_step("Allocate build number",


### PR DESCRIPTION
#434 published `v0.48.6-build.3.64.1`, a build number below the `1002.63.1` line already on TestFlight and in the Sparkle feed.

**Root cause**

#367 allocates automatic builds as `1000 + run/100 . run%100 . attempt` so every CI build stays above the legacy iOS commit-count builds (491). #405 (`033077d`, "fix: restore iOS keyboard layout settings") was cut from a stale checkout and carried an older `release.yml` back onto develop: the offset went from `1000 +` to `1 +`, the explanatory comment disappeared, and the guard assertion in `ReleaseAutomationTests.py` was loosened from `> (491, 0, 0)` to `> (0, 48, 6)`, so nothing caught it. `main` still had the offset until #434 promoted develop.

```
$ git show 033077d -- .github/workflows/release.yml
-          # Start above the legacy iOS commit-count builds (491 at migration).
-          build="$((1000 + GITHUB_RUN_NUMBER / 100)).$((GITHUB_RUN_NUMBER % 100)).$GITHUB_RUN_ATTEMPT"
+          build="$((1 + GITHUB_RUN_NUMBER / 100)).$((GITHUB_RUN_NUMBER % 100)).$GITHUB_RUN_ATTEMPT"
```

**Fix**

Restore the offset and make the test demand a build above 1000. Run numbers on this repository are past 264, so the next automatic build is `1002.65.x` and continues the existing line; nothing on TestFlight or Sparkle has to be withdrawn.

**Verification**

`python3 -m unittest platforms.macos.tests.ReleaseAutomationTests` → 59 tests, OK. With the `1 +` formula the restored assertion fails (`(1, 99, 1)` is not above `(1000, 0, 0)`), so a repeat of #405 now fails CI.

This needs to reach `main` before the next promotion; a `release/*` PR follows once this lands.
