### PR TITLE
ci(codeql): print the Swift extractor diagnostics when analysis fails

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,3 +71,9 @@ jobs:
       - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: '/language:swift'
+      - name: Show what the Swift extractor reported
+        # The analyze step only says that no Swift was extracted; the reason sits in the extractor's diagnostics and the tracer log, which the failed-run SARIF does not expose.
+        if: ${{ failure() }}
+        run: |
+          find "$RUNNER_TEMP/codeql_databases" -path '*diagnostic*' -name '*.jsonl' -exec cat {} + | sort | uniq -c | sort -rn | head -50
+          tail -n 100 "$RUNNER_TEMP/codeql_databases/log/build-tracer.log" 2>/dev/null || true


### PR DESCRIPTION
After #437 the CodeQL Swift job compiles with Xcode 26.3 (run 34732214302: BUILD SUCCEEDED) but `analyze` still fails with "CodeQL detected code written in Swift but this run did not build any of it, or CodeQL could not process any of it". The extractor ran for every swift-frontend invocation and left ~25 diagnostic files, but nothing exposes them: the failed-run SARIF is not served by the API (HTTP 422) and a local reproduction does not attach the tracer on macOS 26 at all.

Add a failure-only step that prints those diagnostics and the tail of the tracer log, so the next dispatch says why.
