### PR TITLE
ci(codeql): build the Swift analysis with implicit modules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,11 +63,13 @@ jobs:
           languages: swift
           build-mode: manual
       - name: Build the app and keyboard for analysis
+        # Xcode 26 builds modules explicitly: every SDK module is a separate -emit-pcm job whose output the compile jobs then read back. The CodeQL extractor replays each job with its own clang, which rejects the PCMs Xcode's clang wrote ("built from a different branch"), so nothing gets extracted. Implicit modules give each compiler its own cache, which is how the job worked under Xcode 16.4.
         run: >-
           xcodebuild -workspace build/ios/MetasequoiaImeIOS.xcworkspace
           -scheme MetasequoiaImeIOS -configuration Debug -sdk iphonesimulator
           -destination 'generic/platform=iOS Simulator'
-          -derivedDataPath build/codeql-ios CODE_SIGNING_ALLOWED=NO build
+          -derivedDataPath build/codeql-ios CODE_SIGNING_ALLOWED=NO
+          SWIFT_ENABLE_EXPLICIT_MODULES=NO CLANG_ENABLE_EXPLICIT_MODULES=NO build
       - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: '/language:swift'
@@ -81,7 +83,9 @@ jobs:
           echo '== extractor logs =='
           find "$db/swift/log" -type f | head -20
           find "$db/swift/log" -type f -name '*.log' -exec tail -n 40 {} + | head -200
-          echo '== tracer: how the extractor was launched and how it ended =='
-          grep -n -iE 'extractor|swift-frontend|exit|signal|crash|dyld' "$db/log/build-tracer.log" | grep -v 'Candidate to intercept' | head -120
+          echo '== tracer: extractor invocations by mode and how they ended =='
+          grep -oE 'invocation: [^,]*extractor, args: \[-[a-z-]+' "$db/log/build-tracer.log" | sort | uniq -c
+          grep -oE 'terminated with exit code [0-9]+' "$db/log/build-tracer.log" | sort | uniq -c
+          grep -E '^\S+ \S+ ERRO' "$db/log/build-tracer.log" | cut -c1-400 | sort | uniq -c | sort -rn | head -30
           echo '== trap dir =='
           find "$db/swift/trap" -type f | head -5


### PR DESCRIPTION
Run 34734311040 (with the dump from #439) finally says why no Swift reaches the database under Xcode 26.3.

**Root cause**: Xcode 26 builds modules explicitly. Each SDK module is its own `-emit-pcm` job and the compile jobs read those PCMs back. The CodeQL extractor replays every job with its own clang, which refuses the PCMs Xcode's clang wrote:

```
ERRO [extractor/compiler] .../iPhoneSimulator.sdk/usr/include/os/availability.h:76:2 module file '.../ModuleCache.noindex/_AvailabilityInternal-4V24DDRJ4LVKXC1B93LYXSLU6.pcm' built from a different branch ((clang-1700.6.4.2)) than the compiler
ERRO [extractor/compiler] <invalid loc>:0:0 failed to emit precompiled module '/dev/null' for module map '.../DarwinFoundation1.modulemap'
[T 03:21:20 39071] Extractor .../swift/tools/osx64/extractor terminated with exit code 1.
```

22 extractor processes ended with exit code 1 in the part of the log that fit, and `swift/trap` stayed empty. Xcode 16.4 used implicit modules, where each compiler keeps its own cache keyed by its version, which is why the job passed until #418 forced the move to Xcode 26.

**Fix**: pass `SWIFT_ENABLE_EXPLICIT_MODULES=NO CLANG_ENABLE_EXPLICIT_MODULES=NO` to the analysis build only. The product builds in `ci.yml` and `release.yml` are untouched.

Also makes the failure dump count extractor invocations by mode and exit code and list the distinct compiler errors, instead of the first 120 tracer lines (which ended before the compile jobs).

**Verification**: the workflow only runs on schedule/dispatch from develop; I will dispatch it after this lands and report the run here.
