### PR TITLE
release: promote develop to main (0.48.6, restore the build offset)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,10 @@ jobs:
         env:
           REQUESTED_TAG: ${{ inputs.tag }}
         run: |
+          # Start above the legacy iOS commit-count builds (491 at migration) and the 1002.x builds already on TestFlight and Sparkle; #405 dropped this offset from a stale checkout and shipped 3.64.1.
           # Three numeric components; retries receive a distinct build, up to 99 attempts.
           test "$GITHUB_RUN_ATTEMPT" -lt 100
-          build="$((1 + GITHUB_RUN_NUMBER / 100)).$((GITHUB_RUN_NUMBER % 100)).$GITHUB_RUN_ATTEMPT"
+          build="$((1000 + GITHUB_RUN_NUMBER / 100)).$((GITHUB_RUN_NUMBER % 100)).$GITHUB_RUN_ATTEMPT"
           if [[ "$REQUESTED_TAG" == *-build.* ]]; then
             build="${REQUESTED_TAG##*-build.}"
           fi

--- a/platforms/macos/tests/ReleaseAutomationTests.py
+++ b/platforms/macos/tests/ReleaseAutomationTests.py
@@ -48,7 +48,8 @@ class BuildNumberTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             builds.append(tuple(map(int, output.strip().split("=")[1].split("."))))
         self.assertEqual(builds, sorted(set(builds)))
-        self.assertGreater(builds[0], (0, 48, 6))
+        # The offset keeps every build above the legacy commit-count builds (491): #405 dropped it from a stale checkout and shipped 3.64.1, a CFBundleVersion below the 1002.x line TestFlight and Sparkle already carry.
+        self.assertGreater(builds[0], (1000, 0, 0))
 
     def test_manual_build_draft_preserves_its_build(self):
         result, output = self.run_step("Allocate build number",


### PR DESCRIPTION
Promotes `develop` to `main` with one change since #434: #435, which restores the `1000 +` offset on automatic build numbers that #405 had dropped. #434 published `v0.48.6-build.3.64.1` (now deleted) because of that regression; with this on `main`, the run this merge triggers publishes `1002.6x.1` and continues the line already on TestFlight and in the Sparkle feed.

`version.txt` stays at 0.48.6; build only, no semantic version is cut.
