### PR TITLE
ci(codeql): build the Swift analysis with Xcode 26.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Daily at 00:00 Asia/Tokyo (UTC+09:00).
     - cron: '0 15 * * *'
+  workflow_dispatch:
 permissions:
   contents: read
 concurrency:
@@ -37,6 +38,9 @@ jobs:
     name: CodeQL / Swift
     runs-on: macos-15
     timeout-minutes: 60
+    env:
+      # The same Xcode the simulator CI and the release build use: the keyboard calls iOS 26 API, which the runner's default Xcode 16.4 (iOS 18.5 SDK) cannot compile.
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
The nightly CodeQL Swift job (e.g. run 34709083809) has failed since 2026-09-11 with:

```
platforms/ios/SharedUI/ScrollEdgeEffects.swift:17:20: error: cannot find 'topEdgeEffect' in scope
platforms/ios/SharedUI/ScrollEdgeEffects.swift:25:34: error: cannot find 'scrollEdgeEffectHidden' in scope
```

**Root cause**: #418 made the keyboard call iOS 26 API. The simulator CI and the release build already compile with `DEVELOPER_DIR=/Applications/Xcode_26.3.app` (since 091e2d7), but `codeql.yml` never pinned an Xcode, so it built with the `macos-15` runner default, Xcode 16.4 with the iOS 18.5 SDK, which has no such symbols.

**Fix**: pin the same `DEVELOPER_DIR` on the CodeQL Swift job, and add `workflow_dispatch` so it can be run on demand rather than waiting for the nightly schedule.

**Verification**: the workflow only fires on schedule/dispatch from the default branch, so it cannot run on this PR; I will dispatch it as soon as this lands on develop and report the run here.
